### PR TITLE
Add support for disabling connectivity checking via the D-Bus interface 

### DIFF
--- a/introspection/org.freedesktop.NetworkManager.xml
+++ b/introspection/org.freedesktop.NetworkManager.xml
@@ -444,6 +444,28 @@
     <property name="Connectivity" type="u" access="read"/>
 
     <!--
+        ConnectivityCheckAvailable:
+
+        Indicates whether connectivity checking service has been
+        configured.  This may return true even if the service is not
+        currently enabled.
+
+        This is primarily intended for use in a privacy control panel,
+        as a way to determine whether to show an option to
+        enable/disable the feature.
+    -->
+    <property name="ConnectivityCheckAvailable" type="b" access="read"/>
+
+    <!--
+        ConnectivityCheckEnabled:
+
+        Indicates whether connectivity checking is enabled.  This
+        property can also be written to to disable connectivity
+        checking (as a privacy control panel might want to do).
+    -->
+    <property name="ConnectivityCheckEnabled" type="b" access="readwrite"/>
+
+    <!--
         GlobalDnsConfiguration:
 
         Dictionary of global DNS settings where the key is one of "searches",

--- a/libnm/nm-client.c
+++ b/libnm/nm-client.c
@@ -122,6 +122,8 @@ enum {
 	PROP_WIMAX_HARDWARE_ENABLED,
 	PROP_ACTIVE_CONNECTIONS,
 	PROP_CONNECTIVITY,
+	PROP_CONNECTIVITY_CHECK_AVAILABLE,
+	PROP_CONNECTIVITY_CHECK_ENABLED,
 	PROP_PRIMARY_CONNECTION,
 	PROP_ACTIVATING_CONNECTION,
 	PROP_DEVICES,
@@ -470,6 +472,66 @@ nm_client_wimax_hardware_get_enabled (NMClient *client)
 		return FALSE;
 
 	return nm_manager_wimax_hardware_get_enabled (NM_CLIENT_GET_PRIVATE (client)->manager);
+}
+
+/**
+ * nm_client_connectivity_check_get_available:
+ * @client: a #NMClient
+ *
+ * Determine whether connectivity checking is available.  This
+ * requires that the URI of a connectivity service has been set in the
+ * configuration file.
+ *
+ * Returns: %TRUE if connectivity checking is available.
+ */
+gboolean
+nm_client_connectivity_check_get_available (NMClient *client)
+{
+	g_return_val_if_fail (NM_IS_CLIENT (client), FALSE);
+
+	if (!nm_client_get_nm_running (client))
+		return FALSE;
+
+	return nm_manager_connectivity_check_get_available (NM_CLIENT_GET_PRIVATE (client)->manager);
+}
+
+/**
+ * nm_client_connectivity_check_get_enabled:
+ * @client: a #NMClient
+ *
+ * Determine whether connectivity checking is enabled.
+ *
+ * Returns: %TRUE if connectivity checking is enabled.
+ */
+gboolean
+nm_client_connectivity_check_get_enabled (NMClient *client)
+{
+	g_return_val_if_fail (NM_IS_CLIENT (client), FALSE);
+
+	if (!nm_client_get_nm_running (client))
+		return FALSE;
+
+	return nm_manager_connectivity_check_get_enabled (NM_CLIENT_GET_PRIVATE (client)->manager);
+}
+
+/**
+ * nm_client_connectivity_check_set_enabled:
+ * @client: a #NMClient
+ * @enabled: %TRUE to enable connectivity checking
+ *
+ * Enable or disable connectivity checking.  Note that if a
+ * connectivity checking URI has not been configured, this will not
+ * have any effect.
+ */
+void
+nm_client_connectivity_check_set_enabled (NMClient *client, gboolean enabled)
+{
+	g_return_if_fail (NM_IS_CLIENT (client));
+
+	if (!nm_client_get_nm_running (client))
+		return;
+
+	nm_manager_connectivity_check_set_enabled (NM_CLIENT_GET_PRIVATE (client)->manager, enabled);
 }
 
 /**
@@ -2590,6 +2652,7 @@ set_property (GObject *object, guint prop_id,
 	case PROP_WIRELESS_ENABLED:
 	case PROP_WWAN_ENABLED:
 	case PROP_WIMAX_ENABLED:
+	case PROP_CONNECTIVITY_CHECK_ENABLED:
 		if (priv->manager)
 			g_object_set_property (G_OBJECT (priv->manager), pspec->name, value);
 		break;
@@ -2656,6 +2719,12 @@ get_property (GObject *object, guint prop_id,
 		break;
 	case PROP_CONNECTIVITY:
 		g_value_set_enum (value, nm_client_get_connectivity (self));
+		break;
+	case PROP_CONNECTIVITY_CHECK_AVAILABLE:
+		g_value_set_boolean (value, nm_client_connectivity_check_get_available (self));
+		break;
+	case PROP_CONNECTIVITY_CHECK_ENABLED:
+		g_value_set_boolean (value, nm_client_connectivity_check_get_enabled (self));
 		break;
 	case PROP_PRIMARY_CONNECTION:
 		g_value_set_object (value, nm_client_get_primary_connection (self));
@@ -2893,6 +2962,30 @@ nm_client_class_init (NMClientClass *client_class)
 		                    NM_CONNECTIVITY_UNKNOWN,
 		                    G_PARAM_READABLE |
 		                    G_PARAM_STATIC_STRINGS));
+
+	/**
+	 * NMClient::connectivity-check-available
+	 *
+	 * Whether a connectivity checking service has been configured.
+	 */
+	g_object_class_install_property
+		(object_class, PROP_CONNECTIVITY_CHECK_AVAILABLE,
+		 g_param_spec_boolean (NM_CLIENT_CONNECTIVITY_CHECK_AVAILABLE, "", "",
+							   FALSE,
+							   G_PARAM_READABLE |
+							   G_PARAM_STATIC_STRINGS));
+
+	/**
+	 * NMClient::connectivity-check-enabled
+	 *
+	 * Whether a connectivity checking service has been enabled.
+	 */
+	g_object_class_install_property
+		(object_class, PROP_CONNECTIVITY_CHECK_ENABLED,
+		 g_param_spec_boolean (NM_CLIENT_CONNECTIVITY_CHECK_ENABLED, "", "",
+							   FALSE,
+							   G_PARAM_READWRITE |
+							   G_PARAM_STATIC_STRINGS));
 
 	/**
 	 * NMClient:primary-connection:

--- a/libnm/nm-client.h
+++ b/libnm/nm-client.h
@@ -50,6 +50,8 @@ G_BEGIN_DECLS
 #define NM_CLIENT_WIMAX_HARDWARE_ENABLED "wimax-hardware-enabled"
 #define NM_CLIENT_ACTIVE_CONNECTIONS "active-connections"
 #define NM_CLIENT_CONNECTIVITY "connectivity"
+#define NM_CLIENT_CONNECTIVITY_CHECK_AVAILABLE "connectivity-check-available"
+#define NM_CLIENT_CONNECTIVITY_CHECK_ENABLED "connectivity-check-enabled"
 #define NM_CLIENT_PRIMARY_CONNECTION "primary-connection"
 #define NM_CLIENT_ACTIVATING_CONNECTION "activating-connection"
 #define NM_CLIENT_DEVICES "devices"
@@ -248,6 +250,11 @@ gboolean nm_client_wwan_hardware_get_enabled (NMClient *client);
 gboolean nm_client_wimax_get_enabled (NMClient *client);
 void     nm_client_wimax_set_enabled (NMClient *client, gboolean enabled);
 gboolean nm_client_wimax_hardware_get_enabled (NMClient *client);
+
+gboolean nm_client_connectivity_check_get_available (NMClient *client);
+gboolean nm_client_connectivity_check_get_enabled (NMClient *client);
+void     nm_client_connectivity_check_set_enabled (NMClient *client,
+												   gboolean enabled);
 
 gboolean nm_client_get_logging (NMClient *client,
                                 char **level,

--- a/libnm/nm-manager.c
+++ b/libnm/nm-manager.c
@@ -83,6 +83,9 @@ typedef struct {
 
 	gboolean wimax_enabled;
 	gboolean wimax_hw_enabled;
+
+	gboolean connectivity_check_available;
+	gboolean connectivity_check_enabled;
 } NMManagerPrivate;
 
 enum {
@@ -99,6 +102,8 @@ enum {
 	PROP_WIMAX_HARDWARE_ENABLED,
 	PROP_ACTIVE_CONNECTIONS,
 	PROP_CONNECTIVITY,
+	PROP_CONNECTIVITY_CHECK_AVAILABLE,
+	PROP_CONNECTIVITY_CHECK_ENABLED,
 	PROP_PRIMARY_CONNECTION,
 	PROP_ACTIVATING_CONNECTION,
 	PROP_DEVICES,
@@ -179,6 +184,8 @@ init_dbus (NMObject *object)
 		{ NM_MANAGER_WIMAX_HARDWARE_ENABLED,    &priv->wimax_hw_enabled },
 		{ NM_MANAGER_ACTIVE_CONNECTIONS,        &priv->active_connections, NULL, NM_TYPE_ACTIVE_CONNECTION, "active-connection" },
 		{ NM_MANAGER_CONNECTIVITY,              &priv->connectivity },
+		{ NM_MANAGER_CONNECTIVITY_CHECK_AVAILABLE, &priv->connectivity_check_available },
+		{ NM_MANAGER_CONNECTIVITY_CHECK_ENABLED, &priv->connectivity_check_enabled },
 		{ NM_MANAGER_PRIMARY_CONNECTION,        &priv->primary_connection, NULL, NM_TYPE_ACTIVE_CONNECTION },
 		{ NM_MANAGER_ACTIVATING_CONNECTION,     &priv->activating_connection, NULL, NM_TYPE_ACTIVE_CONNECTION },
 		{ NM_MANAGER_DEVICES,                   &priv->devices, NULL, NM_TYPE_DEVICE, "device" },
@@ -499,6 +506,31 @@ nm_manager_wimax_hardware_get_enabled (NMManager *manager)
 	g_return_val_if_fail (NM_IS_MANAGER (manager), FALSE);
 
 	return NM_MANAGER_GET_PRIVATE (manager)->wimax_hw_enabled;
+}
+
+gboolean
+nm_manager_connectivity_check_get_available (NMManager *manager)
+{
+	g_return_val_if_fail (NM_IS_MANAGER (manager), FALSE);
+
+	return NM_MANAGER_GET_PRIVATE (manager)->connectivity_check_available;
+}
+
+gboolean
+nm_manager_connectivity_check_get_enabled (NMManager *manager)
+{
+	return NM_MANAGER_GET_PRIVATE (manager)->connectivity_check_enabled;
+}
+
+void
+nm_manager_connectivity_check_set_enabled (NMManager *manager, gboolean enabled)
+{
+	g_return_if_fail (NM_IS_MANAGER (manager));
+
+	_nm_object_set_property (NM_OBJECT (manager),
+	                         NM_DBUS_INTERFACE,
+	                         "ConnectivityCheckEnabled",
+	                         "b", enabled);
 }
 
 gboolean
@@ -1350,6 +1382,13 @@ set_property (GObject *object, guint prop_id,
 			/* Let the property value flip when we get the change signal from NM */
 		}
 		break;
+	case PROP_CONNECTIVITY_CHECK_ENABLED:
+		b = g_value_get_boolean (value);
+		if (priv->connectivity_check_enabled != b) {
+			nm_manager_connectivity_check_set_enabled (NM_MANAGER (object), b);
+			/* Let the property value flip when we get the change signal from NM */
+		}
+		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
 		break;
@@ -1401,6 +1440,12 @@ get_property (GObject *object,
 		break;
 	case PROP_CONNECTIVITY:
 		g_value_set_enum (value, priv->connectivity);
+		break;
+	case PROP_CONNECTIVITY_CHECK_AVAILABLE:
+		g_value_set_boolean (value, priv->connectivity_check_available);
+		break;
+	case PROP_CONNECTIVITY_CHECK_ENABLED:
+		g_value_set_boolean (value, priv->connectivity_check_enabled);
 		break;
 	case PROP_PRIMARY_CONNECTION:
 		g_value_set_object (value, priv->primary_connection);
@@ -1521,6 +1566,18 @@ nm_manager_class_init (NMManagerClass *manager_class)
 		                    NM_CONNECTIVITY_UNKNOWN,
 		                    G_PARAM_READABLE |
 		                    G_PARAM_STATIC_STRINGS));
+	g_object_class_install_property
+		(object_class, PROP_CONNECTIVITY_CHECK_AVAILABLE,
+		 g_param_spec_boolean (NM_MANAGER_CONNECTIVITY_CHECK_AVAILABLE, "", "",
+							   FALSE,
+							   G_PARAM_READABLE |
+							   G_PARAM_STATIC_STRINGS));
+	g_object_class_install_property
+		(object_class, PROP_CONNECTIVITY_CHECK_ENABLED,
+		 g_param_spec_boolean (NM_MANAGER_CONNECTIVITY_CHECK_ENABLED, "", "",
+							   FALSE,
+							   G_PARAM_READWRITE |
+							   G_PARAM_STATIC_STRINGS));
 	g_object_class_install_property
 		(object_class, PROP_PRIMARY_CONNECTION,
 		 g_param_spec_object (NM_MANAGER_PRIMARY_CONNECTION, "", "",

--- a/libnm/nm-manager.h
+++ b/libnm/nm-manager.h
@@ -46,6 +46,8 @@ G_BEGIN_DECLS
 #define NM_MANAGER_WIMAX_HARDWARE_ENABLED "wimax-hardware-enabled"
 #define NM_MANAGER_ACTIVE_CONNECTIONS "active-connections"
 #define NM_MANAGER_CONNECTIVITY "connectivity"
+#define NM_MANAGER_CONNECTIVITY_CHECK_AVAILABLE "connectivity-check-available"
+#define NM_MANAGER_CONNECTIVITY_CHECK_ENABLED "connectivity-check-enabled"
 #define NM_MANAGER_PRIMARY_CONNECTION "primary-connection"
 #define NM_MANAGER_ACTIVATING_CONNECTION "activating-connection"
 #define NM_MANAGER_DEVICES "devices"
@@ -96,6 +98,11 @@ gboolean  nm_manager_wwan_hardware_get_enabled (NMManager *manager);
 gboolean  nm_manager_wimax_get_enabled (NMManager *manager);
 void      nm_manager_wimax_set_enabled (NMManager *manager, gboolean enabled);
 gboolean  nm_manager_wimax_hardware_get_enabled (NMManager *manager);
+
+gboolean  nm_manager_connectivity_check_get_available (NMManager *manager);
+gboolean  nm_manager_connectivity_check_get_enabled (NMManager *manager);
+void      nm_manager_connectivity_check_set_enabled (NMManager *manager,
+													 gboolean enabled);
 
 gboolean nm_manager_get_logging (NMManager *manager,
                                  char **level,

--- a/src/nm-config.c
+++ b/src/nm-config.c
@@ -1590,6 +1590,33 @@ done:
 	return TRUE;
 }
 
+/*****************************************************************************/
+
+void nm_config_set_connectivity_check_enabled (NMConfig *self,
+											   gboolean enabled)
+{
+	NMConfigPrivate *priv;
+	GKeyFile *keyfile;
+
+	g_return_if_fail (NM_IS_CONFIG (self));
+
+	priv = NM_CONFIG_GET_PRIVATE (self);
+	g_return_if_fail (priv->config_data);
+
+	keyfile = nm_config_data_clone_keyfile_intern (priv->config_data);
+
+	/* Remove existing groups */
+	g_key_file_remove_group (keyfile, NM_CONFIG_KEYFILE_GROUP_CONNECTIVITY, NULL);
+
+	if (!enabled) {
+		g_key_file_set_value (keyfile, NM_CONFIG_KEYFILE_GROUP_CONNECTIVITY,
+							  "interval", "0");
+	}
+
+	nm_config_set_values (self, keyfile, TRUE, FALSE);
+	g_key_file_unref (keyfile);
+}
+
 /**
  * nm_config_set_values:
  * @self: the NMConfig instance

--- a/src/nm-config.h
+++ b/src/nm-config.h
@@ -179,6 +179,8 @@ void _nm_config_sort_groups (char **groups, gsize ngroups);
 
 gboolean nm_config_set_global_dns (NMConfig *self, NMGlobalDnsConfig *global_dns, GError **error);
 
+void nm_config_set_connectivity_check_enabled (NMConfig *self, gboolean enabled);
+
 /* internal defines ... */
 extern guint _nm_config_match_nm_version;
 extern char *_nm_config_match_env;

--- a/src/nm-manager.c
+++ b/src/nm-manager.c
@@ -205,6 +205,8 @@ NM_GOBJECT_PROPERTIES_DEFINE (NMManager,
 	PROP_WIMAX_HARDWARE_ENABLED,
 	PROP_ACTIVE_CONNECTIONS,
 	PROP_CONNECTIVITY,
+	PROP_CONNECTIVITY_CHECK_AVAILABLE,
+	PROP_CONNECTIVITY_CHECK_ENABLED,
 	PROP_PRIMARY_CONNECTION,
 	PROP_PRIMARY_CONNECTION_TYPE,
 	PROP_ACTIVATING_CONNECTION,
@@ -6236,6 +6238,16 @@ get_property (GObject *object, guint prop_id,
 	case PROP_CONNECTIVITY:
 		g_value_set_uint (value, priv->connectivity_state);
 		break;
+	case PROP_CONNECTIVITY_CHECK_AVAILABLE:
+		config_data = nm_config_get_data (priv->config);
+		g_value_set_boolean (value, nm_config_data_get_connectivity_uri (config_data) != NULL);
+		break;
+	case PROP_CONNECTIVITY_CHECK_ENABLED:
+		config_data = nm_config_get_data (priv->config);
+		g_value_set_boolean (value,
+							 nm_config_data_get_connectivity_uri (config_data) != NULL &&
+							 nm_config_data_get_connectivity_interval (config_data) != 0);
+		break;
 	case PROP_PRIMARY_CONNECTION:
 		nm_utils_g_value_set_object_path (value, priv->primary_connection);
 		break;
@@ -6298,6 +6310,10 @@ set_property (GObject *object, guint prop_id,
 		break;
 	case PROP_WIMAX_ENABLED:
 		/* WIMAX is depreacted. This does nothing. */
+		break;
+	case PROP_CONNECTIVITY_CHECK_ENABLED:
+		nm_config_set_connectivity_check_enabled (priv->config,
+												  g_value_get_boolean (value));
 		break;
 	case PROP_GLOBAL_DNS_CONFIGURATION:
 		dns_config = nm_global_dns_config_from_dbus (value, &error);
@@ -6522,6 +6538,18 @@ nm_manager_class_init (NMManagerClass *manager_class)
 	                       NM_CONNECTIVITY_UNKNOWN, NM_CONNECTIVITY_FULL, NM_CONNECTIVITY_UNKNOWN,
 	                       G_PARAM_READABLE |
 	                       G_PARAM_STATIC_STRINGS);
+
+	obj_properties[PROP_CONNECTIVITY_CHECK_AVAILABLE] =
+		g_param_spec_boolean (NM_MANAGER_CONNECTIVITY_CHECK_AVAILABLE, "", "",
+							  TRUE,
+							  G_PARAM_READABLE |
+							  G_PARAM_STATIC_STRINGS);
+
+	obj_properties[PROP_CONNECTIVITY_CHECK_ENABLED] =
+		g_param_spec_boolean (NM_MANAGER_CONNECTIVITY_CHECK_ENABLED, "", "",
+							  TRUE,
+							  G_PARAM_READWRITE |
+							  G_PARAM_STATIC_STRINGS);
 
 	obj_properties[PROP_PRIMARY_CONNECTION] =
 	    g_param_spec_string (NM_MANAGER_PRIMARY_CONNECTION, "", "",

--- a/src/nm-manager.h
+++ b/src/nm-manager.h
@@ -45,6 +45,8 @@
 #define NM_MANAGER_WIMAX_HARDWARE_ENABLED "wimax-hardware-enabled"
 #define NM_MANAGER_ACTIVE_CONNECTIONS "active-connections"
 #define NM_MANAGER_CONNECTIVITY "connectivity"
+#define NM_MANAGER_CONNECTIVITY_CHECK_AVAILABLE "connectivity-check-available"
+#define NM_MANAGER_CONNECTIVITY_CHECK_ENABLED "connectivity-check-enabled"
 #define NM_MANAGER_PRIMARY_CONNECTION "primary-connection"
 #define NM_MANAGER_PRIMARY_CONNECTION_TYPE "primary-connection-type"
 #define NM_MANAGER_ACTIVATING_CONNECTION "activating-connection"


### PR DESCRIPTION
This was mentioned in the [Ubuntu Desktop weekly newsletter](https://lists.ubuntu.com/archives/ubuntu-desktop/2017-July/005070.html), but wasn't PR'd here. Patch files also available over at [Bugzilla](https://bugzilla.gnome.org/show_bug.cgi?id=785117)