### PR TITLE
Search in /usr/local before system paths for the dnsmasq binary.

### DIFF
--- a/src/nm-core-utils.c
+++ b/src/nm-core-utils.c
@@ -1152,12 +1152,12 @@ nm_utils_kill_process_sync (pid_t pid, guint64 start_time, int sig, NMLogDomain 
 const char *const NM_PATHS_DEFAULT[] = {
 	PREFIX "/sbin/",
 	PREFIX "/bin/",
+	"/usr/local/sbin/",
 	"/sbin/",
 	"/usr/sbin/",
-	"/usr/local/sbin/",
+	"/usr/local/bin/",
 	"/bin/",
 	"/usr/bin/",
-	"/usr/local/bin/",
 	NULL,
 };
 


### PR DESCRIPTION
When looking for the dnsmasq (or any) binary, NetworkManager should check /usr/local before it checks any system installed version.  This allows the user to replace the binary with a newer version should they desire and is more consistent with the search behaviour commonly found in $PATH.