### PR TITLE
th/libnm_jansson

### DIFF
--- a/libnm-core/nm-json.c
+++ b/libnm-core/nm-json.c
@@ -18,99 +18,134 @@
 
 #include "nm-default.h"
 
-#define NM_JANSSON_C
 #include "nm-json.h"
 
 #include <dlfcn.h>
 
-void *_nm_jansson_json_object_iter_value;
-void *_nm_jansson_json_object_key_to_iter;
-void *_nm_jansson_json_integer;
-void *_nm_jansson_json_object_del;
-void *_nm_jansson_json_array_get;
-void *_nm_jansson_json_array_size;
-void *_nm_jansson_json_array_append_new;
-void *_nm_jansson_json_string;
-void *_nm_jansson_json_object_iter_next;
-void *_nm_jansson_json_loads;
-void *_nm_jansson_json_dumps;
-void *_nm_jansson_json_object_iter_key;
-void *_nm_jansson_json_object;
-void *_nm_jansson_json_object_get;
-void *_nm_jansson_json_array;
-void *_nm_jansson_json_false;
-void *_nm_jansson_json_delete;
-void *_nm_jansson_json_true;
-void *_nm_jansson_json_object_size;
-void *_nm_jansson_json_object_set_new;
-void *_nm_jansson_json_object_iter;
-void *_nm_jansson_json_integer_value;
-void *_nm_jansson_json_string_value;
+typedef struct {
+	NMJsonVt vt;
+	void *dl_handle;
+} JsonVt;
 
-#define TRY_BIND_SYMBOL(symbol) \
-	G_STMT_START { \
-		void *sym = dlsym (handle, #symbol); \
-		if (_nm_jansson_ ## symbol && sym != _nm_jansson_ ## symbol) \
-			return FALSE; \
-		_nm_jansson_ ## symbol = sym; \
-	} G_STMT_END
-
-static gboolean
-bind_symbols (void *handle)
+static JsonVt *
+json_vt (void)
 {
-	TRY_BIND_SYMBOL (json_object_iter_value);
-	TRY_BIND_SYMBOL (json_object_key_to_iter);
-	TRY_BIND_SYMBOL (json_integer);
-	TRY_BIND_SYMBOL (json_object_del);
-	TRY_BIND_SYMBOL (json_array_get);
-	TRY_BIND_SYMBOL (json_array_size);
-	TRY_BIND_SYMBOL (json_array_append_new);
-	TRY_BIND_SYMBOL (json_string);
-	TRY_BIND_SYMBOL (json_object_iter_next);
-	TRY_BIND_SYMBOL (json_loads);
-	TRY_BIND_SYMBOL (json_dumps);
-	TRY_BIND_SYMBOL (json_object_iter_key);
-	TRY_BIND_SYMBOL (json_object);
-	TRY_BIND_SYMBOL (json_object_get);
-	TRY_BIND_SYMBOL (json_array);
-	TRY_BIND_SYMBOL (json_false);
-	TRY_BIND_SYMBOL (json_delete);
-	TRY_BIND_SYMBOL (json_true);
-	TRY_BIND_SYMBOL (json_object_size);
-	TRY_BIND_SYMBOL (json_object_set_new);
-	TRY_BIND_SYMBOL (json_object_iter);
-	TRY_BIND_SYMBOL (json_integer_value);
-	TRY_BIND_SYMBOL (json_string_value);
-
-	return TRUE;
-}
-
-gboolean
-nm_jansson_load (void)
-{
-	static enum {
-		UNKNOWN,
-		AVAILABLE,
-		MISSING,
-	} state = UNKNOWN;
+	JsonVt *vt = NULL;
 	void *handle;
 
-	if (G_LIKELY (state != UNKNOWN))
-		goto out;
-
-	/* First just resolve the symbols to see if there's a conflict already. */
-	if (!bind_symbols (RTLD_DEFAULT))
-		goto out;
+	vt = g_new0 (JsonVt, 1);
 
 	handle = dlopen (JANSSON_SONAME, RTLD_LAZY | RTLD_LOCAL | RTLD_NODELETE | RTLD_DEEPBIND);
 	if (!handle)
-		goto out;
+		return vt;
 
-	/* Now do the actual binding. */
-	if (!bind_symbols (handle))
-		goto out;
+#define TRY_BIND_SYMBOL(symbol) \
+	G_STMT_START { \
+		void *_sym = dlsym (handle, "json" #symbol); \
+		\
+		if (!_sym) \
+			goto fail_symbol; \
+		vt->vt.nm_json ## symbol = _sym; \
+	} G_STMT_END
 
-	state = AVAILABLE;
-out:
-	return state == AVAILABLE;
+	TRY_BIND_SYMBOL (_array);
+	TRY_BIND_SYMBOL (_array_append_new);
+	TRY_BIND_SYMBOL (_array_get);
+	TRY_BIND_SYMBOL (_array_size);
+	TRY_BIND_SYMBOL (_delete);
+	TRY_BIND_SYMBOL (_dumps);
+	TRY_BIND_SYMBOL (_false);
+	TRY_BIND_SYMBOL (_integer);
+	TRY_BIND_SYMBOL (_integer_value);
+	TRY_BIND_SYMBOL (_loads);
+	TRY_BIND_SYMBOL (_object);
+	TRY_BIND_SYMBOL (_object_del);
+	TRY_BIND_SYMBOL (_object_get);
+	TRY_BIND_SYMBOL (_object_iter);
+	TRY_BIND_SYMBOL (_object_iter_key);
+	TRY_BIND_SYMBOL (_object_iter_next);
+	TRY_BIND_SYMBOL (_object_iter_value);
+	TRY_BIND_SYMBOL (_object_key_to_iter);
+	TRY_BIND_SYMBOL (_object_set_new);
+	TRY_BIND_SYMBOL (_object_size);
+	TRY_BIND_SYMBOL (_string);
+	TRY_BIND_SYMBOL (_string_value);
+	TRY_BIND_SYMBOL (_true);
+
+	vt->vt.loaded = TRUE;
+	vt->dl_handle = handle;
+	return vt;
+
+fail_symbol:
+	dlclose (&handle);
+	memset (vt, 0, sizeof (*vt));
+	return vt;
 }
+
+const NMJsonVt *
+nm_json_vt (void)
+{
+	static JsonVt *vt_ptr = NULL;
+	JsonVt *vt;
+
+	vt = g_atomic_pointer_get (&vt_ptr);
+	if (G_LIKELY (vt))
+		goto out;
+
+	vt = json_vt ();
+	if (!g_atomic_pointer_compare_and_exchange (&vt_ptr, NULL, vt)) {
+		if (vt->dl_handle)
+			dlclose (vt->dl_handle);
+		g_free (vt);
+		vt = g_atomic_pointer_get (&vt_ptr);
+		goto out;
+	}
+
+out:
+	nm_assert (vt && vt == g_atomic_pointer_get (&vt_ptr));
+	return &vt->vt;
+}
+
+#define DEF_FCN(name, rval, args_t, args_v) \
+rval name args_t \
+{ \
+	const NMJsonVt *vt = nm_json_vt (); \
+	\
+	nm_assert (vt && vt->loaded && vt->name); \
+	nm_assert (vt->name != name); \
+	return (vt->name) args_v; \
+}
+
+#define DEF_VOI(name, args_t, args_v) \
+void name args_t \
+{ \
+	const NMJsonVt *vt = nm_json_vt (); \
+	\
+	nm_assert (vt && vt->loaded && vt->name); \
+	nm_assert (vt->name != name); \
+	(vt->name) args_v; \
+}
+
+DEF_FCN (nm_json_array,              json_t *,     (void), ());
+DEF_FCN (nm_json_array_append_new,   int,          (json_t *json, json_t *value), (json, value));
+DEF_FCN (nm_json_array_get,          json_t *,     (const json_t *json, size_t index), (json, index));
+DEF_FCN (nm_json_array_size,         size_t,       (const json_t *json), (json));
+DEF_VOI (nm_json_delete,                           (json_t *json), (json));
+DEF_FCN (nm_json_dumps,              char *,       (const json_t *json, size_t flags), (json, flags));
+DEF_FCN (nm_json_false,              json_t *,     (void), ());
+DEF_FCN (nm_json_integer,            json_t *,     (json_int_t value),              (value));
+DEF_FCN (nm_json_integer_value,      json_int_t,   (const json_t *json), (json));
+DEF_FCN (nm_json_loads,              json_t *,     (const char *string, size_t flags, json_error_t *error), (string, flags, error));
+DEF_FCN (nm_json_object,             json_t *,     (void), ());
+DEF_FCN (nm_json_object_del,         int,          (json_t *json, const char *key), (json, key));
+DEF_FCN (nm_json_object_get,         json_t *,     (const json_t *json, const char *key), (json, key));
+DEF_FCN (nm_json_object_iter,        void *,       (json_t *json), (json));
+DEF_FCN (nm_json_object_iter_key,    const char *, (void *iter), (iter));
+DEF_FCN (nm_json_object_iter_next,   void *,       (json_t *json, void *iter), (json, iter));
+DEF_FCN (nm_json_object_iter_value,  json_t *,     (void *iter),                    (iter));
+DEF_FCN (nm_json_object_key_to_iter, void *,       (const char *key),               (key));
+DEF_FCN (nm_json_object_set_new,     int,          (json_t *json, const char *key, json_t *value), (json, key, value));
+DEF_FCN (nm_json_object_size,        size_t,       (const json_t *json), (json));
+DEF_FCN (nm_json_string,             json_t *,     (const char *value), (value));
+DEF_FCN (nm_json_string_value,       const char *, (const json_t *json), (json));
+DEF_FCN (nm_json_true,               json_t *,     (void), ());

--- a/libnm-core/nm-json.c
+++ b/libnm-core/nm-json.c
@@ -41,36 +41,36 @@ json_vt (void)
 
 #define TRY_BIND_SYMBOL(symbol) \
 	G_STMT_START { \
-		void *_sym = dlsym (handle, "json" #symbol); \
+		typeof (symbol) (*_sym) = dlsym (handle, #symbol); \
 		\
 		if (!_sym) \
 			goto fail_symbol; \
-		vt->vt.nm_json ## symbol = _sym; \
+		vt->vt.nm_##symbol = _sym; \
 	} G_STMT_END
 
-	TRY_BIND_SYMBOL (_array);
-	TRY_BIND_SYMBOL (_array_append_new);
-	TRY_BIND_SYMBOL (_array_get);
-	TRY_BIND_SYMBOL (_array_size);
-	TRY_BIND_SYMBOL (_delete);
-	TRY_BIND_SYMBOL (_dumps);
-	TRY_BIND_SYMBOL (_false);
-	TRY_BIND_SYMBOL (_integer);
-	TRY_BIND_SYMBOL (_integer_value);
-	TRY_BIND_SYMBOL (_loads);
-	TRY_BIND_SYMBOL (_object);
-	TRY_BIND_SYMBOL (_object_del);
-	TRY_BIND_SYMBOL (_object_get);
-	TRY_BIND_SYMBOL (_object_iter);
-	TRY_BIND_SYMBOL (_object_iter_key);
-	TRY_BIND_SYMBOL (_object_iter_next);
-	TRY_BIND_SYMBOL (_object_iter_value);
-	TRY_BIND_SYMBOL (_object_key_to_iter);
-	TRY_BIND_SYMBOL (_object_set_new);
-	TRY_BIND_SYMBOL (_object_size);
-	TRY_BIND_SYMBOL (_string);
-	TRY_BIND_SYMBOL (_string_value);
-	TRY_BIND_SYMBOL (_true);
+	TRY_BIND_SYMBOL (json_array);
+	TRY_BIND_SYMBOL (json_array_append_new);
+	TRY_BIND_SYMBOL (json_array_get);
+	TRY_BIND_SYMBOL (json_array_size);
+	TRY_BIND_SYMBOL (json_delete);
+	TRY_BIND_SYMBOL (json_dumps);
+	TRY_BIND_SYMBOL (json_false);
+	TRY_BIND_SYMBOL (json_integer);
+	TRY_BIND_SYMBOL (json_integer_value);
+	TRY_BIND_SYMBOL (json_loads);
+	TRY_BIND_SYMBOL (json_object);
+	TRY_BIND_SYMBOL (json_object_del);
+	TRY_BIND_SYMBOL (json_object_get);
+	TRY_BIND_SYMBOL (json_object_iter);
+	TRY_BIND_SYMBOL (json_object_iter_key);
+	TRY_BIND_SYMBOL (json_object_iter_next);
+	TRY_BIND_SYMBOL (json_object_iter_value);
+	TRY_BIND_SYMBOL (json_object_key_to_iter);
+	TRY_BIND_SYMBOL (json_object_set_new);
+	TRY_BIND_SYMBOL (json_object_size);
+	TRY_BIND_SYMBOL (json_string);
+	TRY_BIND_SYMBOL (json_string_value);
+	TRY_BIND_SYMBOL (json_true);
 
 	vt->vt.loaded = TRUE;
 	vt->dl_handle = handle;
@@ -105,47 +105,3 @@ out:
 	nm_assert (vt && vt == g_atomic_pointer_get (&vt_ptr));
 	return &vt->vt;
 }
-
-#define DEF_FCN(name, rval, args_t, args_v) \
-rval name args_t \
-{ \
-	const NMJsonVt *vt = nm_json_vt (); \
-	\
-	nm_assert (vt && vt->loaded && vt->name); \
-	nm_assert (vt->name != name); \
-	return (vt->name) args_v; \
-}
-
-#define DEF_VOI(name, args_t, args_v) \
-void name args_t \
-{ \
-	const NMJsonVt *vt = nm_json_vt (); \
-	\
-	nm_assert (vt && vt->loaded && vt->name); \
-	nm_assert (vt->name != name); \
-	(vt->name) args_v; \
-}
-
-DEF_FCN (nm_json_array,              json_t *,     (void), ());
-DEF_FCN (nm_json_array_append_new,   int,          (json_t *json, json_t *value), (json, value));
-DEF_FCN (nm_json_array_get,          json_t *,     (const json_t *json, size_t index), (json, index));
-DEF_FCN (nm_json_array_size,         size_t,       (const json_t *json), (json));
-DEF_VOI (nm_json_delete,                           (json_t *json), (json));
-DEF_FCN (nm_json_dumps,              char *,       (const json_t *json, size_t flags), (json, flags));
-DEF_FCN (nm_json_false,              json_t *,     (void), ());
-DEF_FCN (nm_json_integer,            json_t *,     (json_int_t value),              (value));
-DEF_FCN (nm_json_integer_value,      json_int_t,   (const json_t *json), (json));
-DEF_FCN (nm_json_loads,              json_t *,     (const char *string, size_t flags, json_error_t *error), (string, flags, error));
-DEF_FCN (nm_json_object,             json_t *,     (void), ());
-DEF_FCN (nm_json_object_del,         int,          (json_t *json, const char *key), (json, key));
-DEF_FCN (nm_json_object_get,         json_t *,     (const json_t *json, const char *key), (json, key));
-DEF_FCN (nm_json_object_iter,        void *,       (json_t *json), (json));
-DEF_FCN (nm_json_object_iter_key,    const char *, (void *iter), (iter));
-DEF_FCN (nm_json_object_iter_next,   void *,       (json_t *json, void *iter), (json, iter));
-DEF_FCN (nm_json_object_iter_value,  json_t *,     (void *iter),                    (iter));
-DEF_FCN (nm_json_object_key_to_iter, void *,       (const char *key),               (key));
-DEF_FCN (nm_json_object_set_new,     int,          (json_t *json, const char *key, json_t *value), (json, key, value));
-DEF_FCN (nm_json_object_size,        size_t,       (const json_t *json), (json));
-DEF_FCN (nm_json_string,             json_t *,     (const char *value), (value));
-DEF_FCN (nm_json_string_value,       const char *, (const json_t *json), (json));
-DEF_FCN (nm_json_true,               json_t *,     (void), ());

--- a/libnm-core/nm-json.c
+++ b/libnm-core/nm-json.c
@@ -62,10 +62,13 @@ json_vt (void)
 	TRY_BIND_SYMBOL (json_object_del);
 	TRY_BIND_SYMBOL (json_object_get);
 	TRY_BIND_SYMBOL (json_object_iter);
+	TRY_BIND_SYMBOL (json_object_iter_at);
 	TRY_BIND_SYMBOL (json_object_iter_key);
 	TRY_BIND_SYMBOL (json_object_iter_next);
 	TRY_BIND_SYMBOL (json_object_iter_value);
+#if JANSSON_VERSION_HEX >= 0x020300
 	TRY_BIND_SYMBOL (json_object_key_to_iter);
+#endif
 	TRY_BIND_SYMBOL (json_object_set_new);
 	TRY_BIND_SYMBOL (json_object_size);
 	TRY_BIND_SYMBOL (json_string);

--- a/libnm-core/nm-json.h
+++ b/libnm-core/nm-json.h
@@ -18,34 +18,65 @@
 #ifndef __NM_JSON_H__
 #define __NM_JSON_H__
 
-gboolean nm_jansson_load (void);
-
-#ifndef NM_JANSSON_C
-#define json_object_iter_value  (*_nm_jansson_json_object_iter_value)
-#define json_object_key_to_iter (*_nm_jansson_json_object_key_to_iter)
-#define json_integer            (*_nm_jansson_json_integer)
-#define json_object_del         (*_nm_jansson_json_object_del)
-#define json_array_get          (*_nm_jansson_json_array_get)
-#define json_array_size         (*_nm_jansson_json_array_size)
-#define json_array_append_new   (*_nm_jansson_json_array_append_new)
-#define json_string             (*_nm_jansson_json_string)
-#define json_object_iter_next   (*_nm_jansson_json_object_iter_next)
-#define json_loads              (*_nm_jansson_json_loads)
-#define json_dumps              (*_nm_jansson_json_dumps)
-#define json_object_iter_key    (*_nm_jansson_json_object_iter_key)
-#define json_object             (*_nm_jansson_json_object)
-#define json_object_get         (*_nm_jansson_json_object_get)
-#define json_array              (*_nm_jansson_json_array)
-#define json_false              (*_nm_jansson_json_false)
-#define json_delete             (*_nm_jansson_json_delete)
-#define json_true               (*_nm_jansson_json_true)
-#define json_object_size        (*_nm_jansson_json_object_size)
-#define json_object_set_new     (*_nm_jansson_json_object_set_new)
-#define json_object_iter        (*_nm_jansson_json_object_iter)
-#define json_integer_value      (*_nm_jansson_json_integer_value)
-#define json_string_value       (*_nm_jansson_json_string_value)
+#define json_array              nm_json_array
+#define json_array_append_new   nm_json_array_append_new
+#define json_array_get          nm_json_array_get
+#define json_array_size         nm_json_array_size
+#define json_delete             nm_json_delete
+#define json_dumps              nm_json_dumps
+#define json_false              nm_json_false
+#define json_integer            nm_json_integer
+#define json_integer_value      nm_json_integer_value
+#define json_loads              nm_json_loads
+#define json_object             nm_json_object
+#define json_object_del         nm_json_object_del
+#define json_object_get         nm_json_object_get
+#define json_object_iter        nm_json_object_iter
+#define json_object_iter_key    nm_json_object_iter_key
+#define json_object_iter_next   nm_json_object_iter_next
+#define json_object_iter_value  nm_json_object_iter_value
+#define json_object_key_to_iter nm_json_object_key_to_iter
+#define json_object_set_new     nm_json_object_set_new
+#define json_object_size        nm_json_object_size
+#define json_string             nm_json_string
+#define json_string_value       nm_json_string_value
+#define json_true               nm_json_true
 
 #include "nm-utils/nm-jansson.h"
-#endif
+
+typedef struct {
+	gboolean loaded;
+	json_t     *(*nm_json_array)              (void);
+	int         (*nm_json_array_append_new)   (json_t *json, json_t *value);
+	json_t     *(*nm_json_array_get)          (const json_t *json, size_t index);
+	size_t      (*nm_json_array_size)         (const json_t *json);
+	void        (*nm_json_delete)             (json_t *json);
+	char       *(*nm_json_dumps)              (const json_t *json, size_t flags);
+	json_t     *(*nm_json_false)              (void);
+	json_t     *(*nm_json_integer)            (json_int_t value);
+	json_int_t  (*nm_json_integer_value)      (const json_t *json);
+	json_t     *(*nm_json_loads)              (const char *string, size_t flags, json_error_t *error);
+	json_t     *(*nm_json_object)             (void);
+	int         (*nm_json_object_del)         (json_t *json, const char *key);
+	json_t     *(*nm_json_object_get)         (const json_t *json, const char *key);
+	void       *(*nm_json_object_iter)        (json_t *json);
+	const char *(*nm_json_object_iter_key)    (void *iter);
+	void       *(*nm_json_object_iter_next)   (json_t *json, void *iter);
+	json_t     *(*nm_json_object_iter_value)  (void *);
+	void       *(*nm_json_object_key_to_iter) (const char *key);
+	int         (*nm_json_object_set_new)     (json_t *json, const char *key, json_t *value);
+	size_t      (*nm_json_object_size)        (const json_t *json);
+	json_t     *(*nm_json_string)             (const char *value);
+	const char *(*nm_json_string_value)       (const json_t *json);
+	json_t     *(*nm_json_true)               (void);
+} NMJsonVt;
+
+const NMJsonVt *nm_json_vt (void);
+
+static inline gboolean
+nm_json_init (void)
+{
+	return nm_json_vt ()->loaded;
+}
 
 #endif /* __NM_JSON_H__ */

--- a/libnm-core/nm-json.h
+++ b/libnm-core/nm-json.h
@@ -74,9 +74,40 @@ typedef struct {
 const NMJsonVt *nm_json_vt (void);
 
 static inline gboolean
-nm_json_init (void)
+nm_json_init (const NMJsonVt **out_vt)
 {
-	return nm_json_vt ()->loaded;
+	const NMJsonVt *vt;
+
+	vt = nm_json_vt ();
+	NM_SET_OUT (out_vt, vt);
+	return vt->loaded;
 }
+
+#define nm_json_boolean(vt, val) \
+	((val) ? (vt)->nm_json_true () : (vt)->nm_json_false ())
+
+static inline void
+nm_json_decref (const NMJsonVt *vt, json_t *json)
+{
+	if(json && json->refcount != (size_t)-1 && --json->refcount == 0)
+		vt->nm_json_delete (json);
+}
+
+/*****************************************************************************/
+
+/* the following are implemented as pure macros in jansson.h.
+ * They can be used directly, however, add a nm_json* variant,
+ * to make it explict we don't accidentally use jansson ABI. */
+
+#define nm_json_is_boolean(json)                json_is_boolean (json)
+#define nm_json_is_integer(json)                json_is_integer (json)
+#define nm_json_is_string(json)                 json_is_string (json)
+#define nm_json_is_object(json)                 json_is_object (json)
+#define nm_json_is_array(json)                  json_is_array (json)
+#define nm_json_is_true(json)                   json_is_true (json)
+#define nm_json_boolean_value(json)             json_boolean_value (json)
+#define nm_json_array_foreach(a, b, c)          json_array_foreach (a, b, c)
+#define nm_json_object_foreach(a, b, c)         json_object_foreach (a, b, c)
+#define nm_json_object_foreach_safe(a, b, c, d) json_object_foreach_safe (a, b, c, d)
 
 #endif /* __NM_JSON_H__ */

--- a/libnm-core/nm-json.h
+++ b/libnm-core/nm-json.h
@@ -18,30 +18,6 @@
 #ifndef __NM_JSON_H__
 #define __NM_JSON_H__
 
-#define json_array              nm_json_array
-#define json_array_append_new   nm_json_array_append_new
-#define json_array_get          nm_json_array_get
-#define json_array_size         nm_json_array_size
-#define json_delete             nm_json_delete
-#define json_dumps              nm_json_dumps
-#define json_false              nm_json_false
-#define json_integer            nm_json_integer
-#define json_integer_value      nm_json_integer_value
-#define json_loads              nm_json_loads
-#define json_object             nm_json_object
-#define json_object_del         nm_json_object_del
-#define json_object_get         nm_json_object_get
-#define json_object_iter        nm_json_object_iter
-#define json_object_iter_key    nm_json_object_iter_key
-#define json_object_iter_next   nm_json_object_iter_next
-#define json_object_iter_value  nm_json_object_iter_value
-#define json_object_key_to_iter nm_json_object_key_to_iter
-#define json_object_set_new     nm_json_object_set_new
-#define json_object_size        nm_json_object_size
-#define json_string             nm_json_string
-#define json_string_value       nm_json_string_value
-#define json_true               nm_json_true
-
 #include "nm-utils/nm-jansson.h"
 
 typedef struct {
@@ -106,8 +82,23 @@ nm_json_decref (const NMJsonVt *vt, json_t *json)
 #define nm_json_is_array(json)                  json_is_array (json)
 #define nm_json_is_true(json)                   json_is_true (json)
 #define nm_json_boolean_value(json)             json_boolean_value (json)
-#define nm_json_array_foreach(a, b, c)          json_array_foreach (a, b, c)
-#define nm_json_object_foreach(a, b, c)         json_object_foreach (a, b, c)
-#define nm_json_object_foreach_safe(a, b, c, d) json_object_foreach_safe (a, b, c, d)
+
+#define nm_json_array_foreach(vt, array, index, value) \
+    for(index = 0; \
+        index < vt->nm_json_array_size (array) && (value = vt->nm_json_array_get (array, index)); \
+        index++)
+
+#define nm_json_object_foreach(vt, object, key, value) \
+    for(key = vt->nm_json_object_iter_key (vt->nm_json_object_iter (object)); \
+        key && (value = vt->nm_json_object_iter_value (vt->nm_json_object_key_to_iter (key))); \
+        key = vt->nm_json_object_iter_key (vt->nm_json_object_iter_next (object, vt->nm_json_object_key_to_iter (key))))
+
+#define nm_json_object_foreach_safe(vt, object, n, key, value)     \
+    for(key = vt->nm_json_object_iter_key (vt->nm_json_object_iter (object)), \
+            n = vt->nm_json_object_iter_next (object, vt->nm_json_object_key_to_iter (key)); \
+        key && (value = vt->nm_json_object_iter_value (vt->nm_json_object_key_to_iter (key))); \
+        key = vt->nm_json_object_iter_key (n), \
+            n = vt->nm_json_object_iter_next (object, vt->nm_json_object_key_to_iter (key)))
+
 
 #endif /* __NM_JSON_H__ */

--- a/libnm-core/nm-utils.c
+++ b/libnm-core/nm-utils.c
@@ -5210,7 +5210,7 @@ _nm_utils_team_link_watcher_from_json (const NMJsonVt *vt, json_t *json_element)
 
 	g_return_val_if_fail (json_element, NULL);
 
-	nm_json_object_foreach (json_element, j_key, j_val) {
+	nm_json_object_foreach (vt, json_element, j_key, j_val) {
 		if (nm_streq (j_key, "name")) {
 			g_free (name);
 			name = strdup (vt->nm_json_string_value (j_val));
@@ -5413,7 +5413,7 @@ _nm_utils_team_config_equal (const char *conf1,
 	/* Only consider a given subset of nodes, others can change depending on
 	 * current state */
 	for (i = 0, json = json1; i < 2; i++, json = json2) {
-		nm_json_object_foreach_safe (json, tmp, key, value) {
+		nm_json_object_foreach_safe (vt, json, tmp, key, value) {
 			if (!NM_IN_STRSET (key, "runner", "link_watch"))
 				vt->nm_json_object_del (json, key);
 		}
@@ -5498,7 +5498,7 @@ _nm_utils_team_config_get (const char *conf,
 				json_t *j_watcher;
 				int index;
 
-				nm_json_array_foreach (json_element, index, j_watcher) {
+				nm_json_array_foreach (vt, json_element, index, j_watcher) {
 					watcher = _nm_utils_team_link_watcher_from_json (vt, j_watcher);
 					if (watcher)
 						g_ptr_array_add (data, watcher);
@@ -5519,7 +5519,7 @@ _nm_utils_team_config_get (const char *conf,
 			json_t *str_element;
 			int index;
 
-			nm_json_array_foreach (json_element, index, str_element) {
+			nm_json_array_foreach (vt, json_element, index, str_element) {
 				if (nm_json_is_string (str_element))
 					g_ptr_array_add (data, g_strdup (vt->nm_json_string_value (str_element)));
 			}

--- a/libnm-core/nm-utils.c
+++ b/libnm-core/nm-utils.c
@@ -4900,46 +4900,46 @@ _json_add_object (const NMJsonVt *vt,
                   const char *key3,
                   json_t *value)
 {
-	json_t *json_element, *json_link;
+	json_t *js_element, *js_link;
 
-	json_element = vt->nm_json_object_get (json, key1);
-	if (!json_element) {
-		json_element = value;
+	js_element = vt->nm_json_object_get (json, key1);
+	if (!js_element) {
+		js_element = value;
 		if (key2) {
 			if (key3) {
-				json_element = vt->nm_json_object ();
-				vt->nm_json_object_set_new (json_element, key3, value);
+				js_element = vt->nm_json_object ();
+				vt->nm_json_object_set_new (js_element, key3, value);
 			}
-			json_link = vt->nm_json_object ();
-			vt->nm_json_object_set_new (json_link, key2, json_element);
-			json_element = json_link;
+			js_link = vt->nm_json_object ();
+			vt->nm_json_object_set_new (js_link, key2, js_element);
+			js_element = js_link;
 		}
-		vt->nm_json_object_set_new (json, key1, json_element);
+		vt->nm_json_object_set_new (json, key1, js_element);
 		return;
 	}
 
 	if (!key2)
 		goto key_already_there;
 
-	json_link = json_element;
-	json_element = vt->nm_json_object_get (json_element, key2);
-	if (!json_element) {
-		json_element = value;
+	js_link = js_element;
+	js_element = vt->nm_json_object_get (js_element, key2);
+	if (!js_element) {
+		js_element = value;
 		if (key3) {
-			json_element = vt->nm_json_object ();
-			vt->nm_json_object_set_new (json_element, key3, value);
+			js_element = vt->nm_json_object ();
+			vt->nm_json_object_set_new (js_element, key3, value);
 		}
-		vt->nm_json_object_set_new (json_link, key2, json_element);
+		vt->nm_json_object_set_new (js_link, key2, js_element);
 		return;
 	}
 
 	if (!key3)
 		goto key_already_there;
 
-	json_link = json_element;
-	json_element = vt->nm_json_object_get (json_element, key3);
-	if (!json_element) {
-		vt->nm_json_object_set_new (json_link, key3, value);
+	js_link = js_element;
+	js_element = vt->nm_json_object_get (js_element, key3);
+	if (!js_element) {
+		vt->nm_json_object_set_new (js_link, key3, value);
 		return;
 	}
 
@@ -4957,36 +4957,36 @@ _json_del_object (const NMJsonVt *vt,
                   const char *key2,
                   const char *key3)
 {
-	json_t *json_element = json;
-	json_t *json_link = NULL;
+	json_t *js_element = json;
+	json_t *js_link = NULL;
 	const char *iter_key = key1;
 
 	if (key2) {
-		json_link = json;
-		json_element = vt->nm_json_object_get (json, key1);
-		if (!json_element)
+		js_link = json;
+		js_element = vt->nm_json_object_get (json, key1);
+		if (!js_element)
 			return FALSE;
 		iter_key = key2;
 	}
 	if (key3) {
-		json_link = json_element;
-		json_element = vt->nm_json_object_get (json_element, key2);
-		if (!json_element)
+		js_link = js_element;
+		js_element = vt->nm_json_object_get (js_element, key2);
+		if (!js_element)
 			return FALSE;
 		iter_key = key3;
 	}
 
-	if (vt->nm_json_object_del (json_element, iter_key) != 0)
+	if (vt->nm_json_object_del (js_element, iter_key) != 0)
 		return FALSE;
 
 	/* 1st level key only */
-	if (!json_link)
+	if (!js_link)
 		return TRUE;
 
-	if (vt->nm_json_object_size (json_element) == 0)
-		vt->nm_json_object_del (json_link, (key3 ? key2 : key1));
+	if (vt->nm_json_object_size (js_element) == 0)
+		vt->nm_json_object_del (js_link, (key3 ? key2 : key1));
 
-	if (key3 && vt->nm_json_object_size (json_link) == 0)
+	if (key3 && vt->nm_json_object_size (js_link) == 0)
 		vt->nm_json_object_del (json, key1);
 
 	return TRUE;
@@ -5001,7 +5001,7 @@ _json_team_add_defaults (const NMJsonVt *vt,
                          gboolean port_config,
                          gboolean add_implicit)
 {
-	json_t *json_element;
+	json_t *js_element;
 	const char *runner = NULL;
 
 	if (port_config) {
@@ -5011,16 +5011,16 @@ _json_team_add_defaults (const NMJsonVt *vt,
 	}
 
 	/* Retrieve runner or add default one */
-	json_element = vt->nm_json_object_get (json, "runner");
-	if (json_element) {
-		runner = vt->nm_json_string_value (vt->nm_json_object_get (json_element, "name"));
+	js_element = vt->nm_json_object_get (json, "runner");
+	if (js_element) {
+		runner = vt->nm_json_string_value (vt->nm_json_object_get (js_element, "name"));
 	} else {
-		json_element = vt->nm_json_object ();
-		vt->nm_json_object_set_new (json, "runner", json_element);
+		js_element = vt->nm_json_object ();
+		vt->nm_json_object_set_new (json, "runner", js_element);
 	}
 	if (!runner) {
 		runner = NM_SETTING_TEAM_RUNNER_DEFAULT;
-		vt->nm_json_object_set_new (json_element, "name", vt->nm_json_string (runner));
+		vt->nm_json_object_set_new (js_element, "name", vt->nm_json_string (runner));
 	}
 
 
@@ -5031,11 +5031,11 @@ _json_team_add_defaults (const NMJsonVt *vt,
 		                  vt->nm_json_integer (NM_SETTING_TEAM_NOTIFY_MCAST_COUNT_ACTIVEBACKUP_DEFAULT));
 	} else if (   nm_streq (runner, NM_SETTING_TEAM_RUNNER_LOADBALANCE)
 		   || nm_streq (runner, NM_SETTING_TEAM_RUNNER_LACP)) {
-		json_element = vt->nm_json_array ();
-		vt->nm_json_array_append_new (json_element, vt->nm_json_string ("eth"));
-		vt->nm_json_array_append_new (json_element, vt->nm_json_string ("ipv4"));
-		vt->nm_json_array_append_new (json_element, vt->nm_json_string ("ipv6"));
-		_json_add_object (vt, json, "runner", "tx_hash", NULL, json_element);
+		js_element = vt->nm_json_array ();
+		vt->nm_json_array_append_new (js_element, vt->nm_json_string ("eth"));
+		vt->nm_json_array_append_new (js_element, vt->nm_json_string ("ipv4"));
+		vt->nm_json_array_append_new (js_element, vt->nm_json_string ("ipv6"));
+		_json_add_object (vt, json, "runner", "tx_hash", NULL, js_element);
 	}
 
 	if (!add_implicit)
@@ -5066,20 +5066,20 @@ _json_find_object (const NMJsonVt *vt,
                    const char *key2,
                    const char *key3)
 {
-	json_t *json_element;
+	json_t *js_element;
 
 	if (!key1)
 		return NULL;
-	json_element = vt->nm_json_object_get (json, key1);
-	if (!key2 || !json_element)
-		return json_element;
+	js_element = vt->nm_json_object_get (json, key1);
+	if (!key2 || !js_element)
+		return js_element;
 
-	json_element = vt->nm_json_object_get (json_element, key2);
-	if (!key3 || !json_element)
-		return json_element;
+	js_element = vt->nm_json_object_get (js_element, key2);
+	if (!key3 || !js_element)
+		return js_element;
 
-	json_element = vt->nm_json_object_get (json_element, key3);
-	return json_element;
+	js_element = vt->nm_json_object_get (js_element, key3);
+	return js_element;
 }
 
 static inline void
@@ -5090,12 +5090,12 @@ _json_delete_object_on_int_match (const NMJsonVt *vt,
                                   const char *key3,
                                   int val)
 {
-	json_t *json_element;
+	json_t *js_element;
 
-	json_element = _json_find_object (vt, json, key1, key2, key3);
-	if (!json_element || !nm_json_is_integer (json_element))
+	js_element = _json_find_object (vt, json, key1, key2, key3);
+	if (!js_element || !nm_json_is_integer (js_element))
 		return;
-	if (vt->nm_json_integer_value (json_element) == val)
+	if (vt->nm_json_integer_value (js_element) == val)
 		_json_del_object (vt, json, key1, key2, key3);
 }
 
@@ -5107,12 +5107,12 @@ _json_delete_object_on_bool_match (const NMJsonVt *vt,
                                    const char *key3,
                                    gboolean val)
 {
-	json_t *json_element;
+	json_t *js_element;
 
-	json_element = _json_find_object (vt, json, key1, key2, key3);
-	if (!json_element || !nm_json_is_boolean (json_element))
+	js_element = _json_find_object (vt, json, key1, key2, key3);
+	if (!js_element || !nm_json_is_boolean (js_element))
 		return;
-	if ((!nm_json_boolean_value (json_element)) == (!val))
+	if ((!nm_json_boolean_value (js_element)) == (!val))
 		_json_del_object (vt, json, key1, key2, key3);
 }
 
@@ -5124,19 +5124,19 @@ _json_delete_object_on_string_match (const NMJsonVt *vt,
                                      const char *key3,
                                      const char *val)
 {
-	json_t *json_element;
+	json_t *js_element;
 
-	json_element = _json_find_object (vt, json, key1, key2, key3);
-	if (!json_element || !nm_json_is_string (json_element))
+	js_element = _json_find_object (vt, json, key1, key2, key3);
+	if (!js_element || !nm_json_is_string (js_element))
 		return;
-	if (nm_streq0 (vt->nm_json_string_value (json_element), val))
+	if (nm_streq0 (vt->nm_json_string_value (js_element), val))
 		_json_del_object (vt, json, key1, key2, key3);
 }
 
 static void
 _json_team_normalize_defaults (const NMJsonVt *vt, json_t *json, gboolean reset)
 {
-	json_t *json_element;
+	json_t *js_element;
 	const char *runner = NM_SETTING_TEAM_RUNNER_DEFAULT;
 	int notify_peers_count = 0, notify_peers_interval = 0;
 	int mcast_rejoin_count = 0, mcast_rejoin_interval = 0;
@@ -5144,9 +5144,9 @@ _json_team_normalize_defaults (const NMJsonVt *vt, json_t *json, gboolean reset)
 	gboolean runner_active = FALSE, runner_fast_rate = FALSE;
 	int runner_sys_prio = -1, runner_min_ports = -1;
 
-	json_element = _json_find_object (vt, json, "runner", "name", NULL);
-	if (json_element) {
-		runner = vt->nm_json_string_value (json_element);
+	js_element = _json_find_object (vt, json, "runner", "name", NULL);
+	if (js_element) {
+		runner = vt->nm_json_string_value (js_element);
 		_json_delete_object_on_string_match (vt, json, "runner", "name", NULL,
 		                                     NM_SETTING_TEAM_RUNNER_DEFAULT);
 	}
@@ -5200,7 +5200,7 @@ _json_team_normalize_defaults (const NMJsonVt *vt, json_t *json, gboolean reset)
 }
 
 static NMTeamLinkWatcher *
-_nm_utils_team_link_watcher_from_json (const NMJsonVt *vt, json_t *json_element)
+_nm_utils_team_link_watcher_from_json (const NMJsonVt *vt, json_t *js_element)
 {
 	const char *j_key;
 	json_t *j_val;
@@ -5208,9 +5208,9 @@ _nm_utils_team_link_watcher_from_json (const NMJsonVt *vt, json_t *json_element)
 	int val1 = 0, val2 = 0, val3 = 3;
 	NMTeamLinkWatcherArpPingFlags flags = 0;
 
-	g_return_val_if_fail (json_element, NULL);
+	g_return_val_if_fail (js_element, NULL);
 
-	nm_json_object_foreach (vt, json_element, j_key, j_val) {
+	nm_json_object_foreach (vt, js_element, j_key, j_val) {
 		if (nm_streq (j_key, "name")) {
 			g_free (name);
 			name = strdup (vt->nm_json_string_value (j_val));
@@ -5256,61 +5256,61 @@ _nm_utils_team_link_watcher_to_json (const NMJsonVt *vt, NMTeamLinkWatcher *watc
 	int int_val;
 	const char *str_val;
 	NMTeamLinkWatcherArpPingFlags flags = 0;
-	json_t *json_element;
+	json_t *js_element;
 
 	g_return_val_if_fail (watcher, NULL);
 
-	json_element = vt->nm_json_object ();
+	js_element = vt->nm_json_object ();
 	name = nm_team_link_watcher_get_name (watcher);
 	if (!name)
 		goto fail;
 
-	vt->nm_json_object_set_new (json_element, "name", vt->nm_json_string (name));
+	vt->nm_json_object_set_new (js_element, "name", vt->nm_json_string (name));
 
 	if (nm_streq (name, NM_TEAM_LINK_WATCHER_ETHTOOL)) {
 		int_val = nm_team_link_watcher_get_delay_up (watcher);
 		if (int_val)
-			vt->nm_json_object_set_new (json_element, "delay_up", vt->nm_json_integer (int_val));
+			vt->nm_json_object_set_new (js_element, "delay_up", vt->nm_json_integer (int_val));
 		int_val = nm_team_link_watcher_get_delay_down (watcher);
 		if (int_val)
-			vt->nm_json_object_set_new (json_element, "delay_down", vt->nm_json_integer (int_val));
-		return json_element;
+			vt->nm_json_object_set_new (js_element, "delay_down", vt->nm_json_integer (int_val));
+		return js_element;
 	}
 
 	int_val = nm_team_link_watcher_get_init_wait (watcher);
 	if (int_val)
-		vt->nm_json_object_set_new (json_element, "init_wait", vt->nm_json_integer (int_val));
+		vt->nm_json_object_set_new (js_element, "init_wait", vt->nm_json_integer (int_val));
 	int_val = nm_team_link_watcher_get_interval (watcher);
 	if (int_val)
-		vt->nm_json_object_set_new (json_element, "interval", vt->nm_json_integer (int_val));
+		vt->nm_json_object_set_new (js_element, "interval", vt->nm_json_integer (int_val));
 	int_val = nm_team_link_watcher_get_missed_max (watcher);
 	if (int_val != 3)
-		vt->nm_json_object_set_new (json_element, "missed_max", vt->nm_json_integer (int_val));
+		vt->nm_json_object_set_new (js_element, "missed_max", vt->nm_json_integer (int_val));
 	str_val = nm_team_link_watcher_get_target_host (watcher);
 	if (!str_val)
 		goto fail;
-	vt->nm_json_object_set_new (json_element, "target_host", vt->nm_json_string (str_val));
+	vt->nm_json_object_set_new (js_element, "target_host", vt->nm_json_string (str_val));
 
 	if (nm_streq (name, NM_TEAM_LINK_WATCHER_NSNA_PING))
-		return json_element;
+		return js_element;
 
 	str_val = nm_team_link_watcher_get_source_host (watcher);
 	if (!str_val)
 		goto fail;
-	vt->nm_json_object_set_new (json_element, "source_host", vt->nm_json_string (str_val));
+	vt->nm_json_object_set_new (js_element, "source_host", vt->nm_json_string (str_val));
 
 	flags = nm_team_link_watcher_get_flags (watcher);
 	if (flags & NM_TEAM_LINK_WATCHER_ARP_PING_FLAG_VALIDATE_ACTIVE)
-		vt->nm_json_object_set_new (json_element, "validate_active", vt->nm_json_string ("true"));
+		vt->nm_json_object_set_new (js_element, "validate_active", vt->nm_json_string ("true"));
 	if (flags & NM_TEAM_LINK_WATCHER_ARP_PING_FLAG_VALIDATE_INACTIVE)
-		vt->nm_json_object_set_new (json_element, "validate_inactive", vt->nm_json_string ("true"));
+		vt->nm_json_object_set_new (js_element, "validate_inactive", vt->nm_json_string ("true"));
 	if (flags & NM_TEAM_LINK_WATCHER_ARP_PING_FLAG_SEND_ALWAYS)
-		vt->nm_json_object_set_new (json_element, "send_always", vt->nm_json_string ("true"));
+		vt->nm_json_object_set_new (js_element, "send_always", vt->nm_json_string ("true"));
 
-	return json_element;
+	return js_element;
 
 fail:
-	nm_json_decref (vt, json_element);
+	nm_json_decref (vt, js_element);
 	return NULL;
 }
 
@@ -5442,7 +5442,7 @@ _nm_utils_team_config_get (const char *conf,
                            gboolean port_config)
 {
 	json_t *json;
-	json_t *json_element;
+	json_t *js_element;
 	GValue *value = NULL;
 	json_error_t jerror;
 	const NMJsonVt *vt;
@@ -5472,39 +5472,39 @@ _nm_utils_team_config_get (const char *conf,
 		_json_team_add_defaults (vt, json, port_config, TRUE);
 
 	/* Now search the property to retrieve */
-	json_element = vt->nm_json_object_get (json, key);
-	if (json_element && key2)
-		json_element = vt->nm_json_object_get (json_element, key2);
-	if (json_element && key3)
-		json_element = vt->nm_json_object_get (json_element, key3);
+	js_element = vt->nm_json_object_get (json, key);
+	if (js_element && key2)
+		js_element = vt->nm_json_object_get (js_element, key2);
+	if (js_element && key3)
+		js_element = vt->nm_json_object_get (js_element, key3);
 
-	if (json_element) {
+	if (js_element) {
 		value = g_new0 (GValue, 1);
-		if (nm_json_is_string (json_element)) {
+		if (nm_json_is_string (js_element)) {
 			g_value_init (value, G_TYPE_STRING);
-			g_value_set_string (value, vt->nm_json_string_value (json_element));
-		} else if (nm_json_is_integer (json_element)) {
+			g_value_set_string (value, vt->nm_json_string_value (js_element));
+		} else if (nm_json_is_integer (js_element)) {
 			g_value_init (value, G_TYPE_INT);
-			g_value_set_int (value, vt->nm_json_integer_value (json_element));
-		} else if (nm_json_is_boolean (json_element)) {
+			g_value_set_int (value, vt->nm_json_integer_value (js_element));
+		} else if (nm_json_is_boolean (js_element)) {
 			g_value_init (value, G_TYPE_BOOLEAN);
-			g_value_set_boolean (value, nm_json_boolean_value (json_element));
+			g_value_set_boolean (value, nm_json_boolean_value (js_element));
 		} else if (nm_streq (key, "link_watch")) {
 			NMTeamLinkWatcher *watcher;
 			GPtrArray *data = g_ptr_array_new_with_free_func
 			                  ((GDestroyNotify) nm_team_link_watcher_unref);
 
-			if (nm_json_is_array (json_element)) {
+			if (nm_json_is_array (js_element)) {
 				json_t *j_watcher;
 				int index;
 
-				nm_json_array_foreach (vt, json_element, index, j_watcher) {
+				nm_json_array_foreach (vt, js_element, index, j_watcher) {
 					watcher = _nm_utils_team_link_watcher_from_json (vt, j_watcher);
 					if (watcher)
 						g_ptr_array_add (data, watcher);
 				}
 			} else {
-				watcher = _nm_utils_team_link_watcher_from_json (vt, json_element);
+				watcher = _nm_utils_team_link_watcher_from_json (vt, js_element);
 				if (watcher)
 					g_ptr_array_add (data, watcher);
 			}
@@ -5514,12 +5514,12 @@ _nm_utils_team_config_get (const char *conf,
 			} else
 				g_ptr_array_free (data, TRUE);
 
-		} else if (nm_json_is_array (json_element)) {
+		} else if (nm_json_is_array (js_element)) {
 			GPtrArray *data = g_ptr_array_new_with_free_func ((GDestroyNotify) g_free);
 			json_t *str_element;
 			int index;
 
-			nm_json_array_foreach (vt, json_element, index, str_element) {
+			nm_json_array_foreach (vt, js_element, index, str_element) {
 				if (nm_json_is_string (str_element))
 					g_ptr_array_add (data, g_strdup (vt->nm_json_string_value (str_element)));
 			}
@@ -5549,7 +5549,7 @@ _nm_utils_team_config_set (char **conf,
                            const char *key3,
                            const GValue *value)
 {
-	json_t *json, *json_element, *json_link, *json_value = NULL;
+	json_t *json, *js_element, *js_link, *js_value = NULL;
 	json_error_t jerror;
 	gboolean updated = FALSE;
 	char **strv;
@@ -5577,11 +5577,11 @@ _nm_utils_team_config_set (char **conf,
 	/* insert new value */
 	updated = TRUE;
 	if (G_VALUE_HOLDS_STRING (value))
-		json_value = vt->nm_json_string (g_value_get_string (value));
+		js_value = vt->nm_json_string (g_value_get_string (value));
 	else if (G_VALUE_HOLDS_INT (value))
-		json_value = vt->nm_json_integer (g_value_get_int (value));
+		js_value = vt->nm_json_integer (g_value_get_int (value));
 	else if (G_VALUE_HOLDS_BOOLEAN (value))
-		json_value = nm_json_boolean (vt, g_value_get_boolean (value));
+		js_value = nm_json_boolean (vt, g_value_get_boolean (value));
 	else if (G_VALUE_HOLDS_BOXED (value)) {
 		if (nm_streq (key, "link_watch")) {
 			array = g_value_get_boxed (value);
@@ -5591,27 +5591,27 @@ _nm_utils_team_config_set (char **conf,
 			}
 
 			/*
-			 * json_value:   will hold the final link_watcher json (array) object
-			 * json_element: is the next link_watcher to append to json_value
-			 * json_link:    used to transit the json_value from a single link_watcher
+			 * js_value:   will hold the final link_watcher json (array) object
+			 * js_element: is the next link_watcher to append to js_value
+			 * js_link:    used to transit the js_value from a single link_watcher
 			 *               object to an array of link watcher objects
 			 */
-			json_value = NULL;
+			js_value = NULL;
 			for (i = 0; i < array->len; i++) {
 				watcher = array->pdata[i];
-				json_element = _nm_utils_team_link_watcher_to_json (vt, watcher);
-				if (!json_element)
+				js_element = _nm_utils_team_link_watcher_to_json (vt, watcher);
+				if (!js_element)
 					continue;
-				if (!json_value) {
-					json_value = json_element;
+				if (!js_value) {
+					js_value = js_element;
 					continue;
 				}
-				if (!nm_json_is_array (json_value)) {
-					json_link = json_value;
-					json_value = vt->nm_json_array ();
-					vt->nm_json_array_append_new (json_value, json_link);
+				if (!nm_json_is_array (js_value)) {
+					js_link = js_value;
+					js_value = vt->nm_json_array ();
+					vt->nm_json_array_append_new (js_value, js_link);
 				}
-				vt->nm_json_array_append_new (json_value, json_element);
+				vt->nm_json_array_append_new (js_value, js_element);
 			}
 		} else if (   nm_streq (key, "runner")
 		           && nm_streq0 (key2, "tx_hash")) {
@@ -5620,9 +5620,9 @@ _nm_utils_team_config_set (char **conf,
 				updated = FALSE;
 				goto done;
 			}
-			json_value = vt->nm_json_array ();
+			js_value = vt->nm_json_array ();
 			for (i = 0; strv[i]; i++)
-				vt->nm_json_array_append_new (json_value, vt->nm_json_string (strv[i]));
+				vt->nm_json_array_append_new (js_value, vt->nm_json_string (strv[i]));
 		} else {
 			updated = FALSE;
 			goto done;
@@ -5634,34 +5634,34 @@ _nm_utils_team_config_set (char **conf,
 	}
 
 	/* Simplest case: first level key only */
-	json_element = json;
-	json_link = NULL;
+	js_element = json;
+	js_link = NULL;
 
 	if (key2) {
-		json_link = json;
-		json_element = vt->nm_json_object_get (json, iter_key);
-		if (!json_element) {
-			json_element = vt->nm_json_object ();
-			vt->nm_json_object_set_new (json_link, iter_key, json_element);
+		js_link = json;
+		js_element = vt->nm_json_object_get (json, iter_key);
+		if (!js_element) {
+			js_element = vt->nm_json_object ();
+			vt->nm_json_object_set_new (js_link, iter_key, js_element);
 		}
 		iter_key = key2;
 	}
 	if (key3) {
-		json_link = json_element;
-		json_element = vt->nm_json_object_get (json_link, iter_key);
-		if (!json_element) {
-			json_element = vt->nm_json_object ();
-			vt->nm_json_object_set_new (json_link, iter_key, json_element);
+		js_link = js_element;
+		js_element = vt->nm_json_object_get (js_link, iter_key);
+		if (!js_element) {
+			js_element = vt->nm_json_object ();
+			vt->nm_json_object_set_new (js_link, iter_key, js_element);
 		}
 		iter_key = key3;
 	}
 
-	vt->nm_json_object_set_new (json_element, iter_key, json_value);
+	vt->nm_json_object_set_new (js_element, iter_key, js_value);
 
 done:
 	if (updated) {
 		_json_team_normalize_defaults (vt, json, (   nm_streq0 (key, "runner")
-		                                          && nm_streq0 (key2, "name")));
+		                                        && nm_streq0 (key2, "name")));
 		g_free (*conf);
 		*conf = vt->nm_json_dumps (json, JSON_PRESERVE_ORDER);
 		/* Don't save an empty config */

--- a/libnm-core/nm-utils.c
+++ b/libnm-core/nm-utils.c
@@ -5336,7 +5336,7 @@ nm_utils_is_json_object (const char *str, GError **error)
 		return FALSE;
 	}
 
-	if (!nm_jansson_load ())
+	if (!nm_json_init ())
 		return _nm_utils_is_json_object_no_validation (str, error);
 
 	json = json_loads (str, JSON_REJECT_DUPLICATES, &jerror);
@@ -5380,7 +5380,7 @@ _nm_utils_team_config_equal (const char *conf1,
 
 	if (nm_streq0 (conf1, conf2))
 		return TRUE;
-	else if (!nm_jansson_load ())
+	else if (!nm_json_init ())
 		return FALSE;
 
 	/* A NULL configuration is equivalent to default value '{}' */
@@ -5439,7 +5439,7 @@ _nm_utils_team_config_get (const char *conf,
 	if (!key)
 		return NULL;
 
-	if (!nm_jansson_load ())
+	if (!nm_json_init ())
 		return NULL;
 
 	json = json_loads (conf ?: "{}", JSON_REJECT_DUPLICATES, &jerror);
@@ -5549,7 +5549,7 @@ _nm_utils_team_config_set (char **conf,
 
 	g_return_val_if_fail (key, FALSE);
 
-	if (!nm_jansson_load ())
+	if (!nm_json_init ())
 		return FALSE;
 
 	json = json_loads (*conf?: "{}", JSON_REJECT_DUPLICATES, &jerror);


### PR DESCRIPTION
A different approach to wrapping the libjansson symbols.

See commit cd476e4dc922f0acfd65b02639032ee67339ad95.


Preferably, we don't use any `json_*` names, and only include `<jansson.h>` in the glue code. However, defines like `json_int_t` (which depends on configure options of libjansson) and `json_error_t` (which are supposed to be stack-allocated by us), are hard to re-implement.

So, we still include `<jansson.h>` header and make use of such `json*` typedefs. However, don't use any symbols from the ABI.

cd476e4dc922f0acfd65b02639032ee67339ad95 achieved that by re-defining symbols before including the header. I think that is confusing. How about a function table instead?