### PR TITLE
Handle carrier changes by bond devices

### DIFF
--- a/src/devices/nm-device-bond.c
+++ b/src/devices/nm-device-bond.c
@@ -58,24 +58,6 @@ get_generic_capabilities (NMDevice *dev)
 }
 
 static gboolean
-is_available (NMDevice *dev, NMDeviceCheckDevAvailableFlags flags)
-{
-	return TRUE;
-}
-
-static gboolean
-check_connection_available (NMDevice *device,
-                            NMConnection *connection,
-                            NMDeviceCheckConAvailableFlags flags,
-                            const char *specific_object)
-{
-	/* Connections are always available because the carrier state is determined
-	 * by the slave carrier states, not the bonds's state.
-	 */
-	return TRUE;
-}
-
-static gboolean
 check_connection_compatible (NMDevice *device, NMConnection *connection)
 {
 	NMSettingBond *s_bond;
@@ -623,9 +605,7 @@ nm_device_bond_class_init (NMDeviceBondClass *klass)
 	NM_DEVICE_CLASS_DECLARE_TYPES (klass, NM_SETTING_BOND_SETTING_NAME, NM_LINK_TYPE_BOND)
 
 	parent_class->get_generic_capabilities = get_generic_capabilities;
-	parent_class->is_available = is_available;
 	parent_class->check_connection_compatible = check_connection_compatible;
-	parent_class->check_connection_available = check_connection_available;
 	parent_class->complete_connection = complete_connection;
 
 	parent_class->update_connection = update_connection;


### PR DESCRIPTION
This batch changes thy way carrier changes are handled by bond devices:
* pulling cable out of one of the slaves brings slave into disconnected state.
* reconnecting cable reconnects slave automatically.
* pulling out cables of all slaves brings down bond interface - removing its IP configuration.
* reconnecting cable to one of the slaves makes bond interface reistablish its IP configuration.

With this patch bond interface are made to work like all any other interface supporting carrier.
This patch has also been tested with bond interface havind one ethernet and one wifi device - and it works as expected.

This patch allows one to have bond interface between wifi and ethernet and still be able to connect to other wifi networks and not have ip config or routing clashes.

Signed-off-by: Nikolay Martynov <mar.kolya@gmail.com>