### PR TITLE
th/modem_ip_iface

### DIFF
--- a/src/devices/bluetooth/nm-device-bt.c
+++ b/src/devices/bluetooth/nm-device-bt.c
@@ -660,9 +660,7 @@ component_added (NMDevice *device, GObject *component)
 		gs_free char *base = NULL;
 
 		base = g_path_get_basename (priv->rfcomm_iface);
-		if (!NM_IN_STRSET (base,
-		                   nm_modem_get_control_port (modem),
-		                   nm_modem_get_data_port (modem)))
+		if (!nm_streq (base, nm_modem_get_control_port (modem)))
 			return FALSE;
 	}
 

--- a/src/devices/wwan/libnm-wwan.ver
+++ b/src/devices/wwan/libnm-wwan.ver
@@ -11,7 +11,6 @@ global:
 	nm_modem_get_capabilities;
 	nm_modem_get_configured_mtu;
 	nm_modem_get_control_port;
-	nm_modem_get_data_port;
 	nm_modem_get_driver;
 	nm_modem_get_iid;
 	nm_modem_get_path;

--- a/src/devices/wwan/libnm-wwan.ver
+++ b/src/devices/wwan/libnm-wwan.ver
@@ -15,6 +15,7 @@ global:
 	nm_modem_get_driver;
 	nm_modem_get_iid;
 	nm_modem_get_path;
+	nm_modem_get_ip_ifindex;
 	nm_modem_get_secrets;
 	nm_modem_get_state;
 	nm_modem_get_type;

--- a/src/devices/wwan/nm-device-modem.c
+++ b/src/devices/wwan/nm-device-modem.c
@@ -263,17 +263,17 @@ static void
 data_port_changed_cb (NMModem *modem, GParamSpec *pspec, gpointer user_data)
 {
 	NMDevice *self = NM_DEVICE (user_data);
-	gboolean changed;
+	gboolean has_ifindex;
 
 	/* We set the IP iface in the device as soon as we know it, so that we
 	 * properly ifup it if needed */
-	changed = nm_device_set_ip_iface (self, nm_modem_get_data_port (modem));
+	has_ifindex = nm_device_set_ip_iface (self, nm_modem_get_data_port (modem));
 
 	/* Disable IPv6 immediately on the interface since NM handles IPv6
 	 * internally, and leaving it enabled could allow the kernel's IPv6
 	 * RA handling code to run before NM is ready.
 	 */
-	if (changed)
+	if (has_ifindex)
 		nm_device_ipv6_sysctl_set (self, "disable_ipv6", "1");
 }
 

--- a/src/devices/wwan/nm-device-modem.c
+++ b/src/devices/wwan/nm-device-modem.c
@@ -629,11 +629,7 @@ set_modem (NMDeviceModem *self, NMModem *modem)
 	g_signal_connect (modem, NM_MODEM_STATE_CHANGED, G_CALLBACK (modem_state_cb), self);
 	g_signal_connect (modem, NM_MODEM_REMOVED, G_CALLBACK (modem_removed_cb), self);
 
-	/* In the old ModemManager the data port is known from the very beginning;
-	 * while in the new ModemManager the data port is set afterwards when the bearer gets
-	 * created */
 	g_signal_connect (modem, "notify::" NM_MODEM_DATA_PORT, G_CALLBACK (data_port_changed_cb), self);
-
 	g_signal_connect (modem, "notify::" NM_MODEM_DEVICE_ID, G_CALLBACK (ids_changed_cb), self);
 	g_signal_connect (modem, "notify::" NM_MODEM_SIM_ID, G_CALLBACK (ids_changed_cb), self);
 	g_signal_connect (modem, "notify::" NM_MODEM_SIM_OPERATOR_ID, G_CALLBACK (ids_changed_cb), self);
@@ -706,9 +702,9 @@ nm_device_modem_init (NMDeviceModem *self)
 NMDevice *
 nm_device_modem_new (NMModem *modem)
 {
+	NMDevice *self;
 	NMDeviceModemCapabilities caps = NM_DEVICE_MODEM_CAPABILITY_NONE;
 	NMDeviceModemCapabilities current_caps = NM_DEVICE_MODEM_CAPABILITY_NONE;
-	NMDevice *device;
 	const char *data_port;
 
 	g_return_val_if_fail (NM_IS_MODEM (modem), NULL);
@@ -716,26 +712,26 @@ nm_device_modem_new (NMModem *modem)
 	/* Load capabilities */
 	nm_modem_get_capabilities (modem, &caps, &current_caps);
 
-	device = (NMDevice *) g_object_new (NM_TYPE_DEVICE_MODEM,
-	                                    NM_DEVICE_UDI, nm_modem_get_path (modem),
-	                                    NM_DEVICE_IFACE, nm_modem_get_uid (modem),
-	                                    NM_DEVICE_DRIVER, nm_modem_get_driver (modem),
-	                                    NM_DEVICE_TYPE_DESC, "Broadband",
-	                                    NM_DEVICE_DEVICE_TYPE, NM_DEVICE_TYPE_MODEM,
-	                                    NM_DEVICE_RFKILL_TYPE, RFKILL_TYPE_WWAN,
-	                                    NM_DEVICE_MODEM_MODEM, modem,
-	                                    NM_DEVICE_MODEM_CAPABILITIES, caps,
-	                                    NM_DEVICE_MODEM_CURRENT_CAPABILITIES, current_caps,
-	                                    NULL);
+	self = g_object_new (NM_TYPE_DEVICE_MODEM,
+	                     NM_DEVICE_UDI, nm_modem_get_path (modem),
+	                     NM_DEVICE_IFACE, nm_modem_get_uid (modem),
+	                     NM_DEVICE_DRIVER, nm_modem_get_driver (modem),
+	                     NM_DEVICE_TYPE_DESC, "Broadband",
+	                     NM_DEVICE_DEVICE_TYPE, NM_DEVICE_TYPE_MODEM,
+	                     NM_DEVICE_RFKILL_TYPE, RFKILL_TYPE_WWAN,
+	                     NM_DEVICE_MODEM_MODEM, modem,
+	                     NM_DEVICE_MODEM_CAPABILITIES, caps,
+	                     NM_DEVICE_MODEM_CURRENT_CAPABILITIES, current_caps,
+	                     NULL);
 
 	/* If the data port is known, set it as the IP interface immediately */
 	data_port = nm_modem_get_data_port (modem);
 	if (data_port) {
-		nm_device_set_ip_iface (device, data_port);
-		nm_device_ipv6_sysctl_set (device, "disable_ipv6", "1");
+		nm_device_set_ip_iface (self, data_port);
+		nm_device_ipv6_sysctl_set (self, "disable_ipv6", "1");
 	}
 
-	return device;
+	return self;
 }
 
 static void

--- a/src/devices/wwan/nm-device-modem.c
+++ b/src/devices/wwan/nm-device-modem.c
@@ -702,17 +702,15 @@ nm_device_modem_init (NMDeviceModem *self)
 NMDevice *
 nm_device_modem_new (NMModem *modem)
 {
-	NMDevice *self;
 	NMDeviceModemCapabilities caps = NM_DEVICE_MODEM_CAPABILITY_NONE;
 	NMDeviceModemCapabilities current_caps = NM_DEVICE_MODEM_CAPABILITY_NONE;
-	const char *data_port;
 
 	g_return_val_if_fail (NM_IS_MODEM (modem), NULL);
 
 	/* Load capabilities */
 	nm_modem_get_capabilities (modem, &caps, &current_caps);
 
-	self = g_object_new (NM_TYPE_DEVICE_MODEM,
+	return g_object_new (NM_TYPE_DEVICE_MODEM,
 	                     NM_DEVICE_UDI, nm_modem_get_path (modem),
 	                     NM_DEVICE_IFACE, nm_modem_get_uid (modem),
 	                     NM_DEVICE_DRIVER, nm_modem_get_driver (modem),
@@ -723,15 +721,6 @@ nm_device_modem_new (NMModem *modem)
 	                     NM_DEVICE_MODEM_CAPABILITIES, caps,
 	                     NM_DEVICE_MODEM_CURRENT_CAPABILITIES, current_caps,
 	                     NULL);
-
-	/* If the data port is known, set it as the IP interface immediately */
-	data_port = nm_modem_get_data_port (modem);
-	if (data_port) {
-		nm_device_set_ip_iface (self, data_port);
-		nm_device_ipv6_sysctl_set (self, "disable_ipv6", "1");
-	}
-
-	return self;
 }
 
 static void

--- a/src/devices/wwan/nm-device-modem.c
+++ b/src/devices/wwan/nm-device-modem.c
@@ -743,9 +743,10 @@ dispose (GObject *object)
 {
 	NMDeviceModemPrivate *priv = NM_DEVICE_MODEM_GET_PRIVATE ((NMDeviceModem *) object);
 
-	if (priv->modem)
+	if (priv->modem) {
 		g_signal_handlers_disconnect_by_data (priv->modem, NM_DEVICE_MODEM (object));
-	g_clear_object (&priv->modem);
+		g_clear_object (&priv->modem);
+	}
 
 	G_OBJECT_CLASS (nm_device_modem_parent_class)->dispose (object);
 }

--- a/src/devices/wwan/nm-modem-broadband.c
+++ b/src/devices/wwan/nm-modem-broadband.c
@@ -1409,35 +1409,34 @@ nm_modem_broadband_init (NMModemBroadband *self)
 NMModem *
 nm_modem_broadband_new (GObject *object, GError **error)
 {
-	NMModem *modem;
 	MMObject *modem_object;
 	MMModem *modem_iface;
-	gchar *drivers;
+	const char *const*drivers;
+	gs_free char *driver = NULL;
 
 	g_return_val_if_fail (MM_IS_OBJECT (object), NULL);
 	modem_object = MM_OBJECT (object);
 
 	/* Ensure we have the 'Modem' interface and the primary port at least */
 	modem_iface = mm_object_peek_modem (modem_object);
-	g_return_val_if_fail (!!modem_iface, NULL);
-	g_return_val_if_fail (!!mm_modem_get_primary_port (modem_iface), NULL);
+	g_return_val_if_fail (modem_iface, NULL);
+	g_return_val_if_fail (mm_modem_get_primary_port (modem_iface), NULL);
 
 	/* Build a single string with all drivers listed */
-	drivers = g_strjoinv (", ", (gchar **)mm_modem_get_drivers (modem_iface));
+	drivers = mm_modem_get_drivers (modem_iface);
+	if (drivers)
+		driver = g_strjoinv (", ", (char **) drivers);
 
-	modem = g_object_new (NM_TYPE_MODEM_BROADBAND,
-	                      NM_MODEM_PATH, mm_object_get_path (modem_object),
-	                      NM_MODEM_UID, mm_modem_get_primary_port (modem_iface),
-	                      NM_MODEM_CONTROL_PORT, mm_modem_get_primary_port (modem_iface),
-	                      NM_MODEM_DATA_PORT, NULL, /* We don't know it until bearer created */
-	                      NM_MODEM_IP_TYPES, mm_ip_family_to_nm (mm_modem_get_supported_ip_families (modem_iface)),
-	                      NM_MODEM_STATE, (int) mm_state_to_nm (mm_modem_get_state (modem_iface)),
-	                      NM_MODEM_DEVICE_ID, mm_modem_get_device_identifier (modem_iface),
-	                      NM_MODEM_BROADBAND_MODEM, modem_object,
-	                      NM_MODEM_DRIVER, drivers,
-	                      NULL);
-	g_free (drivers);
-	return modem;
+	return g_object_new (NM_TYPE_MODEM_BROADBAND,
+	                     NM_MODEM_PATH, mm_object_get_path (modem_object),
+	                     NM_MODEM_UID, mm_modem_get_primary_port (modem_iface),
+	                     NM_MODEM_CONTROL_PORT, mm_modem_get_primary_port (modem_iface),
+	                     NM_MODEM_IP_TYPES, mm_ip_family_to_nm (mm_modem_get_supported_ip_families (modem_iface)),
+	                     NM_MODEM_STATE, (int) mm_state_to_nm (mm_modem_get_state (modem_iface)),
+	                     NM_MODEM_DEVICE_ID, mm_modem_get_device_identifier (modem_iface),
+	                     NM_MODEM_BROADBAND_MODEM, modem_object,
+	                     NM_MODEM_DRIVER, driver,
+	                     NULL);
 }
 
 static void

--- a/src/devices/wwan/nm-modem-broadband.c
+++ b/src/devices/wwan/nm-modem-broadband.c
@@ -385,9 +385,10 @@ connect_ready (MMModemSimple *simple_iface,
 				g_dbus_error_strip_remote_error (error);
 			ctx->first_error = error;
 		} else
-			g_error_free (error);
+			g_clear_error (&error);
 
-		if (ctx->ip_type_tries == 0 && g_error_matches (error, MM_CORE_ERROR, MM_CORE_ERROR_RETRY)) {
+		if (   ctx->ip_type_tries == 0
+		    && g_error_matches (error, MM_CORE_ERROR, MM_CORE_ERROR_RETRY)) {
 			/* Try one more time */
 			ctx->ip_type_tries++;
 		} else {

--- a/src/devices/wwan/nm-modem.c
+++ b/src/devices/wwan/nm-modem.c
@@ -1690,7 +1690,7 @@ constructed (GObject *object)
 
 	priv = NM_MODEM_GET_PRIVATE (NM_MODEM (object));
 
-	g_return_if_fail (priv->data_port || priv->control_port);
+	g_return_if_fail (priv->control_port);
 }
 
 /*****************************************************************************/
@@ -1767,7 +1767,7 @@ nm_modem_class_init (NMModemClass *klass)
 	obj_properties[PROP_DATA_PORT] =
 	     g_param_spec_string (NM_MODEM_DATA_PORT, "", "",
 	                          NULL,
-	                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT |
+	                          G_PARAM_READWRITE |
 	                          G_PARAM_STATIC_STRINGS);
 
 	obj_properties[PROP_IP_IFINDEX] =

--- a/src/devices/wwan/nm-modem.c
+++ b/src/devices/wwan/nm-modem.c
@@ -557,6 +557,8 @@ port_speed_is_zero (const char *port)
 	struct termios options;
 	nm_auto_close int fd = -1;
 
+	nm_assert (port);
+
 	fd = open (port, O_RDWR | O_NONBLOCK | O_NOCTTY | O_CLOEXEC);
 	if (fd < 0)
 		return FALSE;
@@ -597,6 +599,12 @@ ppp_stage3_ip_config_start (NMModem *self,
 			return NM_ACT_STAGE_RETURN_FAILURE;
 	}
 
+	if (!priv->data_port) {
+		_LOGE ("error starting PPP (no data port)");
+		NM_SET_OUT (out_failure_reason, NM_DEVICE_STATE_REASON_PPP_START_FAILED);
+		return NM_ACT_STAGE_RETURN_FAILURE;
+	}
+
 	/* Check if ModemManager requested a specific IP timeout to be used. If 0 reported,
 	 * use the default one (30s) */
 	if (priv->mm_ip_timeout > 0) {
@@ -628,9 +636,7 @@ ppp_stage3_ip_config_start (NMModem *self,
 	                              ip_timeout, baud_override, &error)) {
 		_LOGE ("error starting PPP: %s", error->message);
 		g_error_free (error);
-
 		g_clear_object (&priv->ppp_manager);
-
 		NM_SET_OUT (out_failure_reason, NM_DEVICE_STATE_REASON_PPP_START_FAILED);
 		return NM_ACT_STAGE_RETURN_FAILURE;
 	}

--- a/src/devices/wwan/nm-modem.c
+++ b/src/devices/wwan/nm-modem.c
@@ -44,14 +44,10 @@
 
 NM_GOBJECT_PROPERTIES_DEFINE (NMModem,
 	PROP_CONTROL_PORT,
-	PROP_DATA_PORT,
 	PROP_IP_IFINDEX,
 	PROP_PATH,
 	PROP_UID,
 	PROP_DRIVER,
-	PROP_IP4_METHOD,
-	PROP_IP6_METHOD,
-	PROP_IP_TIMEOUT,
 	PROP_STATE,
 	PROP_DEVICE_ID,
 	PROP_SIM_ID,
@@ -80,7 +76,11 @@ typedef struct _NMModemPrivate {
 	char *driver;
 	char *control_port;
 	char *data_port;
+
+	/* TODO: ip_iface is solely used for nm_modem_owns_port().
+	 * We should rework the code that it's not necessary */
 	char *ip_iface;
+
 	int ip_ifindex;
 	NMModemIPMethod ip4_method;
 	NMModemIPMethod ip6_method;
@@ -98,7 +98,7 @@ typedef struct _NMModemPrivate {
 	guint32 secrets_tries;
 	NMActRequestGetSecretsCallId *secrets_id;
 
-	guint32 mm_ip_timeout;
+	guint mm_ip_timeout;
 
 	guint32 ip4_route_table;
 	guint32 ip4_route_metric;
@@ -156,7 +156,7 @@ _nmlog_prefix (char *prefix, NMModem *self)
 
 /*****************************************************************************/
 
-static void _set_ip_ifindex (NMModem *self, int ifindex);
+static void _set_ip_ifindex (NMModem *self, int ifindex, const char *ifname);
 
 /*****************************************************************************/
 /* State/enabled/connected */
@@ -462,19 +462,18 @@ ppp_ifindex_set (NMPPPManager *ppp_manager,
                  gpointer user_data)
 {
 	NMModem *self = NM_MODEM (user_data);
-	NMModemPrivate *priv = NM_MODEM_GET_PRIVATE (self);
 
 	nm_assert (ifindex >= 0);
+	nm_assert (NM_MODEM_GET_PRIVATE (self)->ppp_manager == ppp_manager);
 
-	/* Notify about the new data port to use.
-	 *
-	 * @iface might be %NULL. */
-	if (g_strcmp0 (priv->data_port, iface) != 0) {
-		g_free (priv->data_port);
-		priv->data_port = g_strdup (iface);
-		_notify (self, PROP_DATA_PORT);
+	if (ifindex <= 0 && iface) {
+		/* this might happen, if the ifname was already deleted
+		 * and we failed to resolve ifindex.
+		 *
+		 * Forget about the name. */
+		iface = NULL;
 	}
-	_set_ip_ifindex (self, ifindex);
+	_set_ip_ifindex (self, ifindex, iface);
 }
 
 static void
@@ -565,8 +564,18 @@ port_speed_is_zero (const char *port)
 {
 	struct termios options;
 	nm_auto_close int fd = -1;
+	gs_free char *path = NULL;
 
 	nm_assert (port);
+
+	if (port[0] != '/') {
+		if (   !port[0]
+		    || strchr (port, '/')
+		    || NM_IN_STRSET (port, ".", ".."))
+			return FALSE;
+		path = g_build_path ("/sys/class/tty", port, NULL);
+		port = path;
+	}
 
 	fd = open (port, O_RDWR | O_NONBLOCK | O_NOCTTY | O_CLOEXEC);
 	if (fd < 0)
@@ -1134,12 +1143,12 @@ deactivate_cleanup (NMModem *self, NMDevice *device)
 			}
 		}
 	}
+
+	nm_clear_g_free (&priv->data_port);
+	priv->mm_ip_timeout = 0;
 	priv->ip4_method = NM_MODEM_IP_METHOD_UNKNOWN;
 	priv->ip6_method = NM_MODEM_IP_METHOD_UNKNOWN;
-
-	_set_ip_ifindex (self, -1);
-	if (nm_clear_g_free (&priv->ip_iface))
-		_notify (self, PROP_DATA_PORT);
+	_set_ip_ifindex (self, -1, NULL);
 }
 
 /*****************************************************************************/
@@ -1393,17 +1402,9 @@ nm_modem_get_control_port (NMModem *self)
 const char *
 nm_modem_get_data_port (NMModem *self)
 {
-	NMModemPrivate *priv;
-
 	g_return_val_if_fail (NM_IS_MODEM (self), NULL);
 
-	priv = NM_MODEM_GET_PRIVATE (self);
-
-	/* The ip_iface takes precedence over the data interface when PPP is used,
-	 * since data_iface is the TTY over which PPP is run, and that TTY can't
-	 * do IP.  The caller really wants the thing that's doing IP.
-	 */
-	return priv->ip_iface ?: priv->data_port;
+	return NM_MODEM_GET_PRIVATE (self)->data_port;
 }
 
 int
@@ -1422,16 +1423,101 @@ nm_modem_get_ip_ifindex (NMModem *self)
 }
 
 static void
-_set_ip_ifindex (NMModem *self, int ifindex)
+_set_ip_ifindex (NMModem *self, int ifindex, const char *ifname)
 {
 	NMModemPrivate *priv = NM_MODEM_GET_PRIVATE (self);
 
 	nm_assert (ifindex >= -1);
+	nm_assert ((ifindex > 0) == !!ifname);
+
+	if (!nm_streq0 (priv->ip_iface, ifname)) {
+		g_free (priv->ip_iface);
+		priv->ip_iface = g_strdup (ifname);
+	}
 
 	if (priv->ip_ifindex != ifindex) {
 		priv->ip_ifindex = ifindex;
 		_notify (self, PROP_IP_IFINDEX);
 	}
+}
+
+gboolean
+nm_modem_set_data_port (NMModem *self,
+                        NMPlatform *platform,
+                        const char *data_port,
+                        NMModemIPMethod ip4_method,
+                        NMModemIPMethod ip6_method,
+                        guint timeout,
+                        GError **error)
+{
+	NMModemPrivate *priv;
+	gboolean is_ppp;
+	int ifindex = -1;
+
+	g_return_val_if_fail (NM_IS_MODEM (self), FALSE);
+	g_return_val_if_fail (NM_IS_PLATFORM (platform), FALSE);
+	g_return_val_if_fail (!error || !*error, FALSE);
+
+	priv = NM_MODEM_GET_PRIVATE (self);
+
+	if (   priv->ppp_manager
+	    || priv->data_port
+	    || priv->ip_ifindex != -1) {
+		g_set_error_literal (error, NM_UTILS_ERROR, NM_UTILS_ERROR_UNKNOWN,
+		                     "cannot set data port in activated state");
+		/* this really shouldn't happen. Assert. */
+		g_return_val_if_reached (FALSE);
+	}
+
+	if (!data_port) {
+		g_set_error_literal (error, NM_UTILS_ERROR, NM_UTILS_ERROR_UNKNOWN,
+		                     "missing data port");
+		return FALSE;
+	}
+
+	is_ppp =    (ip4_method == NM_MODEM_IP_METHOD_PPP)
+	         || (ip6_method == NM_MODEM_IP_METHOD_PPP);
+	if (is_ppp) {
+		if (   !NM_IN_SET (ip4_method, NM_MODEM_IP_METHOD_UNKNOWN, NM_MODEM_IP_METHOD_PPP)
+		    || !NM_IN_SET (ip6_method, NM_MODEM_IP_METHOD_UNKNOWN, NM_MODEM_IP_METHOD_PPP)) {
+			g_set_error_literal (error, NM_UTILS_ERROR, NM_UTILS_ERROR_UNKNOWN,
+			                     "conflicting ip methods");
+			return FALSE;
+		}
+	} else if (   !NM_IN_SET (ip4_method, NM_MODEM_IP_METHOD_UNKNOWN, NM_MODEM_IP_METHOD_STATIC, NM_MODEM_IP_METHOD_AUTO)
+	           || !NM_IN_SET (ip6_method, NM_MODEM_IP_METHOD_UNKNOWN, NM_MODEM_IP_METHOD_STATIC, NM_MODEM_IP_METHOD_AUTO)
+	           || (   ip4_method == NM_MODEM_IP_METHOD_UNKNOWN
+	               && ip6_method == NM_MODEM_IP_METHOD_UNKNOWN)) {
+		g_set_error_literal (error, NM_UTILS_ERROR, NM_UTILS_ERROR_UNKNOWN,
+		                     "invalid ip methods");
+		return FALSE;
+	}
+
+	if (!is_ppp) {
+		ifindex = nm_platform_if_nametoindex (platform, data_port);
+		if (ifindex <= 0) {
+			g_set_error (error, NM_UTILS_ERROR, NM_UTILS_ERROR_UNKNOWN,
+			             "cannot find network interface %s", data_port);
+			return FALSE;
+		}
+		if (!nm_platform_process_events_ensure_link (platform, ifindex, data_port)) {
+			g_set_error (error, NM_UTILS_ERROR, NM_UTILS_ERROR_UNKNOWN,
+			             "cannot find network interface %s in platform cache", data_port);
+			return FALSE;
+		}
+	}
+
+	priv->mm_ip_timeout = timeout;
+	priv->ip4_method = ip4_method;
+	priv->ip6_method = ip6_method;
+	if (is_ppp) {
+		priv->data_port = g_strdup (data_port);
+		_set_ip_ifindex (self, -1, NULL);
+	} else {
+		priv->data_port = NULL;
+		_set_ip_ifindex (self, ifindex, data_port);
+	}
+	return TRUE;
 }
 
 gboolean
@@ -1560,23 +1646,11 @@ get_property (GObject *object, guint prop_id,
 	case PROP_CONTROL_PORT:
 		g_value_set_string (value, priv->control_port);
 		break;
-	case PROP_DATA_PORT:
-		g_value_set_string (value, nm_modem_get_data_port (self));
-		break;
 	case PROP_IP_IFINDEX:
 		g_value_set_int (value, nm_modem_get_ip_ifindex (self));
 		break;
 	case PROP_UID:
 		g_value_set_string (value, priv->uid);
-		break;
-	case PROP_IP4_METHOD:
-		g_value_set_uint (value, priv->ip4_method);
-		break;
-	case PROP_IP6_METHOD:
-		g_value_set_uint (value, priv->ip6_method);
-		break;
-	case PROP_IP_TIMEOUT:
-		g_value_set_uint (value, priv->mm_ip_timeout);
 		break;
 	case PROP_STATE:
 		g_value_set_int (value, priv->state);
@@ -1620,22 +1694,9 @@ set_property (GObject *object, guint prop_id,
 		/* construct-only */
 		priv->control_port = g_value_dup_string (value);
 		break;
-	case PROP_DATA_PORT:
-		g_free (priv->data_port);
-		priv->data_port = g_value_dup_string (value);
-		break;
 	case PROP_UID:
 		/* construct-only */
 		priv->uid = g_value_dup_string (value);
-		break;
-	case PROP_IP4_METHOD:
-		priv->ip4_method = g_value_get_uint (value);
-		break;
-	case PROP_IP6_METHOD:
-		priv->ip6_method = g_value_get_uint (value);
-		break;
-	case PROP_IP_TIMEOUT:
-		priv->mm_ip_timeout = g_value_get_uint (value);
 		break;
 	case PROP_STATE:
 		/* construct-only */
@@ -1764,39 +1825,11 @@ nm_modem_class_init (NMModemClass *klass)
 	                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY |
 	                          G_PARAM_STATIC_STRINGS);
 
-	obj_properties[PROP_DATA_PORT] =
-	     g_param_spec_string (NM_MODEM_DATA_PORT, "", "",
-	                          NULL,
-	                          G_PARAM_READWRITE |
-	                          G_PARAM_STATIC_STRINGS);
-
 	obj_properties[PROP_IP_IFINDEX] =
 	     g_param_spec_int (NM_MODEM_IP_IFINDEX, "", "",
 	                       0, G_MAXINT, 0,
 	                       G_PARAM_READABLE |
 	                       G_PARAM_STATIC_STRINGS);
-
-	obj_properties[PROP_IP4_METHOD] =
-	     g_param_spec_uint (NM_MODEM_IP4_METHOD, "", "",
-	                        NM_MODEM_IP_METHOD_UNKNOWN,
-	                        NM_MODEM_IP_METHOD_AUTO,
-	                        NM_MODEM_IP_METHOD_UNKNOWN,
-	                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT |
-	                        G_PARAM_STATIC_STRINGS);
-
-	obj_properties[PROP_IP6_METHOD] =
-	     g_param_spec_uint (NM_MODEM_IP6_METHOD, "", "",
-	                        NM_MODEM_IP_METHOD_UNKNOWN,
-	                        NM_MODEM_IP_METHOD_AUTO,
-	                        NM_MODEM_IP_METHOD_UNKNOWN,
-	                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT |
-	                        G_PARAM_STATIC_STRINGS);
-
-	obj_properties[PROP_IP_TIMEOUT] =
-	     g_param_spec_uint (NM_MODEM_IP_TIMEOUT, "", "",
-	                        0, 360, 20,
-	                        G_PARAM_READWRITE |
-	                        G_PARAM_STATIC_STRINGS);
 
 	obj_properties[PROP_STATE] =
 	     g_param_spec_int (NM_MODEM_STATE, "", "",

--- a/src/devices/wwan/nm-modem.c
+++ b/src/devices/wwan/nm-modem.c
@@ -1665,6 +1665,7 @@ finalize (GObject *object)
 	g_free (priv->driver);
 	g_free (priv->control_port);
 	g_free (priv->data_port);
+	g_free (priv->ppp_iface);
 	g_free (priv->device_id);
 	g_free (priv->sim_id);
 	g_free (priv->sim_operator_id);

--- a/src/devices/wwan/nm-modem.c
+++ b/src/devices/wwan/nm-modem.c
@@ -1138,7 +1138,8 @@ deactivate_cleanup (NMModem *self, NMDevice *device)
 	priv->ip6_method = NM_MODEM_IP_METHOD_UNKNOWN;
 
 	_set_ip_ifindex (self, -1);
-	nm_clear_g_free (&priv->ip_iface);
+	if (nm_clear_g_free (&priv->ip_iface))
+		_notify (self, PROP_DATA_PORT);
 }
 
 /*****************************************************************************/

--- a/src/devices/wwan/nm-modem.c
+++ b/src/devices/wwan/nm-modem.c
@@ -1399,14 +1399,6 @@ nm_modem_get_control_port (NMModem *self)
 	return NM_MODEM_GET_PRIVATE (self)->control_port;
 }
 
-const char *
-nm_modem_get_data_port (NMModem *self)
-{
-	g_return_val_if_fail (NM_IS_MODEM (self), NULL);
-
-	return NM_MODEM_GET_PRIVATE (self)->data_port;
-}
-
 int
 nm_modem_get_ip_ifindex (NMModem *self)
 {

--- a/src/devices/wwan/nm-modem.c
+++ b/src/devices/wwan/nm-modem.c
@@ -1097,7 +1097,10 @@ deactivate_cleanup (NMModem *self, NMDevice *device)
 
 	priv->in_bytes = priv->out_bytes = 0;
 
-	g_clear_object (&priv->ppp_manager);
+	if (priv->ppp_manager) {
+		g_signal_handlers_disconnect_by_data (priv->ppp_manager, self);
+		g_clear_object (&priv->ppp_manager);
+	}
 
 	if (device) {
 		g_return_if_fail (NM_IS_DEVICE (device));

--- a/src/devices/wwan/nm-modem.c
+++ b/src/devices/wwan/nm-modem.c
@@ -79,7 +79,7 @@ typedef struct _NMModemPrivate {
 	char *driver;
 	char *control_port;
 	char *data_port;
-	char *ppp_iface;
+	char *ip_iface;
 	NMModemIPMethod ip4_method;
 	NMModemIPMethod ip6_method;
 	NMUtilsIPv6IfaceId iid;
@@ -1128,7 +1128,7 @@ deactivate_cleanup (NMModem *self, NMDevice *device)
 	priv->ip4_method = NM_MODEM_IP_METHOD_UNKNOWN;
 	priv->ip6_method = NM_MODEM_IP_METHOD_UNKNOWN;
 
-	nm_clear_g_free (&priv->ppp_iface);
+	nm_clear_g_free (&priv->ip_iface);
 }
 
 /*****************************************************************************/
@@ -1388,11 +1388,11 @@ nm_modem_get_data_port (NMModem *self)
 
 	priv = NM_MODEM_GET_PRIVATE (self);
 
-	/* The ppp_iface takes precedence over the data interface when PPP is used,
+	/* The ip_iface takes precedence over the data interface when PPP is used,
 	 * since data_iface is the TTY over which PPP is run, and that TTY can't
 	 * do IP.  The caller really wants the thing that's doing IP.
 	 */
-	return priv->ppp_iface ?: priv->data_port;
+	return priv->ip_iface ?: priv->data_port;
 }
 
 gboolean
@@ -1406,7 +1406,7 @@ nm_modem_owns_port (NMModem *self, const char *iface)
 		return NM_MODEM_GET_CLASS (self)->owns_port (self, iface);
 
 	return NM_IN_STRSET (iface,
-	                     priv->ppp_iface,
+	                     priv->ip_iface,
 	                     priv->data_port,
 	                     priv->control_port);
 }
@@ -1671,7 +1671,7 @@ finalize (GObject *object)
 	g_free (priv->driver);
 	g_free (priv->control_port);
 	g_free (priv->data_port);
-	g_free (priv->ppp_iface);
+	g_free (priv->ip_iface);
 	g_free (priv->device_id);
 	g_free (priv->sim_id);
 	g_free (priv->sim_operator_id);

--- a/src/devices/wwan/nm-modem.h
+++ b/src/devices/wwan/nm-modem.h
@@ -38,6 +38,7 @@
 #define NM_MODEM_DRIVER          "driver"
 #define NM_MODEM_CONTROL_PORT    "control-port"
 #define NM_MODEM_DATA_PORT       "data-port"
+#define NM_MODEM_IP_IFINDEX      "ip-ifindex"
 #define NM_MODEM_IP4_METHOD      "ip4-method"
 #define NM_MODEM_IP6_METHOD      "ip6-method"
 #define NM_MODEM_IP_TIMEOUT      "ip-timeout"
@@ -168,6 +169,7 @@ const char *nm_modem_get_path            (NMModem *modem);
 const char *nm_modem_get_uid             (NMModem *modem);
 const char *nm_modem_get_control_port    (NMModem *modem);
 const char *nm_modem_get_data_port       (NMModem *modem);
+int         nm_modem_get_ip_ifindex      (NMModem *modem);
 const char *nm_modem_get_driver          (NMModem *modem);
 const char *nm_modem_get_device_id       (NMModem *modem);
 const char *nm_modem_get_sim_id          (NMModem *modem);

--- a/src/devices/wwan/nm-modem.h
+++ b/src/devices/wwan/nm-modem.h
@@ -164,7 +164,6 @@ GType nm_modem_get_type (void);
 const char *nm_modem_get_path            (NMModem *modem);
 const char *nm_modem_get_uid             (NMModem *modem);
 const char *nm_modem_get_control_port    (NMModem *modem);
-const char *nm_modem_get_data_port       (NMModem *modem);
 int         nm_modem_get_ip_ifindex      (NMModem *modem);
 const char *nm_modem_get_driver          (NMModem *modem);
 const char *nm_modem_get_device_id       (NMModem *modem);

--- a/src/devices/wwan/nm-modem.h
+++ b/src/devices/wwan/nm-modem.h
@@ -37,11 +37,7 @@
 #define NM_MODEM_PATH            "path"
 #define NM_MODEM_DRIVER          "driver"
 #define NM_MODEM_CONTROL_PORT    "control-port"
-#define NM_MODEM_DATA_PORT       "data-port"
 #define NM_MODEM_IP_IFINDEX      "ip-ifindex"
-#define NM_MODEM_IP4_METHOD      "ip4-method"
-#define NM_MODEM_IP6_METHOD      "ip6-method"
-#define NM_MODEM_IP_TIMEOUT      "ip-timeout"
 #define NM_MODEM_STATE           "state"
 #define NM_MODEM_DEVICE_ID       "device-id"
 #define NM_MODEM_SIM_ID          "sim-id"
@@ -175,6 +171,14 @@ const char *nm_modem_get_device_id       (NMModem *modem);
 const char *nm_modem_get_sim_id          (NMModem *modem);
 const char *nm_modem_get_sim_operator_id (NMModem *modem);
 gboolean    nm_modem_get_iid             (NMModem *modem, NMUtilsIPv6IfaceId *out_iid);
+
+gboolean    nm_modem_set_data_port (NMModem *self,
+                                    NMPlatform *platform,
+                                    const char *data_port,
+                                    NMModemIPMethod ip4_method,
+                                    NMModemIPMethod ip6_method,
+                                    guint timeout,
+                                    GError **error);
 
 gboolean    nm_modem_owns_port        (NMModem *modem, const char *iface);
 

--- a/src/devices/wwan/nm-wwan-factory.c
+++ b/src/devices/wwan/nm-wwan-factory.c
@@ -80,7 +80,7 @@ modem_added_cb (NMModemManager *manager,
 {
 	NMWwanFactory *self = NM_WWAN_FACTORY (user_data);
 	NMDevice *device;
-	const char *driver, *port;
+	const char *driver;
 
 	/* Do nothing if the modem was consumed by some other plugin */
 	if (nm_device_factory_emit_component_added (NM_DEVICE_FACTORY (self), G_OBJECT (modem)))
@@ -93,10 +93,9 @@ modem_added_cb (NMModemManager *manager,
 	 * by the Bluetooth code during the connection process.
 	 */
 	if (driver && strstr (driver, "bluetooth")) {
-		port = nm_modem_get_data_port (modem);
-		if (!port)
-			port = nm_modem_get_control_port (modem);
-		nm_log_info (LOGD_MB, "ignoring modem '%s' (no associated Bluetooth device)", port);
+		nm_log_info (LOGD_MB, "ignoring modem '%s' (no associated Bluetooth device)",
+		             nm_modem_get_data_port (modem)
+		               ?: nm_modem_get_control_port (modem));
 		return;
 	}
 

--- a/src/devices/wwan/nm-wwan-factory.c
+++ b/src/devices/wwan/nm-wwan-factory.c
@@ -94,8 +94,7 @@ modem_added_cb (NMModemManager *manager,
 	 */
 	if (driver && strstr (driver, "bluetooth")) {
 		nm_log_info (LOGD_MB, "ignoring modem '%s' (no associated Bluetooth device)",
-		             nm_modem_get_data_port (modem)
-		               ?: nm_modem_get_control_port (modem));
+		             nm_modem_get_control_port (modem));
 		return;
 	}
 

--- a/src/platform/nm-platform.h
+++ b/src/platform/nm-platform.h
@@ -1106,6 +1106,10 @@ const char *nm_platform_link_get_type_name (NMPlatform *self, int ifindex);
 gboolean nm_platform_link_refresh (NMPlatform *self, int ifindex);
 void nm_platform_process_events (NMPlatform *self);
 
+const NMPlatformLink *nm_platform_process_events_ensure_link (NMPlatform *self,
+                                                              int ifindex,
+                                                              const char *ifname);
+
 gboolean nm_platform_link_set_up (NMPlatform *self, int ifindex, gboolean *out_no_firmware);
 gboolean nm_platform_link_set_down (NMPlatform *self, int ifindex);
 gboolean nm_platform_link_set_arp (NMPlatform *self, int ifindex);


### PR DESCRIPTION
Rework handling of ip-iface vs. data-port in NMModem and related.

The path tries to do two things (for NMModem):

- there should always be a clear distinction between an networking interface (ip-iface) and other identifiers, like the data port for ppp.

- rely less on interface names, but try to resolve the ifindex as early as possible. The ifindex can be used as an ID for a network link, the ifname cannot, because interfaces can be renamed. Sometimes, we get only the name from external API (like ModemManager or PPP). In this case, we should resolve the ifindex as early as possible, to minimize the time for renaming-race, and then proceed with the ifindex.

NMDevice currently has `nm_device_get_ifindex()` and `nm_device_get_ip_ifindex()`. Eventually, this should be separated, so that we don't track a control-device and a data-device in one. This branch is a small step in that direction.

Please review.