### PR TITLE
th/ifcfg route parse

### DIFF
--- a/libnm-core/nm-core-internal.h
+++ b/libnm-core/nm-core-internal.h
@@ -198,6 +198,16 @@ GHashTable *_nm_utils_copy_strdict (GHashTable *strdict);
 
 typedef gpointer (*NMUtilsCopyFunc) (gpointer);
 
+gboolean _nm_ip_route_attribute_validate_all (const NMIPRoute *route);
+
+static inline void
+_nm_auto_ip_route_unref (NMIPRoute **v)
+{
+	if (*v)
+		nm_ip_route_unref (*v);
+}
+#define nm_auto_ip_route_unref nm_auto (_nm_auto_ip_route_unref)
+
 GPtrArray *_nm_utils_copy_slist_to_array (const GSList *list,
                                           NMUtilsCopyFunc copy_func,
                                           GDestroyNotify unref_func);

--- a/libnm-core/nm-setting-ip-config.c
+++ b/libnm-core/nm-setting-ip-config.c
@@ -1289,7 +1289,7 @@ nm_ip_route_attribute_validate  (const char *name,
 		char *sep;
 
 		switch (spec->str_type) {
-		case 'a':	/* IP address */
+		case 'a': /* IP address */
 			if (!nm_utils_ipaddr_valid (family, string)) {
 				g_set_error (error,
 				             NM_CONNECTION_ERROR,
@@ -1301,7 +1301,7 @@ nm_ip_route_attribute_validate  (const char *name,
 				return FALSE;
 			}
 			break;
-		case 'p':	/* IP address + optional prefix */
+		case 'p': /* IP address + optional prefix */
 			string_free = g_strdup (string);
 			sep = strchr (string_free, '/');
 			if (sep) {
@@ -1330,6 +1330,26 @@ nm_ip_route_attribute_validate  (const char *name,
 		}
 	}
 
+	return TRUE;
+}
+
+gboolean
+_nm_ip_route_attribute_validate_all (const NMIPRoute *route)
+{
+	GHashTableIter iter;
+	const char *key;
+	GVariant *val;
+
+	g_return_val_if_fail (route, FALSE);
+
+	if (!route->attributes)
+		return TRUE;
+
+	g_hash_table_iter_init (&iter, route->attributes);
+	while (g_hash_table_iter_next (&iter, (gpointer *) &key, (gpointer *) &val)) {
+		if (!nm_ip_route_attribute_validate (key, val, route->family, NULL, NULL))
+			return FALSE;
+	}
 	return TRUE;
 }
 

--- a/shared/nm-utils/nm-glib.h
+++ b/shared/nm-utils/nm-glib.h
@@ -452,4 +452,33 @@ _nm_g_variant_new_take_string (gchar *string)
 }
 #define g_variant_new_take_string _nm_g_variant_new_take_string
 
+#if !GLIB_CHECK_VERSION(2, 38, 0)
+_nm_printf (1, 2)
+static inline GVariant *
+_nm_g_variant_new_printf (const char *format_string, ...)
+{
+	char *string;
+	va_list ap;
+
+	g_return_val_if_fail (format_string, NULL);
+
+	va_start (ap, format_string);
+	string = g_strdup_vprintf (format_string, ap);
+	va_end (ap);
+
+	return g_variant_new_take_string (string);
+}
+#define g_variant_new_printf(...) _nm_g_variant_new_printf(__VA_ARGS__)
+#else
+#define g_variant_new_printf(...) \
+	({ \
+		GVariant *_v; \
+		\
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS \
+		_v = g_variant_new_printf (__VA_ARGS__); \
+		G_GNUC_END_IGNORE_DEPRECATIONS \
+		_v; \
+	})
+#endif
+
 #endif  /* __NM_GLIB_H__ */

--- a/shared/nm-utils/nm-macros-internal.h
+++ b/shared/nm-utils/nm-macros-internal.h
@@ -26,15 +26,15 @@
 #include <stdlib.h>
 #include <errno.h>
 
-#include "nm-glib.h"
-
-/*****************************************************************************/
-
 #define _nm_packed __attribute__ ((packed))
 #define _nm_unused __attribute__ ((unused))
 #define _nm_pure   __attribute__ ((pure))
 #define _nm_const  __attribute__ ((const))
 #define _nm_printf(a,b) __attribute__ ((__format__ (__printf__, a, b)))
+
+#include "nm-glib.h"
+
+/*****************************************************************************/
 
 #define nm_offsetofend(t,m) (G_STRUCT_OFFSET (t,m) + sizeof (((t *) NULL)->m))
 

--- a/shared/nm-utils/nm-shared-utils.c
+++ b/shared/nm-utils/nm-shared-utils.c
@@ -32,6 +32,10 @@ const void *const _NM_PTRARRAY_EMPTY[1] = { NULL };
 
 /*****************************************************************************/
 
+const NMIPAddr nm_ip_addr_zero = { 0 };
+
+/*****************************************************************************/
+
 void
 nm_utils_strbuf_append_c (char **buf, gsize *len, char c)
 {

--- a/shared/nm-utils/nm-shared-utils.c
+++ b/shared/nm-utils/nm-shared-utils.c
@@ -325,6 +325,118 @@ _nm_utils_ascii_str_to_int64 (const char *str, guint base, gint64 min, gint64 ma
 /*****************************************************************************/
 
 /**
+ * nm_utils_strsplit_set:
+ * @str: the string to split.
+ * @delimiters: the set of delimiters. If %NULL, defaults to " \t\n",
+ *   like bash's $IFS.
+ *
+ * This is a replacement for g_strsplit_set() which avoids copying
+ * each word once (the entire strv array), but instead copies it once
+ * and all words point into that internal copy.
+ *
+ * Another difference from g_strsplit_set() is that this never returns
+ * empty words. Multiple delimiters are combined and treated as one.
+ *
+ * Returns: %NULL if @str is %NULL or contains only delimiters.
+ *   Otherwise, a %NULL terminated strv array containing non-empty
+ *   words, split at the delimiter characters (delimiter characters
+ *   are removed).
+ *   The strings to which the result strv array points to are allocated
+ *   after the returned result itself. Don't free the strings themself,
+ *   but free everything with g_free().
+ */
+const char **
+nm_utils_strsplit_set (const char *str, const char *delimiters)
+{
+	const char **ptr, **ptr0;
+	gsize alloc_size, plen, i;
+	gsize str_len;
+	char *s0;
+	char *s;
+	guint8 delimiters_table[256];
+
+	if (!str)
+		return NULL;
+
+	/* initialize lookup table for delimiter */
+	if (!delimiters)
+		delimiters = " \t\n";
+	memset (delimiters_table, 0, sizeof (delimiters_table));
+	for (i = 0; delimiters[i]; i++)
+		delimiters_table[(guint8) delimiters[i]] = 1;
+
+#define _is_delimiter(ch, delimiters_table) \
+	((delimiters_table)[(guint8) (ch)] != 0)
+
+	/* skip initial delimiters, and return of the remaining string is
+	 * empty. */
+	while (_is_delimiter (str[0], delimiters_table))
+		str++;
+	if (!str[0])
+		return NULL;
+
+	str_len = strlen (str) + 1;
+	alloc_size = 8;
+
+	/* we allocate the buffer larger, so to copy @str at the
+	 * end of it as @s0. */
+	ptr0 = g_malloc ((sizeof (const char *) * (alloc_size + 1)) + str_len);
+	s0 = (char *) &ptr0[alloc_size + 1];
+	memcpy (s0, str, str_len);
+
+	plen = 0;
+	s = s0;
+	ptr = ptr0;
+
+	while (TRUE) {
+		if (plen >= alloc_size) {
+			const char **ptr_old = ptr;
+
+			/* reallocate the buffer. Note that for now the string
+			 * continues to be in ptr0/s0. We fix that at the end. */
+			alloc_size += 2;
+			ptr = g_malloc ((sizeof (const char *) * (alloc_size + 1)) + str_len);
+			memcpy (ptr, ptr_old, sizeof (const char *) * plen);
+			if (ptr_old != ptr0)
+				g_free (ptr_old);
+		}
+
+		ptr[plen++] = s;
+
+		nm_assert (s[0] && !_is_delimiter (s[0], delimiters_table));
+
+		while (TRUE) {
+			s++;
+			if (_is_delimiter (s[0], delimiters_table))
+				break;
+			if (s[0] == '\0')
+				goto done;
+		}
+
+		s[0] = '\0';
+		s++;
+		while (_is_delimiter (s[0], delimiters_table))
+			s++;
+		if (s[0] == '\0')
+			break;
+	}
+done:
+	ptr[plen] = NULL;
+
+	if (ptr != ptr0) {
+		/* we reallocated the buffer. We must copy over the
+		 * string @s0 and adjust the pointers. */
+		s = (char *) &ptr[alloc_size + 1];
+		memcpy (s, s0, str_len);
+		for (i = 0; i < plen; i++)
+			ptr[i] = &s[ptr[i] - s0];
+		g_free (ptr0);
+	}
+
+	return ptr;
+}
+
+/**
  * nm_utils_strv_find_first:
  * @list: the strv list to search
  * @len: the length of the list, or a negative value if @list is %NULL terminated.

--- a/shared/nm-utils/nm-shared-utils.h
+++ b/shared/nm-utils/nm-shared-utils.h
@@ -22,6 +22,25 @@
 #ifndef __NM_SHARED_UTILS_H__
 #define __NM_SHARED_UTILS_H__
 
+#include <netinet/in.h>
+
+/*****************************************************************************/
+
+typedef struct {
+	union {
+		guint8 addr_ptr[1];
+		in_addr_t addr4;
+		struct in6_addr addr6;
+
+		/* NMIPAddr is really a union for IP addresses.
+		 * However, as ethernet addresses fit in here nicely, use
+		 * it also for an ethernet MAC address. */
+		guint8 addr_eth[6 /*ETH_ALEN*/];
+	};
+} NMIPAddr;
+
+extern const NMIPAddr nm_ip_addr_zero;
+
 /*****************************************************************************/
 
 #define NM_CMP_RETURN(c) \

--- a/shared/nm-utils/nm-shared-utils.h
+++ b/shared/nm-utils/nm-shared-utils.h
@@ -170,9 +170,18 @@ gboolean nm_utils_ip_is_site_local (int addr_family,
 
 /*****************************************************************************/
 
+gboolean nm_utils_parse_inaddr_bin  (const char *text,
+                                     int family,
+                                     gpointer out_addr);
+
 gboolean nm_utils_parse_inaddr (const char *text,
                                 int family,
                                 char **out_addr);
+
+gboolean nm_utils_parse_inaddr_prefix_bin (const char *text,
+                                           int family,
+                                           gpointer out_addr,
+                                           int *out_prefix);
 
 gboolean nm_utils_parse_inaddr_prefix (const char *text,
                                        int family,

--- a/shared/nm-utils/nm-shared-utils.h
+++ b/shared/nm-utils/nm-shared-utils.h
@@ -153,6 +153,8 @@ void nm_utils_strbuf_append_str (char **buf, gsize *len, const char *str);
 
 /*****************************************************************************/
 
+const char **nm_utils_strsplit_set (const char *str, const char *delimiters);
+
 gssize nm_utils_strv_find_first (char **list, gssize len, const char *needle);
 
 char **_nm_utils_strv_cleanup (char **strv,

--- a/src/nm-core-utils.c
+++ b/src/nm-core-utils.c
@@ -110,10 +110,6 @@ _nm_utils_set_testing (NMUtilsTestFlags flags)
 
 /*****************************************************************************/
 
-const NMIPAddr nm_ip_addr_zero = NMIPAddrInit;
-
-/*****************************************************************************/
-
 static GSList *_singletons = NULL;
 static gboolean _singletons_shutdown = FALSE;
 

--- a/src/nm-core-utils.h
+++ b/src/nm-core-utils.h
@@ -90,25 +90,6 @@ GETTER (void) \
 
 /*****************************************************************************/
 
-typedef struct {
-	union {
-		guint8 addr_ptr[1];
-		in_addr_t addr4;
-		struct in6_addr addr6;
-
-		/* NMIPAddr is really a union for IP addresses.
-		 * However, as ethernet addresses fit in here nicely, use
-		 * it also for an ethernet MAC address. */
-		guint8 addr_eth[6 /*ETH_ALEN*/];
-	};
-} NMIPAddr;
-
-extern const NMIPAddr nm_ip_addr_zero;
-
-#define NMIPAddrInit { .addr6 = IN6ADDR_ANY_INIT }
-
-/*****************************************************************************/
-
 guint nm_utils_in6_addr_hash (const struct in6_addr *addr);
 
 gboolean nm_ethernet_address_is_valid (gconstpointer addr, gssize len);

--- a/src/platform/nm-linux-platform.c
+++ b/src/platform/nm-linux-platform.c
@@ -2087,7 +2087,7 @@ _new_from_nl_route (struct nlmsghdr *nlh, gboolean id_only)
 	    || tb[RTA_GATEWAY]
 	    || tb[RTA_FLOW]) {
 		int ifindex = 0;
-		NMIPAddr gateway = NMIPAddrInit;
+		NMIPAddr gateway = { };
 
 		if (tb[RTA_OIF])
 			ifindex = nla_get_u32 (tb[RTA_OIF]);

--- a/src/settings/plugins/ifcfg-rh/nms-ifcfg-rh-writer.c
+++ b/src/settings/plugins/ifcfg-rh/nms-ifcfg-rh-writer.c
@@ -1891,7 +1891,17 @@ get_route_attributes_string (NMIPRoute *route, int family)
 			                        (lock && g_variant_get_boolean (lock)) ? "lock " : "",
 			                        g_variant_get_uint32 (attr));
 		} else if (strstr (names[i], "lock-")) {
-			/* handled above */
+			const char *n = &(names[i])[NM_STRLEN ("lock-")];
+
+			attr = nm_ip_route_get_attribute (route, n);
+			if (!attr) {
+				g_string_append_printf (str,
+				                        "%s lock 0",
+				                        n);
+			} else {
+				/* we also have a corresponding attribute with the numeric value. The
+				 * lock setting is handled above. */
+			}
 		} else if (nm_streq (names[i], NM_IP_ROUTE_ATTRIBUTE_TOS)) {
 			g_string_append_printf (str, "%s 0x%02x", names[i], (unsigned) g_variant_get_byte (attr));
 		} else if (   nm_streq (names[i], NM_IP_ROUTE_ATTRIBUTE_SRC)

--- a/src/settings/plugins/ifcfg-rh/shvar.c
+++ b/src/settings/plugins/ifcfg-rh/shvar.c
@@ -645,7 +645,7 @@ svFileGetName (const shvarFile *s)
 }
 
 void
-svFileSetName_test_only (shvarFile *s, const char *fileName)
+_nmtst_svFileSetName (shvarFile *s, const char *fileName)
 {
 	/* changing the file name is not supported for regular
 	 * operation. Only allowed to use in tests, othewise,
@@ -655,7 +655,7 @@ svFileSetName_test_only (shvarFile *s, const char *fileName)
 }
 
 void
-svFileSetModified_test_only (shvarFile *s)
+_nmtst_svFileSetModified (shvarFile *s)
 {
 	/* marking a file as modified is only for testing. */
 	s->modified = TRUE;

--- a/src/settings/plugins/ifcfg-rh/shvar.h
+++ b/src/settings/plugins/ifcfg-rh/shvar.h
@@ -35,8 +35,8 @@ typedef struct _shvarFile shvarFile;
 
 const char *svFileGetName (const shvarFile *s);
 
-void svFileSetName_test_only (shvarFile *s, const char *fileName);
-void svFileSetModified_test_only (shvarFile *s);
+void _nmtst_svFileSetName (shvarFile *s, const char *fileName);
+void _nmtst_svFileSetModified (shvarFile *s);
 
 /* Create the file <name>, return a shvarFile (never fails) */
 shvarFile *svCreateFile (const char *name);

--- a/src/settings/plugins/ifcfg-rh/tests/test-ifcfg-rh.c
+++ b/src/settings/plugins/ifcfg-rh/tests/test-ifcfg-rh.c
@@ -9156,8 +9156,8 @@ test_write_unknown (gconstpointer test_data)
 
 	sv = _svOpenFile (testfile);
 
-	svFileSetName_test_only (sv, filename_tmp_1);
-	svFileSetModified_test_only (sv);
+	_nmtst_svFileSetName (sv, filename_tmp_1);
+	_nmtst_svFileSetModified (sv);
 
 	if (g_str_has_suffix (testfile, "ifcfg-test-write-unknown-4")) {
 		_svGetValue_check (sv, "NAME", "l4x");


### PR DESCRIPTION
Refactor parsing of routes in ifcfg-rh plugin.

Soon we will add more route attributes ("table", maybe "onlink").

I think it's fundamentally wrong to do a fuzzy parsing, with accepting any invalid configuration (wrongly).
I think parsing should be strict, and individual cases/options must be explicitly implemented.

Yes, this change results in rejecting some hand-written files, that contain unexpected fields.