### PR TITLE
IWD backend 8021x networks support proposal

### DIFF
--- a/src/devices/wifi/nm-device-iwd.c
+++ b/src/devices/wifi/nm-device-iwd.c
@@ -455,7 +455,6 @@ get_ap_by_path (NMDeviceIwd *self, const char *path)
 {
 	g_return_val_if_fail (path != NULL, NULL);
 	return g_hash_table_lookup (NM_DEVICE_IWD_GET_PRIVATE (self)->aps, path);
-
 }
 
 static gboolean
@@ -1243,8 +1242,6 @@ act_stage2_config (NMDevice *device, NMDeviceStateReason *out_failure_reason)
 	                                               NM_IWD_NETWORK_INTERFACE,
 	                                               NULL, &error);
 	if (!network_proxy) {
-		return FALSE;
-
 		_LOGE (LOGD_DEVICE | LOGD_WIFI,
 		       "Activation: (wifi) could not get Network interface proxy for %s: %s",
 		       nm_wifi_ap_get_supplicant_path (ap),

--- a/src/devices/wifi/nm-iwd-manager.h
+++ b/src/devices/wifi/nm-iwd-manager.h
@@ -36,6 +36,13 @@
 #define NM_IWD_KNOWN_NETWORKS_INTERFACE "net.connman.iwd.KnownNetworks"
 #define NM_IWD_SIGNAL_AGENT_INTERFACE   "net.connman.iwd.SignalLevelAgent"
 
+typedef enum {
+	NM_IWD_NETWORK_SECURITY_NONE,
+	NM_IWD_NETWORK_SECURITY_WEP,
+	NM_IWD_NETWORK_SECURITY_PSK,
+	NM_IWD_NETWORK_SECURITY_8021X,
+} NMIwdNetworkSecurity;
+
 #define NM_TYPE_IWD_MANAGER              (nm_iwd_manager_get_type ())
 #define NM_IWD_MANAGER(obj)              (G_TYPE_CHECK_INSTANCE_CAST ((obj), NM_TYPE_IWD_MANAGER, NMIwdManager))
 #define NM_IWD_MANAGER_CLASS(klass)      (G_TYPE_CHECK_CLASS_CAST ((klass),  NM_TYPE_IWD_MANAGER, NMIwdManagerClass))
@@ -49,5 +56,10 @@ typedef struct _NMIwdManagerClass NMIwdManagerClass;
 GType nm_iwd_manager_get_type (void);
 
 NMIwdManager *nm_iwd_manager_get (void);
+
+gboolean nm_iwd_manager_is_known_network (NMIwdManager *self, const gchar *name,
+                                          NMIwdNetworkSecurity security);
+void nm_iwd_manager_network_connected (NMIwdManager *self, const gchar *name,
+                                       NMIwdNetworkSecurity security);
 
 #endif /* __NETWORKMANAGER_IWD_MANAGER_H__ */


### PR DESCRIPTION
The main idea here is to not require secrets for 8021x networks that we know have been configured with IWD already, and fail early for 8021x networks that have not been configured.

This should not conflict with the Wifi backend config option changes.