### PR TITLE
automation: clone from github instead of anongit.freedesktop.org

### DIFF
--- a/contrib/rh-bkr/build-from-source.sh
+++ b/contrib/rh-bkr/build-from-source.sh
@@ -5,7 +5,7 @@ set -xv
 
 BUILD_DIR="${BUILD_DIR:-/tmp/nm-build}"
 BUILD_ID="${BUILD_ID:-master}"
-BUILD_REPO="${BUILD_REPO-git://anongit.freedesktop.org/NetworkManager/NetworkManager}"
+BUILD_REPO="${BUILD_REPO-https://github.com/NetworkManager/NetworkManager.git}"
 ARCH="${ARCH:-`arch`}"
 WITH_DEBUG="$WITH_DEBUG"
 DO_TEST_BUILD="${DO_TEST_BUILD:-yes}"


### PR DESCRIPTION
It looks that freedesktop blocks our git clone requests from time to
time. Github should handle more loads.