### PR TITLE
th/static_asserts

### DIFF
--- a/libnm-core/nm-setting-bond.c
+++ b/libnm-core/nm-setting-bond.c
@@ -537,7 +537,7 @@ _nm_setting_bond_option_supported (const char *option, NMBondMode mode)
 
 	for (i = 0; i < G_N_ELEMENTS (bond_unsupp_modes); i++) {
 		if (nm_streq (option, bond_unsupp_modes[i].option))
-		    return !NM_FLAGS_HAS (bond_unsupp_modes[i].unsupp_modes, BIT (mode));
+			return !NM_FLAGS_ANY (bond_unsupp_modes[i].unsupp_modes, BIT (mode));
 	}
 
 	return TRUE;

--- a/libnm-core/tests/test-general.c
+++ b/libnm-core/tests/test-general.c
@@ -210,6 +210,10 @@ static void
 test_nm_g_slice_free_fcn (void)
 {
 	gpointer p;
+	struct {
+		char a1;
+		char a2;
+	} xx;
 
 	p = g_slice_new (gint64);
 	(nm_g_slice_free_fcn (gint64)) (p);
@@ -222,6 +226,9 @@ test_nm_g_slice_free_fcn (void)
 
 	p = g_slice_new (gint64);
 	nm_g_slice_free_fcn_gint64 (p);
+
+	p = g_slice_alloc (sizeof (xx));
+	(nm_g_slice_free_fcn (xx)) (p);
 }
 
 /*****************************************************************************/

--- a/libnm-core/tests/test-general.c
+++ b/libnm-core/tests/test-general.c
@@ -6206,7 +6206,9 @@ _test_find_binary_search_do_uint32 (const int *int_array, gsize len)
 	const int OFFSET = 100;
 	const int NEEDLE = 0 + OFFSET;
 	gssize expected_result = -1;
-	guint32 array[len];
+	guint32 array[30];
+
+	g_assert (len <= G_N_ELEMENTS (array));
 
 	/* the test data has negative values. Shift them... */
 	for (idx = 0; idx < len; idx++) {

--- a/m4/compiler_options.m4
+++ b/m4/compiler_options.m4
@@ -79,6 +79,7 @@ if test "$GCC" = "yes" -a "$set_more_warnings" != "no"; then
 		      -Wshift-negative-value \
 		      -Wstrict-prototypes \
 		      -Wundef \
+		      -Wvla \
 		      -Wno-duplicate-decl-specifier \
 		      -Wno-format-truncation \
 		      -Wno-format-y2k \

--- a/shared/nm-utils/nm-shared-utils.h
+++ b/shared/nm-utils/nm-shared-utils.h
@@ -326,12 +326,18 @@ _nm_g_slice_free_fcn_define (16)
 		/* If mem_size is a compile time constant, the compiler
 		 * will be able to optimize this. Hence, you don't want
 		 * to call this with a non-constant size argument. */ \
-		switch (mem_size) { \
+		G_STATIC_ASSERT_EXPR (   ((mem_size) ==  1) \
+		                      || ((mem_size) ==  2) \
+		                      || ((mem_size) ==  4) \
+		                      || ((mem_size) ==  8) \
+		                      || ((mem_size) == 12) \
+		                      || ((mem_size) == 16)); \
+		switch ((mem_size)) { \
 		case  1: _fcn = _nm_g_slice_free_fcn_1;  break; \
 		case  2: _fcn = _nm_g_slice_free_fcn_2;  break; \
 		case  4: _fcn = _nm_g_slice_free_fcn_4;  break; \
 		case  8: _fcn = _nm_g_slice_free_fcn_8;  break; \
-		case 12: _fcn = _nm_g_slice_free_fcn_12;  break; \
+		case 12: _fcn = _nm_g_slice_free_fcn_12; break; \
 		case 16: _fcn = _nm_g_slice_free_fcn_16; break; \
 		default: g_assert_not_reached (); _fcn = NULL; break; \
 		} \

--- a/src/devices/nm-device.c
+++ b/src/devices/nm-device.c
@@ -12246,7 +12246,7 @@ nm_device_check_connection_available (NMDevice *self,
 
 		for (i = 0; i <= NM_DEVICE_CHECK_CON_AVAILABLE_ALL; i++) {
 			for (j = 1; j <= NM_DEVICE_CHECK_CON_AVAILABLE_ALL; j <<= 1) {
-				if (NM_FLAGS_HAS (i, j)) {
+				if (NM_FLAGS_ANY (i, j)) {
 					k = i & ~j;
 					nm_assert (   available_all[i] == available_all[k]
 					           || available_all[i]);

--- a/src/main.c
+++ b/src/main.c
@@ -93,8 +93,10 @@ static void
 _init_nm_debug (NMConfig *config)
 {
 	gs_free char *debug = NULL;
-	const guint D_RLIMIT_CORE = 1;
-	const guint D_FATAL_WARNINGS = 2;
+	enum {
+		D_RLIMIT_CORE =    (1 << 0),
+		D_FATAL_WARNINGS = (1 << 1),
+	};
 	GDebugKey keys[] = {
 		{ "RLIMIT_CORE", D_RLIMIT_CORE },
 		{ "fatal-warnings", D_FATAL_WARNINGS },

--- a/src/nm-audit-manager.c
+++ b/src/nm-audit-manager.c
@@ -123,7 +123,7 @@ build_message (GPtrArray *fields, AuditBackend backend)
 	for (i = 0; i < fields->len; i++) {
 		field = fields->pdata[i];
 
-		if (!NM_FLAGS_HAS (field->backends, backend))
+		if (!NM_FLAGS_ANY (field->backends, backend))
 			continue;
 
 		if (first)

--- a/src/nm-core-utils.c
+++ b/src/nm-core-utils.c
@@ -1246,8 +1246,8 @@ typedef struct {
 static gboolean
 match_device_s390_subchannels_parse (const char *s390_subchannels, guint32 *out_a, guint32 *out_b, guint32 *out_c)
 {
-	const int BUFSIZE = 30;
-	char buf[BUFSIZE + 1];
+	char buf[30 + 1];
+	const int BUFSIZE = G_N_ELEMENTS (buf) - 1;
 	guint i = 0;
 	char *pa = NULL, *pb = NULL, *pc = NULL;
 	gint64 a, b, c;

--- a/src/nm-ip4-config.c
+++ b/src/nm-ip4-config.c
@@ -2879,9 +2879,9 @@ nm_ip4_config_equal (const NMIP4Config *a, const NMIP4Config *b)
 {
 	GChecksum *a_checksum = g_checksum_new (G_CHECKSUM_SHA1);
 	GChecksum *b_checksum = g_checksum_new (G_CHECKSUM_SHA1);
-	gsize a_len = g_checksum_type_get_length (G_CHECKSUM_SHA1);
-	gsize b_len = g_checksum_type_get_length (G_CHECKSUM_SHA1);
-	guchar a_data[a_len], b_data[b_len];
+	guchar a_data[20], b_data[20];
+	gsize a_len = sizeof (a_data);
+	gsize b_len = sizeof (b_data);
 	gboolean equal;
 
 	if (a)
@@ -2892,7 +2892,8 @@ nm_ip4_config_equal (const NMIP4Config *a, const NMIP4Config *b)
 	g_checksum_get_digest (a_checksum, a_data, &a_len);
 	g_checksum_get_digest (b_checksum, b_data, &b_len);
 
-	g_assert (a_len == b_len);
+	nm_assert (a_len == sizeof (a_data));
+	nm_assert (b_len == sizeof (b_data));
 	equal = !memcmp (a_data, b_data, a_len);
 
 	g_checksum_free (a_checksum);

--- a/src/nm-ip6-config.c
+++ b/src/nm-ip6-config.c
@@ -2477,9 +2477,9 @@ nm_ip6_config_equal (const NMIP6Config *a, const NMIP6Config *b)
 {
 	GChecksum *a_checksum = g_checksum_new (G_CHECKSUM_SHA1);
 	GChecksum *b_checksum = g_checksum_new (G_CHECKSUM_SHA1);
-	gsize a_len = g_checksum_type_get_length (G_CHECKSUM_SHA1);
-	gsize b_len = g_checksum_type_get_length (G_CHECKSUM_SHA1);
-	guchar a_data[a_len], b_data[b_len];
+	guchar a_data[20], b_data[20];
+	gsize a_len = sizeof (a_data);
+	gsize b_len = sizeof (b_data);
 	gboolean equal;
 
 	if (a)
@@ -2490,7 +2490,8 @@ nm_ip6_config_equal (const NMIP6Config *a, const NMIP6Config *b)
 	g_checksum_get_digest (a_checksum, a_data, &a_len);
 	g_checksum_get_digest (b_checksum, b_data, &b_len);
 
-	g_assert (a_len == b_len);
+	nm_assert (a_len == sizeof (a_data));
+	nm_assert (b_len == sizeof (b_data));
 	equal = !memcmp (a_data, b_data, a_len);
 
 	g_checksum_free (a_checksum);

--- a/src/nm-logging.c
+++ b/src/nm-logging.c
@@ -663,7 +663,7 @@ _nm_log_impl (const char *file,
 				NMLogDomain dom = dom_all & _nm_logging_enabled_state[level];
 
 				for (diter = &global.domain_desc[0]; diter->name; diter++) {
-					if (!NM_FLAGS_HAS (dom_all, diter->num))
+					if (!NM_FLAGS_ANY (dom_all, diter->num))
 						continue;
 
 					/* construct a list of all domains (not only the enabled ones).
@@ -681,7 +681,7 @@ _nm_log_impl (const char *file,
 						g_string_append (s_domain_all, diter->name);
 					}
 
-					if (NM_FLAGS_HAS (dom, diter->num)) {
+					if (NM_FLAGS_ANY (dom, diter->num)) {
 						if (i_domain > 0) {
 							/* SYSLOG_FACILITY is specified multiple times for each domain that is actually enabled. */
 							_iovec_set_format_a (iov++, _MAX_LEN (30, diter->name), "SYSLOG_FACILITY=%s", diter->name);

--- a/src/platform/nm-linux-platform.c
+++ b/src/platform/nm-linux-platform.c
@@ -283,7 +283,7 @@ typedef enum {
 
 #define FOR_EACH_DELAYED_ACTION(iflags, flags_all) \
 	for ((iflags) = (DelayedActionType) 0x1LL; (iflags) <= DELAYED_ACTION_TYPE_MAX; (iflags) <<= 1) \
-		if (NM_FLAGS_HAS (flags_all, iflags))
+		if (NM_FLAGS_ANY (flags_all, iflags))
 
 typedef enum {
 	/* Negative values are errors from kernel. Add dummy member to

--- a/src/platform/nmp-netns.c
+++ b/src/platform/nmp-netns.c
@@ -200,8 +200,8 @@ _stack_current_ns_types (NMPNetns *netns, int ns_types)
 		}
 
 		for (i = 0; i < G_N_ELEMENTS (ns_types_check); i++) {
-			if (   NM_FLAGS_HAS (ns_types, ns_types_check[i])
-			    && NM_FLAGS_HAS (info->ns_types, ns_types_check[i])) {
+			if (   NM_FLAGS_ANY (ns_types, ns_types_check[i])
+			    && NM_FLAGS_ANY (info->ns_types, ns_types_check[i])) {
 				res = NM_FLAGS_SET (res, ns_types_check[i]);
 				ns_types = NM_FLAGS_UNSET (ns_types, ns_types_check[i]);
 			}

--- a/src/platform/tests/test-link.c
+++ b/src/platform/tests/test-link.c
@@ -2230,7 +2230,7 @@ test_netns_push (gpointer fixture, gconstpointer test_data)
 		p = pl_base;
 		for (j = nstack; j >= 1; ) {
 			j--;
-			if (NM_FLAGS_HAS (stack[j].ns_types, ns_type)) {
+			if (NM_FLAGS_ANY (stack[j].ns_types, ns_type)) {
 				p = stack[j].pl;
 				break;
 			}

--- a/src/platform/tests/test-nmp-object.c
+++ b/src/platform/tests/test-nmp-object.c
@@ -54,27 +54,20 @@ test_obj_base (void)
 	gs_unref_object GCancellable *obj_cancellable = g_cancellable_new ();
 	nm_auto_nmpobj NMPObject *obj_link = nmp_object_new_link (10);
 
-#define STATIC_ASSERT(cond) \
-	G_STMT_START { \
-		G_STATIC_ASSERT (cond); \
-		G_STATIC_ASSERT_EXPR (cond); \
-		g_assert (cond); \
-	} G_STMT_END
+	g_assert (&g->g_type_instance              == (void *) &o->_class);
+	g_assert (&g->g_type_instance.g_class      == (void *) &o->_class);
 
-	STATIC_ASSERT (&g->g_type_instance              == (void *) &o->_class);
-	STATIC_ASSERT (&g->g_type_instance.g_class      == (void *) &o->_class);
+	g_assert (sizeof (o->parent.parent)        == sizeof (GTypeInstance));
 
-	STATIC_ASSERT (sizeof (o->parent.parent)        == sizeof (GTypeInstance));
+	g_assert (&c->parent                       == (void *) c);
+	g_assert (&c->parent.parent.g_type_class   == (void *) c);
+	g_assert (&c->parent.parent.g_type         == (void *) c);
+	g_assert (&c->parent.parent.g_type         == &k->g_type);
 
-	STATIC_ASSERT (&c->parent                       == (void *) c);
-	STATIC_ASSERT (&c->parent.parent.g_type_class   == (void *) c);
-	STATIC_ASSERT (&c->parent.parent.g_type         == (void *) c);
-	STATIC_ASSERT (&c->parent.parent.g_type         == &k->g_type);
+	g_assert (sizeof (c->parent.parent)        == sizeof (GTypeClass));
 
-	STATIC_ASSERT (sizeof (c->parent.parent)        == sizeof (GTypeClass));
-
-	STATIC_ASSERT (&o->parent                       == (void *) o);
-	STATIC_ASSERT (&o->parent.klass                 == (void *) &o->_class);
+	g_assert (&o->parent                       == (void *) o);
+	g_assert (&o->parent.klass                 == (void *) &o->_class);
 
 	obj = (NMObjBaseInst *) obj_cancellable;
 	g_assert (!NMP_CLASS_IS_VALID ((NMPClass *) obj->klass));


### PR DESCRIPTION
Compile NM with -Wvla and don't use variable length arrays.

It makes static-asserts against a non-compile-time constant work. Otherwise, the assertion is silently ignored.