### PR TITLE
nmtui connect: avoid segfault when iface is not found

### DIFF
--- a/clients/tui/nmt-connect-connection-list.c
+++ b/clients/tui/nmt-connect-connection-list.c
@@ -621,6 +621,7 @@ nmt_connect_connection_list_get_connection (NmtConnectConnectionList  *list,
 	NmtConnectDevice *nmtdev;
 	NmtConnectConnection *nmtconn = NULL;
 	NMConnection *conn = NULL;
+	const char *iface = NULL;
 
 	g_return_val_if_fail (identifier, FALSE);
 
@@ -643,9 +644,12 @@ nmt_connect_connection_list_get_connection (NmtConnectConnectionList  *list,
 				goto found;
 		}
 
-		if (!conn && nmtdev->device && !strcmp (identifier, nm_device_get_ip_iface (nmtdev->device))) {
-			nmtconn = nmtdev->conns->data;
-			goto found;
+		if (!conn && nmtdev->device) {
+			iface = nm_device_get_ip_iface (nmtdev->device);
+			if (iface && !strcmp (identifier, iface)) {
+				nmtconn = nmtdev->conns->data;
+				goto found;
+			}
 		}
 	}
 


### PR DESCRIPTION
Hi,

I'm not sure why but when I use `nmtui connect` with a network that doesn't exist, the iface (not sure what that is). `nm_device_get_ip_iface` returns `NULL` and the following `strcmp` segfaults

This patch avoids the segfault