### PR TITLE
contrib/fedora: Update required packages

### DIFF
--- a/contrib/fedora/REQUIRED_PACKAGES
+++ b/contrib/fedora/REQUIRED_PACKAGES
@@ -20,11 +20,13 @@ yum install \
     dbus-glib-devel \
     dbus-python \
     dbus-x11 \
+    dhclient \
     gettext-devel \
     git \
     gobject-introspection-devel \
     gtk-doc \
     intltool \
+    iptables \
     jansson-devel \
     libcurl-devel \
     libndp-devel \


### PR DESCRIPTION
Add dhclient and iptables packages to build dependencies to satisfy
rpmbuild complaints:

```
error: Failed build dependencies:
	dhclient is needed by NetworkManager-1:1.9.2-18653.43dba57439.fc28.x86_64
	iptables is needed by NetworkManager-1:1.9.2-18653.43dba57439.fc28.x86_64
ERROR: rpmbuild FAILED
```