### PR TITLE
contrib/fedora: Add mockbuild.sh

### DIFF
--- a/contrib/fedora/rpm/README
+++ b/contrib/fedora/rpm/README
@@ -21,3 +21,7 @@ sudo sh ./contrib/fedora/REQUIRED_PACKAGES
 #
 sudo dnf install ./contrib/fedora/rpm/latest/RPMS/x86_64/*rpm
 
+
+
+# To generate a clean build from git using mock, run:
+./contrib/fedora/rpm/mockbuild.sh

--- a/contrib/fedora/rpm/mockbuild.sh
+++ b/contrib/fedora/rpm/mockbuild.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# mockbuild.sh
+#
+# Generate SRPM from git tree and rebuild it using mock.
+
+SCRIPTDIR="$(dirname "$(readlink -f "$0")")"
+FEDORAVER=$(sed -E 's/.*([0-9]{2}).*/\1/g' /etc/fedora-release)
+ARCH=$(uname -m)
+SRPM=${SCRIPTDIR}/latest/SRPMS/NetworkManager*.src.rpm
+
+alias mock="mock -r fedora-${FEDORAVER}-${ARCH}"
+
+# Generate SRPM
+${SCRIPTDIR}/build_clean.sh --srpm --git
+
+# Rebuild SRPM
+mock --rebuild ${SRPM}
+
+exit


### PR DESCRIPTION
This script comes handy to build from git tree without having to
install build dependencies on the system, the actual build happens
inside mock environment.