### PR TITLE
th/libnm attribute handling

### DIFF
--- a/libnm-core/nm-core-internal.h
+++ b/libnm-core/nm-core-internal.h
@@ -216,6 +216,8 @@ GHashTable *_nm_utils_copy_strdict (GHashTable *strdict);
 
 typedef gpointer (*NMUtilsCopyFunc) (gpointer);
 
+const char **_nm_ip_address_get_attribute_names (const NMIPAddress *addr, gboolean sorted, guint *out_length);
+
 gboolean _nm_ip_route_attribute_validate_all (const NMIPRoute *route);
 const char **_nm_ip_route_get_attribute_names (const NMIPRoute *route, gboolean sorted, guint *out_length);
 GHashTable *_nm_ip_route_get_attributes_direct (NMIPRoute *route);

--- a/libnm-core/nm-keyfile-reader.c
+++ b/libnm-core/nm-keyfile-reader.c
@@ -490,15 +490,17 @@ ip_address_or_route_parser (KeyfileReaderInfo *info, NMSetting *setting, const c
 		const char **key_basename;
 
 		for (key_basename = key_names; *key_basename; key_basename++) {
-			char *key_name;
+			char key_name_buf[100];
+			const char *key_name;
 			gpointer item;
 			char options_key[128];
 
 			/* -1 means no suffix */
-			if (i >= 0)
-				key_name = g_strdup_printf ("%s%d", *key_basename, i);
-			else
-				key_name = g_strdup (*key_basename);
+			key_name = *key_basename;
+			if (i >= 0) {
+				nm_sprintf_buf (key_name_buf, "%s%d", key_name, i);
+				key_name = key_name_buf;
+			}
 
 			item = read_one_ip_address_or_route (info, key, setting_name, key_name, ipv6, routes,
 			                                     gateway ? NULL : &gateway, setting);
@@ -506,8 +508,6 @@ ip_address_or_route_parser (KeyfileReaderInfo *info, NMSetting *setting, const c
 				nm_sprintf_buf (options_key, "%s_options", key_name);
 				fill_route_attributes (info->keyfile, item, setting_name, options_key, ipv6 ? AF_INET6 : AF_INET);
 			}
-
-			g_free (key_name);
 
 			if (info->error) {
 				g_ptr_array_unref (list);

--- a/libnm-core/nm-setting-ip-config.c
+++ b/libnm-core/nm-setting-ip-config.c
@@ -2527,7 +2527,7 @@ verify (NMSetting *setting, NMConnection *connection, GError **error)
 			return FALSE;
 		}
 
-		label = nm_ip_address_get_attribute (addr, "label");
+		label = nm_ip_address_get_attribute (addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL);
 		if (label) {
 			if (!g_variant_is_of_type (label, G_VARIANT_TYPE_STRING)) {
 				g_set_error (error,

--- a/libnm-core/nm-setting-ip-config.c
+++ b/libnm-core/nm-setting-ip-config.c
@@ -537,22 +537,14 @@ nm_ip_address_set_prefix (NMIPAddress *address,
 char **
 nm_ip_address_get_attribute_names (NMIPAddress *address)
 {
-	GHashTableIter iter;
-	const char *key;
-	GPtrArray *names;
+	const char **names;
 
 	g_return_val_if_fail (address != NULL, NULL);
 
-	names = g_ptr_array_new ();
-
-	if (address->attributes) {
-		g_hash_table_iter_init (&iter, address->attributes);
-		while (g_hash_table_iter_next (&iter, (gpointer *) &key, NULL))
-			g_ptr_array_add (names, g_strdup (key));
-	}
-	g_ptr_array_add (names, NULL);
-
-	return (char **) g_ptr_array_free (names, FALSE);
+	names = nm_utils_strdict_get_keys (address->attributes, TRUE, NULL);
+	if (!names)
+		return g_new0 (char *, 1);
+	return nm_utils_strv_make_deep_copied (names);
 }
 
 /**

--- a/libnm-core/nm-setting-ip-config.c
+++ b/libnm-core/nm-setting-ip-config.c
@@ -1136,28 +1136,9 @@ _nm_ip_route_get_attributes_direct (NMIPRoute *route)
 const char **
 _nm_ip_route_get_attribute_names (const NMIPRoute *route, gboolean sorted, guint *out_length)
 {
-	const char **names;
-	guint length;
-
 	g_return_val_if_fail (route != NULL, NULL);
 
-	if (   !route->attributes
-	    || !g_hash_table_size (route->attributes)) {
-		NM_SET_OUT (out_length, 0);
-		return NULL;
-	}
-
-	names = (const char **) g_hash_table_get_keys_as_array (route->attributes, &length);
-	if (   sorted
-	    && length > 1) {
-		g_qsort_with_data (names,
-		                   length,
-		                   sizeof (char *),
-		                   nm_strcmp_p_with_data,
-		                   NULL);
-	}
-	NM_SET_OUT (out_length, length);
-	return names;
+	return nm_utils_strdict_get_keys (route->attributes, sorted, out_length);
 }
 
 /**
@@ -1171,21 +1152,14 @@ _nm_ip_route_get_attribute_names (const NMIPRoute *route, gboolean sorted, guint
 char **
 nm_ip_route_get_attribute_names (NMIPRoute *route)
 {
-	char **names;
-	guint i, len;
+	const char **names;
 
 	g_return_val_if_fail (route != NULL, NULL);
 
-	names = (char **) _nm_ip_route_get_attribute_names (route, TRUE, &len);
+	names = _nm_ip_route_get_attribute_names (route, TRUE, NULL);
 	if (!names)
 		return g_new0 (char *, 1);
-
-	nm_assert (len > 0 && names && names[len] == NULL);
-	for (i = 0; i < len; i++) {
-		nm_assert (names[i]);
-		names[i] = g_strdup (names[i]);
-	}
-	return names;
+	return nm_utils_strv_make_deep_copied (names);
 }
 
 /**

--- a/libnm-core/nm-setting-ip-config.c
+++ b/libnm-core/nm-setting-ip-config.c
@@ -526,6 +526,14 @@ nm_ip_address_set_prefix (NMIPAddress *address,
 	address->prefix = prefix;
 }
 
+const char **
+_nm_ip_address_get_attribute_names (const NMIPAddress *address, gboolean sorted, guint *out_length)
+{
+	nm_assert (address);
+
+	return nm_utils_strdict_get_keys (address->attributes, sorted, out_length);
+}
+
 /**
  * nm_ip_address_get_attribute_names:
  * @address: the #NMIPAddress
@@ -541,7 +549,7 @@ nm_ip_address_get_attribute_names (NMIPAddress *address)
 
 	g_return_val_if_fail (address != NULL, NULL);
 
-	names = nm_utils_strdict_get_keys (address->attributes, TRUE, NULL);
+	names = _nm_ip_address_get_attribute_names (address, TRUE, NULL);
 	if (!names)
 		return g_new0 (char *, 1);
 	return nm_utils_strv_make_deep_copied (names);
@@ -1128,7 +1136,7 @@ _nm_ip_route_get_attributes_direct (NMIPRoute *route)
 const char **
 _nm_ip_route_get_attribute_names (const NMIPRoute *route, gboolean sorted, guint *out_length)
 {
-	g_return_val_if_fail (route != NULL, NULL);
+	nm_assert (route);
 
 	return nm_utils_strdict_get_keys (route->attributes, sorted, out_length);
 }

--- a/libnm-core/nm-setting-ip-config.h
+++ b/libnm-core/nm-setting-ip-config.h
@@ -32,6 +32,8 @@
 
 G_BEGIN_DECLS
 
+#define NM_IP_ADDRESS_ATTRIBUTE_LABEL        "label"
+
 typedef struct NMIPAddress NMIPAddress;
 
 GType        nm_ip_address_get_type            (void);

--- a/libnm-core/nm-setting-ip4-config.c
+++ b/libnm-core/nm-setting-ip4-config.c
@@ -363,7 +363,7 @@ ip4_addresses_set (NMSetting  *setting,
 	if (g_variant_lookup (s_ip4, "address-labels", "^as", &labels)) {
 		for (i = 0; i < addrs->len && labels[i]; i++)
 			if (*labels[i])
-				nm_ip_address_set_attribute (addrs->pdata[i], "label", g_variant_new_string (labels[i]));
+				nm_ip_address_set_attribute (addrs->pdata[i], NM_IP_ADDRESS_ATTRIBUTE_LABEL, g_variant_new_string (labels[i]));
 		g_strfreev (labels);
 	}
 	g_variant_unref (s_ip4);
@@ -391,7 +391,7 @@ ip4_address_labels_get (NMSetting    *setting,
 	num_addrs = nm_setting_ip_config_get_num_addresses (s_ip);
 	for (i = 0; i < num_addrs; i++) {
 		NMIPAddress *addr = nm_setting_ip_config_get_address (s_ip, i);
-		GVariant *label = nm_ip_address_get_attribute (addr, "label");
+		GVariant *label = nm_ip_address_get_attribute (addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL);
 
 		if (label) {
 			have_labels = TRUE;
@@ -404,7 +404,7 @@ ip4_address_labels_get (NMSetting    *setting,
 	labels = g_ptr_array_sized_new (num_addrs);
 	for (i = 0; i < num_addrs; i++) {
 		NMIPAddress *addr = nm_setting_ip_config_get_address (s_ip, i);
-		GVariant *label = nm_ip_address_get_attribute (addr, "label");
+		GVariant *label = nm_ip_address_get_attribute (addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL);
 
 		g_ptr_array_add (labels, (char *) (label ? g_variant_get_string (label, NULL) : ""));
 	}

--- a/libnm-core/nm-setting-tc-config.c
+++ b/libnm-core/nm-setting-tc-config.c
@@ -442,22 +442,14 @@ nm_tc_action_get_kind (NMTCAction *action)
 char **
 nm_tc_action_get_attribute_names (NMTCAction *action)
 {
-	GHashTableIter iter;
-	const char *key;
-	GPtrArray *names;
+	const char **names;
 
 	g_return_val_if_fail (action != NULL, NULL);
 
-	names = g_ptr_array_new ();
-
-	if (action->attributes) {
-		g_hash_table_iter_init (&iter, action->attributes);
-		while (g_hash_table_iter_next (&iter, (gpointer *) &key, NULL))
-			g_ptr_array_add (names, g_strdup (key));
-	}
-	g_ptr_array_add (names, NULL);
-
-	return (char **) g_ptr_array_free (names, FALSE);
+	names = nm_utils_strdict_get_keys (action->attributes, TRUE, NULL);
+	if (!names)
+		return g_new0 (char *, 1);
+	return nm_utils_strv_make_deep_copied (names);
 }
 
 /**
@@ -1329,7 +1321,7 @@ _action_to_variant (NMTCAction *action)
 
 	for (i = 0; attrs[i]; i++) {
 		g_variant_builder_add (&builder, "{sv}", attrs[i],
-				       nm_tc_action_get_attribute (action, attrs[i]));
+		                       nm_tc_action_get_attribute (action, attrs[i]));
 	}
 
 	return g_variant_builder_end (&builder);

--- a/libnm-core/nm-utils.c
+++ b/libnm-core/nm-utils.c
@@ -1878,7 +1878,7 @@ GVariant *
 nm_utils_ip_addresses_to_variant (GPtrArray *addresses)
 {
 	GVariantBuilder builder;
-	int i;
+	guint i;
 
 	g_variant_builder_init (&builder, G_VARIANT_TYPE ("aa{sv}"));
 
@@ -1886,8 +1886,8 @@ nm_utils_ip_addresses_to_variant (GPtrArray *addresses)
 		for (i = 0; i < addresses->len; i++) {
 			NMIPAddress *addr = addresses->pdata[i];
 			GVariantBuilder addr_builder;
-			char **names;
-			int n;
+			gs_free const char **names = NULL;
+			guint j, len;
 
 			g_variant_builder_init (&addr_builder, G_VARIANT_TYPE ("a{sv}"));
 			g_variant_builder_add (&addr_builder, "{sv}",
@@ -1897,13 +1897,12 @@ nm_utils_ip_addresses_to_variant (GPtrArray *addresses)
 			                       "prefix",
 			                       g_variant_new_uint32 (nm_ip_address_get_prefix (addr)));
 
-			names = nm_ip_address_get_attribute_names (addr);
-			for (n = 0; names[n]; n++) {
+			names = _nm_ip_address_get_attribute_names (addr, TRUE, &len);
+			for (j = 0; j < len; j++) {
 				g_variant_builder_add (&addr_builder, "{sv}",
-				                       names[n],
-				                       nm_ip_address_get_attribute (addr, names[n]));
+				                       names[j],
+				                       nm_ip_address_get_attribute (addr, names[j]));
 			}
-			g_strfreev (names);
 
 			g_variant_builder_add (&builder, "a{sv}", &addr_builder);
 		}

--- a/libnm-core/nm-utils.c
+++ b/libnm-core/nm-utils.c
@@ -2453,10 +2453,10 @@ nm_utils_tc_action_from_str (const char *str, GError **error)
 	nm_assert (str);
 	nm_assert (!error || !*error);
 
-        ht = nm_utils_parse_variant_attributes (str,
-                                                ' ', ' ', FALSE,
-                                                tc_action_attribute_spec,
-                                                error);
+	ht = nm_utils_parse_variant_attributes (str,
+	                                        ' ', ' ', FALSE,
+	                                        tc_action_attribute_spec,
+	                                        error);
 	if (!ht)
 		return FALSE;
 
@@ -2492,10 +2492,10 @@ nm_utils_tc_action_from_str (const char *str, GError **error)
 			return NULL;
 		}
 
-	        options = nm_utils_parse_variant_attributes (rest,
-	                                                     ' ', ' ', FALSE,
-	                                                     attrs,
-	                                                     error);
+		options = nm_utils_parse_variant_attributes (rest,
+		                                             ' ', ' ', FALSE,
+		                                             attrs,
+		                                             error);
 		if (!options) {
 			nm_tc_action_unref (action);
 			return NULL;

--- a/libnm-core/tests/test-general.c
+++ b/libnm-core/tests/test-general.c
@@ -959,7 +959,7 @@ test_setting_ip4_config_labels (void)
 	nmtst_assert_setting_verifies (NM_SETTING (s_ip4));
 
 	addr = nm_setting_ip_config_get_address (s_ip4, 0);
-	label = nm_ip_address_get_attribute (addr, "label");
+	label = nm_ip_address_get_attribute (addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL);
 	g_assert (label == NULL);
 
 	/* The 'address-labels' property should be omitted from the serialization if
@@ -984,28 +984,28 @@ test_setting_ip4_config_labels (void)
 	/* addr 2 */
 	addr = nm_ip_address_new (AF_INET, "2.3.4.5", 24, &error);
 	g_assert_no_error (error);
-	nm_ip_address_set_attribute (addr, "label", g_variant_new_string ("eth0:1"));
+	nm_ip_address_set_attribute (addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL, g_variant_new_string ("eth0:1"));
 
 	nm_setting_ip_config_add_address (s_ip4, addr);
 	nm_ip_address_unref (addr);
 	nmtst_assert_setting_verifies (NM_SETTING (s_ip4));
 
 	addr = nm_setting_ip_config_get_address (s_ip4, 1);
-	label = nm_ip_address_get_attribute (addr, "label");
+	label = nm_ip_address_get_attribute (addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL);
 	g_assert (label != NULL);
 	g_assert_cmpstr (g_variant_get_string (label, NULL), ==, "eth0:1");
 
 	/* addr 3 */
 	addr = nm_ip_address_new (AF_INET, "3.4.5.6", 24, &error);
 	g_assert_no_error (error);
-	nm_ip_address_set_attribute (addr, "label", NULL);
+	nm_ip_address_set_attribute (addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL, NULL);
 
 	nm_setting_ip_config_add_address (s_ip4, addr);
 	nm_ip_address_unref (addr);
 	nmtst_assert_setting_verifies (NM_SETTING (s_ip4));
 
 	addr = nm_setting_ip_config_get_address (s_ip4, 2);
-	label = nm_ip_address_get_attribute (addr, "label");
+	label = nm_ip_address_get_attribute (addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL);
 	g_assert (label == NULL);
 
 	/* Remove addr 1 and re-verify remaining addresses */
@@ -1014,13 +1014,13 @@ test_setting_ip4_config_labels (void)
 
 	addr = nm_setting_ip_config_get_address (s_ip4, 0);
 	g_assert_cmpstr (nm_ip_address_get_address (addr), ==, "2.3.4.5");
-	label = nm_ip_address_get_attribute (addr, "label");
+	label = nm_ip_address_get_attribute (addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL);
 	g_assert (label != NULL);
 	g_assert_cmpstr (g_variant_get_string (label, NULL), ==, "eth0:1");
 
 	addr = nm_setting_ip_config_get_address (s_ip4, 1);
 	g_assert_cmpstr (nm_ip_address_get_address (addr), ==, "3.4.5.6");
-	label = nm_ip_address_get_attribute (addr, "label");
+	label = nm_ip_address_get_attribute (addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL);
 	g_assert (label == NULL);
 
 	/* If we serialize as the daemon, the labels should appear in the D-Bus
@@ -1051,11 +1051,11 @@ test_setting_ip4_config_labels (void)
 	g_assert (addrs != NULL);
 	g_assert_cmpint (addrs->len, ==, 2);
 	addr = addrs->pdata[0];
-	label = nm_ip_address_get_attribute (addr, "label");
+	label = nm_ip_address_get_attribute (addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL);
 	g_assert (label != NULL);
 	g_assert_cmpstr (g_variant_get_string (label, NULL), ==, "eth0:1");
 	addr = addrs->pdata[1];
-	label = nm_ip_address_get_attribute (addr, "label");
+	label = nm_ip_address_get_attribute (addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL);
 	g_assert (label == NULL);
 	g_ptr_array_unref (addrs);
 
@@ -1078,13 +1078,13 @@ test_setting_ip4_config_labels (void)
 
 	addr = nm_setting_ip_config_get_address (s_ip4, 0);
 	g_assert_cmpstr (nm_ip_address_get_address (addr), ==, "2.3.4.5");
-	label = nm_ip_address_get_attribute (addr, "label");
+	label = nm_ip_address_get_attribute (addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL);
 	g_assert (label != NULL);
 	g_assert_cmpstr (g_variant_get_string (label, NULL), ==, "eth0:1");
 
 	addr = nm_setting_ip_config_get_address (s_ip4, 1);
 	g_assert_cmpstr (nm_ip_address_get_address (addr), ==, "3.4.5.6");
-	label = nm_ip_address_get_attribute (addr, "label");
+	label = nm_ip_address_get_attribute (addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL);
 	g_assert (label == NULL);
 
 	g_object_unref (conn);
@@ -1101,12 +1101,12 @@ test_setting_ip4_config_labels (void)
 
 	addr = nm_setting_ip_config_get_address (s_ip4, 0);
 	g_assert_cmpstr (nm_ip_address_get_address (addr), ==, "2.3.4.5");
-	label = nm_ip_address_get_attribute (addr, "label");
+	label = nm_ip_address_get_attribute (addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL);
 	g_assert_cmpstr (g_variant_get_string (label, NULL), ==, "eth0:1");
 
 	addr = nm_setting_ip_config_get_address (s_ip4, 1);
 	g_assert_cmpstr (nm_ip_address_get_address (addr), ==, "3.4.5.6");
-	label = nm_ip_address_get_attribute (addr, "label");
+	label = nm_ip_address_get_attribute (addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL);
 	g_assert (label == NULL);
 
 	/* Test explicit property assignment */
@@ -1126,13 +1126,13 @@ test_setting_ip4_config_labels (void)
 
 	addr = nm_setting_ip_config_get_address (s_ip4, 0);
 	g_assert_cmpstr (nm_ip_address_get_address (addr), ==, "2.3.4.5");
-	label = nm_ip_address_get_attribute (addr, "label");
+	label = nm_ip_address_get_attribute (addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL);
 	g_assert (label != NULL);
 	g_assert_cmpstr (g_variant_get_string (label, NULL), ==, "eth0:1");
 
 	addr = nm_setting_ip_config_get_address (s_ip4, 1);
 	g_assert_cmpstr (nm_ip_address_get_address (addr), ==, "3.4.5.6");
-	label = nm_ip_address_get_attribute (addr, "label");
+	label = nm_ip_address_get_attribute (addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL);
 	g_assert (label == NULL);
 
 	g_object_unref (conn);
@@ -3057,10 +3057,10 @@ test_setting_compare_addresses (void)
 
 	a = nm_ip_address_new (AF_INET, "192.168.7.5", 24, NULL);
 
-	nm_ip_address_set_attribute (a, "label", g_variant_new_string ("xoxoxo"));
+	nm_ip_address_set_attribute (a, NM_IP_ADDRESS_ATTRIBUTE_LABEL, g_variant_new_string ("xoxoxo"));
 	nm_setting_ip_config_add_address ((NMSettingIPConfig *) s1, a);
 
-	nm_ip_address_set_attribute (a, "label", g_variant_new_string ("hello"));
+	nm_ip_address_set_attribute (a, NM_IP_ADDRESS_ATTRIBUTE_LABEL, g_variant_new_string ("hello"));
 	nm_setting_ip_config_add_address ((NMSettingIPConfig *) s2, a);
 
 	nm_ip_address_unref (a);
@@ -3089,10 +3089,10 @@ test_setting_compare_routes (void)
 
 	r = nm_ip_route_new (AF_INET, "192.168.12.0", 24, "192.168.11.1", 473, NULL);
 
-	nm_ip_route_set_attribute (r, "label", g_variant_new_string ("xoxoxo"));
+	nm_ip_route_set_attribute (r, NM_IP_ADDRESS_ATTRIBUTE_LABEL, g_variant_new_string ("xoxoxo"));
 	nm_setting_ip_config_add_route ((NMSettingIPConfig *) s1, r);
 
-	nm_ip_route_set_attribute (r, "label", g_variant_new_string ("hello"));
+	nm_ip_route_set_attribute (r, NM_IP_ADDRESS_ATTRIBUTE_LABEL, g_variant_new_string ("hello"));
 	nm_setting_ip_config_add_route ((NMSettingIPConfig *) s2, r);
 
 	nm_ip_route_unref (r);

--- a/shared/nm-utils/nm-shared-utils.c
+++ b/shared/nm-utils/nm-shared-utils.c
@@ -1175,3 +1175,20 @@ nm_utils_strdict_get_keys (const GHashTable *hash,
 	NM_SET_OUT (out_length, length);
 	return names;
 }
+
+char **
+nm_utils_strv_make_deep_copied (const char **strv)
+{
+	gsize i;
+
+	/* it takes a strv dictionary, and copies each
+	 * strings. Note that this updates @strv *in-place*
+	 * and returns it. */
+
+	if (!strv)
+		return NULL;
+	for (i = 0; strv[i]; i++)
+		strv[i] = g_strdup (strv[i]);
+
+	return (char **) strv;
+}

--- a/shared/nm-utils/nm-shared-utils.c
+++ b/shared/nm-utils/nm-shared-utils.c
@@ -1148,3 +1148,30 @@ nm_utils_named_values_from_str_dict (GHashTable *hash, guint *out_len)
 	NM_SET_OUT (out_len, len);
 	return values;
 }
+
+const char **
+nm_utils_strdict_get_keys (const GHashTable *hash,
+                           gboolean sorted,
+                           guint *out_length)
+{
+	const char **names;
+	guint length;
+
+	if (   !hash
+	    || !g_hash_table_size ((GHashTable *) hash)) {
+		NM_SET_OUT (out_length, 0);
+		return NULL;
+	}
+
+	names = (const char **) g_hash_table_get_keys_as_array ((GHashTable *) hash, &length);
+	if (   sorted
+	    && length > 1) {
+		g_qsort_with_data (names,
+		                   length,
+		                   sizeof (char *),
+		                   nm_strcmp_p_with_data,
+		                   NULL);
+	}
+	NM_SET_OUT (out_length, length);
+	return names;
+}

--- a/shared/nm-utils/nm-shared-utils.h
+++ b/shared/nm-utils/nm-shared-utils.h
@@ -443,6 +443,10 @@ typedef struct {
 
 NMUtilsNamedValue *nm_utils_named_values_from_str_dict (GHashTable *hash, guint *out_len);
 
+const char **nm_utils_strdict_get_keys (const GHashTable *hash,
+                                        gboolean sorted,
+                                        guint *out_length);
+
 /*****************************************************************************/
 
 #define NM_UTILS_NS_PER_SECOND  ((gint64) 1000000000)

--- a/shared/nm-utils/nm-shared-utils.h
+++ b/shared/nm-utils/nm-shared-utils.h
@@ -447,6 +447,8 @@ const char **nm_utils_strdict_get_keys (const GHashTable *hash,
                                         gboolean sorted,
                                         guint *out_length);
 
+char **nm_utils_strv_make_deep_copied (const char **strv);
+
 /*****************************************************************************/
 
 #define NM_UTILS_NS_PER_SECOND  ((gint64) 1000000000)

--- a/src/nm-ip4-config.c
+++ b/src/nm-ip4-config.c
@@ -957,7 +957,7 @@ nm_ip4_config_merge_setting (NMIP4Config *self,
 		address.preferred = NM_PLATFORM_LIFETIME_PERMANENT;
 		address.addr_source = NM_IP_CONFIG_SOURCE_USER;
 
-		label = nm_ip_address_get_attribute (s_addr, "label");
+		label = nm_ip_address_get_attribute (s_addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL);
 		if (label)
 			g_strlcpy (address.label, g_variant_get_string (label, NULL), sizeof (address.label));
 
@@ -1069,7 +1069,7 @@ nm_ip4_config_create_setting (const NMIP4Config *self)
 
 		s_addr = nm_ip_address_new_binary (AF_INET, &address->address, address->plen, NULL);
 		if (*address->label)
-			nm_ip_address_set_attribute (s_addr, "label", g_variant_new_string (address->label));
+			nm_ip_address_set_attribute (s_addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL, g_variant_new_string (address->label));
 
 		nm_setting_ip_config_add_address (s_ip4, s_addr);
 		nm_ip_address_unref (s_addr);
@@ -2963,7 +2963,7 @@ get_property (GObject *object, guint prop_id,
 
 				if (*address->label) {
 					g_variant_builder_add (&addr_builder, "{sv}",
-					                       "label",
+					                       NM_IP_ADDRESS_ATTRIBUTE_LABEL,
 					                       g_variant_new_string (address->label));
 				}
 

--- a/src/settings/plugins/ifcfg-rh/nms-ifcfg-rh-reader.c
+++ b/src/settings/plugins/ifcfg-rh/nms-ifcfg-rh-reader.c
@@ -1625,7 +1625,7 @@ read_aliases (NMSettingIPConfig *s_ip4, gboolean read_defroute, const char *file
 			                            read_defroute ? &gateway : NULL,
 			                            &err);
 			if (ok) {
-				nm_ip_address_set_attribute (addr, "label", g_variant_new_string (device));
+				nm_ip_address_set_attribute (addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL, g_variant_new_string (device));
 				if (!nm_setting_ip_config_add_address (s_ip4, addr))
 					PARSE_WARNING ("duplicate IP4 address in alias file %s", item);
 				if (nm_streq0 (nm_setting_ip_config_get_method (s_ip4), NM_SETTING_IP4_CONFIG_METHOD_DISABLED))

--- a/src/settings/plugins/ifcfg-rh/nms-ifcfg-rh-writer.c
+++ b/src/settings/plugins/ifcfg-rh/nms-ifcfg-rh-writer.c
@@ -2275,7 +2275,7 @@ write_ip4_setting (NMConnection *connection,
 		if (i > 0) {
 			GVariant *label;
 
-			label = nm_ip_address_get_attribute (addr, "label");
+			label = nm_ip_address_get_attribute (addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL);
 			if (label)
 				continue;
 		}
@@ -2478,7 +2478,7 @@ write_ip4_aliases (NMConnection *connection, const char *base_ifcfg_path)
 
 		addr = nm_setting_ip_config_get_address (s_ip4, i);
 
-		label_var = nm_ip_address_get_attribute (addr, "label");
+		label_var = nm_ip_address_get_attribute (addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL);
 		if (!label_var)
 			continue;
 		label = g_variant_get_string (label_var, NULL);

--- a/src/settings/plugins/ifcfg-rh/tests/test-ifcfg-rh.c
+++ b/src/settings/plugins/ifcfg-rh/tests/test-ifcfg-rh.c
@@ -2079,7 +2079,7 @@ test_read_wired_aliases_good (gconstpointer test_data)
 		g_assert (j < expected_num_addresses);
 
 		g_assert_cmpint (nm_ip_address_get_prefix (ip4_addr), ==, 24);
-		label = nm_ip_address_get_attribute (ip4_addr, "label");
+		label = nm_ip_address_get_attribute (ip4_addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL);
 		if (expected_label[j])
 			g_assert_cmpstr (g_variant_get_string (label, NULL), ==, expected_label[j]);
 		else
@@ -2131,7 +2131,7 @@ test_read_wired_aliases_bad (const char *base, const char *expected_id)
 	g_assert (ip4_addr != NULL);
 	g_assert_cmpstr (nm_ip_address_get_address (ip4_addr), ==, "192.168.1.5");
 	g_assert_cmpint (nm_ip_address_get_prefix (ip4_addr), ==, 24);
-	g_assert (nm_ip_address_get_attribute (ip4_addr, "label") == NULL);
+	g_assert (nm_ip_address_get_attribute (ip4_addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL) == NULL);
 
 	/* Gateway */
 	g_assert_cmpstr (nm_setting_ip_config_get_gateway (s_ip4), ==, "192.168.1.1");
@@ -5141,7 +5141,7 @@ test_write_wired_aliases (void)
 		addr = nm_ip_address_new (AF_INET, ip[i], 24, &error);
 		g_assert_no_error (error);
 		if (label[i])
-			nm_ip_address_set_attribute (addr, "label", g_variant_new_string (label[i]));
+			nm_ip_address_set_attribute (addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL, g_variant_new_string (label[i]));
 		nm_setting_ip_config_add_address (s_ip4, addr);
 		nm_ip_address_unref (addr);
 	}
@@ -5200,9 +5200,9 @@ test_write_wired_aliases (void)
 		else {
 			g_assert_cmpint (nm_ip_address_get_prefix (addr), ==, 24);
 			if (label[j])
-				g_assert_cmpstr (g_variant_get_string (nm_ip_address_get_attribute (addr, "label"), NULL), ==, label[j]);
+				g_assert_cmpstr (g_variant_get_string (nm_ip_address_get_attribute (addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL), NULL), ==, label[j]);
 			else
-				g_assert (nm_ip_address_get_attribute (addr, "label") == NULL);
+				g_assert (nm_ip_address_get_attribute (addr, NM_IP_ADDRESS_ATTRIBUTE_LABEL) == NULL);
 			ip[j] = NULL;
 		}
 	}


### PR DESCRIPTION
Some fixes regarding attribute handling

Already partly discussed on IRC. As there was no conclusion there, I open a PR.


TODO: keyfile is unable to store/load address attributes.