### PR TITLE
th/wifi_iwd_config

### DIFF
--- a/contrib/fedora/rpm/NetworkManager.spec
+++ b/contrib/fedora/rpm/NetworkManager.spec
@@ -50,6 +50,7 @@
 %bcond_without wwan
 %bcond_without team
 %bcond_without wifi
+%bcond_with iwd
 %bcond_without ovs
 %bcond_without ppp
 %bcond_without nmtui
@@ -221,6 +222,11 @@ Summary: Wifi plugin for NetworkManager
 Group: System Environment/Base
 Requires: %{name}%{?_isa} = %{epoch}:%{version}-%{release}
 Requires: wpa_supplicant >= 1:1.1
+# the wifi plugin doesn't require iwd, even if it was build with
+# iwd support. Note that the plugin supports both supplicant and
+# iwd backend, that doesn't mean that the user requires to have them
+# both installed. Maybe both iwd and supplicant should Provide a "wireless-daemon"
+# meta package.
 Obsoletes: NetworkManager < %{obsoletes_device_plugins}
 
 %description wifi
@@ -425,6 +431,11 @@ intltoolize --automake --copy --force
 %endif
 %else
 	--enable-wifi=no \
+%endif
+%if %{with iwd}
+	--with-iwd=yes \
+%else
+	--with-iwd=no \
 %endif
 	--enable-vala=yes \
 	--enable-introspection \

--- a/man/NetworkManager.conf.xml
+++ b/man/NetworkManager.conf.xml
@@ -927,6 +927,15 @@ managed=1
             </para>
           </listitem>
         </varlistentry>
+        <varlistentry id="wifi.backend">
+          <term><varname>wifi.backend</varname></term>
+          <listitem>
+            <para>
+              Specify the Wi-Fi backend used for the device. Currently supported
+              are <literal>wpa_supplicant</literal> and <literal>iwd</literal> (experimental).
+            </para>
+          </listitem>
+        </varlistentry>
         <varlistentry>
           <term><varname>wifi.scan-generate-mac-address-mask</varname></term>
           <listitem>

--- a/src/NetworkManagerUtils.c
+++ b/src/NetworkManagerUtils.c
@@ -935,3 +935,37 @@ nm_utils_g_value_set_object_path_array (GValue *value,
 }
 
 /*****************************************************************************/
+
+int
+nm_match_spec_device_by_pllink (const NMPlatformLink *pllink,
+                                const GSList *specs,
+                                int no_match_value)
+{
+	NMMatchSpecMatchType m;
+
+	/* we can only match by certain properties that are available on the
+	 * platform link (and even @pllink might be missing.
+	 *
+	 * It's still useful because of specs like "*" and "except:interface-name:eth0",
+	 * which match even in that case. */
+	m = nm_match_spec_device (specs,
+	                          pllink ? pllink->name : NULL,
+	                          NULL,
+	                          pllink ? pllink->driver : NULL,
+	                          NULL,
+	                          NULL,
+	                          NULL);
+
+	switch (m) {
+	case NM_MATCH_SPEC_MATCH:
+		return TRUE;
+	case NM_MATCH_SPEC_NEG_MATCH:
+		return FALSE;
+	case NM_MATCH_SPEC_NO_MATCH:
+		return no_match_value;
+	}
+	nm_assert_not_reached ();
+	return no_match_value;
+}
+
+

--- a/src/NetworkManagerUtils.h
+++ b/src/NetworkManagerUtils.h
@@ -64,6 +64,10 @@ void nm_utils_g_value_set_object_path_array (GValue *value,
                                              NMUtilsObjectFunc filter_func,
                                              gpointer user_data);
 
+int nm_match_spec_device_by_pllink (const NMPlatformLink *pllink,
+                                    const GSList *specs,
+                                    int no_match_value);
+
 /*****************************************************************************/
 
 #endif /* __NETWORKMANAGER_UTILS_H__ */

--- a/src/devices/wifi/nm-device-iwd.c
+++ b/src/devices/wifi/nm-device-iwd.c
@@ -284,7 +284,7 @@ get_ordered_networks_cb (GObject *source, GAsyncResult *res, gpointer user_data)
 		return;
 	}
 
-	priv->new_aps = g_hash_table_new (g_str_hash, g_str_equal);
+	priv->new_aps = g_hash_table_new (nm_str_hash, g_str_equal);
 
 	g_variant_get (variant, "(a(osns))", &networks);
 
@@ -1791,7 +1791,7 @@ nm_device_iwd_init (NMDeviceIwd *self)
 {
 	NMDeviceIwdPrivate *priv = NM_DEVICE_IWD_GET_PRIVATE (self);
 
-	priv->aps = g_hash_table_new (g_str_hash, g_str_equal);
+	priv->aps = g_hash_table_new (nm_str_hash, g_str_equal);
 
 	/* Make sure the manager is running */
 	(void) nm_iwd_manager_get ();

--- a/src/devices/wifi/nm-device-wifi.c
+++ b/src/devices/wifi/nm-device-wifi.c
@@ -1040,7 +1040,7 @@ _hw_addr_set_scanning (NMDeviceWifi *self, gboolean do_reset)
 	priv = NM_DEVICE_WIFI_GET_PRIVATE (self);
 
 	randomize = nm_config_data_get_device_config_boolean (NM_CONFIG_GET_DATA,
-	                                                      "wifi.scan-rand-mac-address",
+	                                                      NM_CONFIG_KEYFILE_KEY_DEVICE_WIFI_SCAN_RAND_MAC_ADDRESS,
 	                                                      device,
 	                                                      TRUE, TRUE);
 

--- a/src/devices/wifi/nm-wifi-factory.c
+++ b/src/devices/wifi/nm-wifi-factory.c
@@ -110,7 +110,11 @@ create_device (NMDeviceFactory *factory,
 	                                                      NULL);
 	nm_strstrip (backend);
 
-	nm_log_dbg (LOGD_PLATFORM | LOGD_WIFI, "(%s) config: backend is %s, %i", iface, backend, WITH_IWD);
+	nm_log_dbg (LOGD_PLATFORM | LOGD_WIFI,
+	            "(%s) config: backend is %s%s%s%s",
+	            iface,
+	            NM_PRINT_FMT_QUOTE_STRING (backend),
+	            WITH_IWD ? " (iwd support enabled)" : "");
 	if (!backend || !strcasecmp (backend, "wpa_supplicant"))
 		return nm_device_wifi_new (iface, capabilities);
 #if WITH_IWD

--- a/src/devices/wifi/nm-wifi-factory.c
+++ b/src/devices/wifi/nm-wifi-factory.c
@@ -104,10 +104,11 @@ create_device (NMDeviceFactory *factory,
 	if (plink->type != NM_LINK_TYPE_WIFI)
 		return nm_device_olpc_mesh_new (iface);
 
-	backend = nm_config_data_get_value (NM_CONFIG_GET_DATA,
-	                                    NM_CONFIG_KEYFILE_GROUP_MAIN,
-	                                    NM_CONFIG_KEYFILE_KEY_MAIN_WIFI_BACKEND,
-	                                    NM_CONFIG_GET_VALUE_STRIP);
+	backend = nm_config_data_get_device_config_by_pllink (NM_CONFIG_GET_DATA,
+	                                                      NM_CONFIG_KEYFILE_KEY_DEVICE_WIFI_BACKEND,
+	                                                      plink,
+	                                                      NULL);
+	nm_strstrip (backend);
 
 	nm_log_dbg (LOGD_PLATFORM | LOGD_WIFI, "(%s) config: backend is %s, %i", iface, backend, WITH_IWD);
 	if (!backend || !strcasecmp (backend, "wpa_supplicant"))

--- a/src/nm-config-data.h
+++ b/src/nm-config-data.h
@@ -188,6 +188,11 @@ char *nm_config_data_get_device_config (const NMConfigData *self,
                                         NMDevice *device,
                                         gboolean *has_match);
 
+char *nm_config_data_get_device_config_by_pllink (const NMConfigData *self,
+                                                  const char *property,
+                                                  const NMPlatformLink *pllink,
+                                                  gboolean *has_match);
+
 gboolean nm_config_data_get_device_config_boolean (const NMConfigData *self,
                                                    const char *property,
                                                    NMDevice *device,

--- a/src/nm-config.h
+++ b/src/nm-config.h
@@ -79,6 +79,7 @@
 #define NM_CONFIG_KEYFILE_KEY_DEVICE_IGNORE_CARRIER         "ignore-carrier"
 #define NM_CONFIG_KEYFILE_KEY_DEVICE_SRIOV_NUM_VFS          "sriov-num-vfs"
 #define NM_CONFIG_KEYFILE_KEY_DEVICE_WIFI_BACKEND           "wifi.backend"
+#define NM_CONFIG_KEYFILE_KEY_DEVICE_WIFI_SCAN_RAND_MAC_ADDRESS "wifi.scan-rand-mac-address"
 #define NM_CONFIG_KEYFILE_KEY_DEVICE_CARRIER_WAIT_TIMEOUT   "carrier-wait-timeout"
 
 #define NM_CONFIG_KEYFILE_KEYPREFIX_WAS                     ".was."

--- a/src/nm-config.h
+++ b/src/nm-config.h
@@ -64,7 +64,6 @@
 #define NM_CONFIG_KEYFILE_KEY_MAIN_DEBUG                    "debug"
 #define NM_CONFIG_KEYFILE_KEY_MAIN_HOSTNAME_MODE            "hostname-mode"
 #define NM_CONFIG_KEYFILE_KEY_MAIN_SLAVES_ORDER             "slaves-order"
-#define NM_CONFIG_KEYFILE_KEY_MAIN_WIFI_BACKEND             "wifi-backend"
 #define NM_CONFIG_KEYFILE_KEY_LOGGING_BACKEND               "backend"
 #define NM_CONFIG_KEYFILE_KEY_CONFIG_ENABLE                 "enable"
 #define NM_CONFIG_KEYFILE_KEY_ATOMIC_SECTION_WAS            ".was"
@@ -79,6 +78,7 @@
 #define NM_CONFIG_KEYFILE_KEY_DEVICE_MANAGED                "managed"
 #define NM_CONFIG_KEYFILE_KEY_DEVICE_IGNORE_CARRIER         "ignore-carrier"
 #define NM_CONFIG_KEYFILE_KEY_DEVICE_SRIOV_NUM_VFS          "sriov-num-vfs"
+#define NM_CONFIG_KEYFILE_KEY_DEVICE_WIFI_BACKEND           "wifi.backend"
 #define NM_CONFIG_KEYFILE_KEY_DEVICE_CARRIER_WAIT_TIMEOUT   "carrier-wait-timeout"
 
 #define NM_CONFIG_KEYFILE_KEYPREFIX_WAS                     ".was."


### PR DESCRIPTION
Make `wifi.backend` configurable per device.

Note https://mail.gnome.org/archives/networkmanager-list/2017-December/msg00027.html , where Andrew said:

> > Would it ever make sense that one device is managed by supplicant and
> > another by iwd? I think it would.
> 
> I'm not sure, multiple real wifi devices in one system is generally a
> rare situation and it's hard to tell what is expected from the
> software.

