### PR TITLE
Update NetworkManager.conf man page to account for stub-resolv.conf

### DIFF
--- a/man/NetworkManager.conf.xml
+++ b/man/NetworkManager.conf.xml
@@ -312,6 +312,7 @@ no-auto-default=*
         <listitem><para>Set the DNS (<filename>resolv.conf</filename>) processing mode.
         If the key is unspecified, <literal>default</literal> is used,
         unless <filename>/etc/resolv.conf</filename> is a symlink to
+        <filename>/run/systemd/resolve/stub-resolv.conf</filename>,
         <filename>/run/systemd/resolve/resolv.conf</filename>,
         <filename>/lib/systemd/resolv.conf</filename> or
         <filename>/usr/lib/systemd/resolv.conf</filename>.


### PR DESCRIPTION
NetworkManager checks if /etc/resolv.conf is a symlink to /run/systemd/resolve/stub-resolv.conf since commit e09503dcc43039905018b26304bfe94287211aa6. This should be documented in the corresponding section of NetworkManager.conf(5).