### PR TITLE
th/connectivity_rework

### DIFF
--- a/src/devices/nm-device.h
+++ b/src/devices/nm-device.h
@@ -783,6 +783,8 @@ typedef void (*NMDeviceConnectivityCallback) (NMDevice *self,
                                               GError *error,
                                               gpointer user_data);
 
+void nm_device_check_connectivity_update_interval (NMDevice *self);
+
 NMDeviceConnectivityHandle *nm_device_check_connectivity (NMDevice *self,
                                                           NMDeviceConnectivityCallback callback,
                                                           gpointer user_data);

--- a/src/devices/nm-device.h
+++ b/src/devices/nm-device.h
@@ -775,12 +775,20 @@ gboolean nm_device_hw_addr_get_cloned (NMDevice *self,
                                        gboolean *preserve,
                                        GError **error);
 
+typedef struct _NMDeviceConnectivityHandle NMDeviceConnectivityHandle;
+
 typedef void (*NMDeviceConnectivityCallback) (NMDevice *self,
+                                              NMDeviceConnectivityHandle *handle,
                                               NMConnectivityState state,
+                                              GError *error,
                                               gpointer user_data);
-void nm_device_check_connectivity (NMDevice *self,
-                                   NMDeviceConnectivityCallback callback,
-                                   gpointer user_data);
+
+NMDeviceConnectivityHandle *nm_device_check_connectivity (NMDevice *self,
+                                                          NMDeviceConnectivityCallback callback,
+                                                          gpointer user_data);
+
+void nm_device_check_connectivity_cancel (NMDeviceConnectivityHandle *handle);
+
 NMConnectivityState nm_device_get_connectivity_state (NMDevice *self);
 
 typedef struct _NMBtVTableNetworkServer NMBtVTableNetworkServer;

--- a/src/main.c
+++ b/src/main.c
@@ -402,9 +402,7 @@ main (int argc, char *argv[])
 	                            manager))
 		goto done;
 
-#if WITH_CONCHECK
 	NM_UTILS_KEEP_ALIVE (manager, nm_connectivity_get (), "NMManager-depends-on-NMConnectivity");
-#endif
 
 	nm_dispatcher_init ();
 

--- a/src/main.c
+++ b/src/main.c
@@ -402,8 +402,6 @@ main (int argc, char *argv[])
 	                            manager))
 		goto done;
 
-	NM_UTILS_KEEP_ALIVE (manager, nm_connectivity_get (), "NMManager-depends-on-NMConnectivity");
-
 	nm_dispatcher_init ();
 
 	g_signal_connect (manager, NM_MANAGER_CONFIGURE_QUIT, G_CALLBACK (manager_configure_quit), config);

--- a/src/nm-connectivity.c
+++ b/src/nm-connectivity.c
@@ -500,7 +500,7 @@ nm_connectivity_check_start (NMConnectivity *self,
 			curl_easy_setopt (ehandle, CURLOPT_INTERFACE, cb_data->ifspec);
 			curl_multi_add_handle (priv->concheck.curl_mhandle, ehandle);
 
-			cb_data->timeout_id = g_timeout_add_seconds (30, _timeout_cb, cb_data);
+			cb_data->timeout_id = g_timeout_add_seconds (20, _timeout_cb, cb_data);
 
 			_LOG2D ("start request to '%s'", priv->uri);
 			return cb_data;

--- a/src/nm-connectivity.h
+++ b/src/nm-connectivity.h
@@ -34,7 +34,7 @@
 #define NM_IS_CONNECTIVITY_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), NM_TYPE_CONNECTIVITY))
 #define NM_CONNECTIVITY_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS ((obj), NM_TYPE_CONNECTIVITY, NMConnectivityClass))
 
-#define NM_CONNECTIVITY_PERIODIC_CHECK  "nm-connectivity-periodic-check"
+#define NM_CONNECTIVITY_CONFIG_CHANGED  "config-changed"
 
 typedef struct _NMConnectivityClass NMConnectivityClass;
 
@@ -45,6 +45,8 @@ NMConnectivity *nm_connectivity_get (void);
 const char *nm_connectivity_state_to_string (NMConnectivityState state);
 
 gboolean nm_connectivity_check_enabled (NMConnectivity *self);
+
+guint nm_connectivity_get_interval (NMConnectivity *self);
 
 typedef struct _NMConnectivityCheckHandle NMConnectivityCheckHandle;
 

--- a/src/nm-connectivity.h
+++ b/src/nm-connectivity.h
@@ -24,6 +24,9 @@
 
 #include "nm-dbus-interface.h"
 
+#define NM_CONNECTIVITY_ERROR ((NMConnectivityState) -1)
+#define NM_CONNECTIVITY_FAKE  ((NMConnectivityState) -2)
+
 #define NM_TYPE_CONNECTIVITY            (nm_connectivity_get_type ())
 #define NM_CONNECTIVITY(obj)            (G_TYPE_CHECK_INSTANCE_CAST ((obj), NM_TYPE_CONNECTIVITY, NMConnectivity))
 #define NM_CONNECTIVITY_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST ((klass), NM_TYPE_CONNECTIVITY, NMConnectivityClass))
@@ -41,13 +44,21 @@ NMConnectivity *nm_connectivity_get (void);
 
 const char *nm_connectivity_state_to_string (NMConnectivityState state);
 
-void                 nm_connectivity_check_async  (NMConnectivity       *self,
-                                                   const char           *iface,
-                                                   GAsyncReadyCallback   callback,
-                                                   gpointer              user_data);
-NMConnectivityState  nm_connectivity_check_finish (NMConnectivity       *self,
-                                                   GAsyncResult         *result,
-                                                   GError              **error);
 gboolean nm_connectivity_check_enabled (NMConnectivity *self);
+
+typedef struct _NMConnectivityCheckHandle NMConnectivityCheckHandle;
+
+typedef void (*NMConnectivityCheckCallback) (NMConnectivity *self,
+                                             NMConnectivityCheckHandle *handle,
+                                             NMConnectivityState state,
+                                             GError *error,
+                                             gpointer user_data);
+
+NMConnectivityCheckHandle *nm_connectivity_check_start (NMConnectivity *self,
+                                                        const char *iface,
+                                                        NMConnectivityCheckCallback callback,
+                                                        gpointer user_data);
+
+void nm_connectivity_check_cancel (NMConnectivityCheckHandle *handle);
 
 #endif /* __NETWORKMANAGER_CONNECTIVITY_H__ */

--- a/src/nm-core-utils.h
+++ b/src/nm-core-utils.h
@@ -239,6 +239,13 @@ gint64 nm_utils_get_monotonic_timestamp_ms (void);
 gint32 nm_utils_get_monotonic_timestamp_s (void);
 gint64 nm_utils_monotonic_timestamp_as_boottime (gint64 timestamp, gint64 timestamp_ticks_per_ns);
 
+static inline gint64
+nm_utils_get_monotonic_timestamp_ns_cached (gint64 *cache_now)
+{
+	return    (*cache_now)
+	       ?: (*cache_now = nm_utils_get_monotonic_timestamp_ns ());
+}
+
 gboolean    nm_utils_is_valid_path_component (const char *name);
 const char *NM_ASSERT_VALID_PATH_COMPONENT (const char *name);
 

--- a/src/nm-manager.c
+++ b/src/nm-manager.c
@@ -132,10 +132,8 @@ typedef struct {
 
 	NMState state;
 	NMConfig *config;
-	NMConnectivityState connectivity_state;
-
+	NMConnectivity *concheck_mgr;
 	NMPolicy *policy;
-
 	NMHostnameManager *hostname_manager;
 
 	struct {
@@ -169,6 +167,8 @@ typedef struct {
 	guint timestamp_update_id;
 
 	guint devices_inited_id;
+
+	NMConnectivityState connectivity_state;
 
 	bool startup:1;
 	bool devices_inited:1;
@@ -330,6 +330,34 @@ static NMActiveConnection *active_connection_find_first (NMManager *self,
 static NM_CACHED_QUARK_FCN ("active-connection-add-and-activate", active_connection_add_and_activate_quark)
 
 static NM_CACHED_QUARK_FCN ("autoconnect-root", autoconnect_root_quark)
+
+/*****************************************************************************/
+
+static void
+concheck_config_changed_cb (NMConnectivity *connectivity,
+                            NMManager *self)
+{
+	NMManagerPrivate *priv = NM_MANAGER_GET_PRIVATE (self);
+	NMDevice *device;
+
+	c_list_for_each_entry (device, &priv->devices_lst_head, devices_lst)
+		nm_device_check_connectivity_update_interval (device);
+}
+
+static NMConnectivity *
+concheck_get_mgr (NMManager *self)
+{
+	NMManagerPrivate *priv = NM_MANAGER_GET_PRIVATE (self);
+
+	if (G_UNLIKELY (!priv->concheck_mgr)) {
+		priv->concheck_mgr = g_object_ref (nm_connectivity_get ());
+		g_signal_connect (priv->concheck_mgr,
+		                  NM_CONNECTIVITY_CONFIG_CHANGED,
+		                  G_CALLBACK (concheck_config_changed_cb),
+		                  self);
+	}
+	return priv->concheck_mgr;
+}
 
 /*****************************************************************************/
 
@@ -5504,10 +5532,10 @@ check_connectivity_auth_done_cb (NMAuthChain *chain,
 	data->remaining = 0;
 
 	c_list_for_each_entry (device, &priv->devices_lst_head, devices_lst) {
-		data->remaining++;
-		nm_device_check_connectivity (device,
-		                              device_connectivity_done,
-		                              data);
+		if (nm_device_check_connectivity (device,
+		                                  device_connectivity_done,
+		                                  data))
+			data->remaining++;
 	}
 
 	if (data->remaining == 0) {
@@ -6624,7 +6652,7 @@ get_property (GObject *object, guint prop_id,
 		break;
 	case PROP_CONNECTIVITY_CHECK_ENABLED:
 		g_value_set_boolean (value,
-		                     nm_connectivity_check_enabled (nm_connectivity_get ()));
+		                     nm_connectivity_check_enabled (concheck_get_mgr (self)));
 		break;
 	case PROP_PRIMARY_CONNECTION:
 		nm_dbus_utils_g_value_set_object_path (value, priv->primary_connection);
@@ -6753,6 +6781,13 @@ dispose (GObject *object)
 	nm_clear_g_source (&priv->devices_inited_id);
 
 	g_clear_pointer (&priv->checkpoint_mgr, nm_checkpoint_manager_free);
+
+	if (priv->concheck_mgr) {
+		g_signal_handlers_disconnect_by_func (priv->concheck_mgr,
+		                                      G_CALLBACK (concheck_config_changed_cb),
+		                                      self);
+		g_clear_object (&priv->concheck_mgr);
+	}
 
 	if (priv->auth_mgr) {
 		g_signal_handlers_disconnect_by_func (priv->auth_mgr,

--- a/src/tests/config/test-config.c
+++ b/src/tests/config/test-config.c
@@ -318,10 +318,10 @@ test_config_global_dns (void)
 	g_object_unref (config);
 }
 
-#if WITH_CONCHECK
 static void
 test_config_connectivity_check (void)
 {
+#if WITH_CONCHECK
 	const char *CONFIG_INTERN = BUILDDIR"/test-connectivity-check-intern.conf";
 	NMConfig *config;
 	NMConnectivity *connectivity;
@@ -351,8 +351,10 @@ test_config_connectivity_check (void)
 	g_object_unref (config);
 
 	g_assert (remove (CONFIG_INTERN) == 0);
-}
+#else
+	g_test_skip ("concheck disabled");
 #endif
+}
 
 static void
 test_config_no_auto_default (void)
@@ -1048,9 +1050,7 @@ main (int argc, char **argv)
 
 	g_test_add_func ("/config/set-values", test_config_set_values);
 	g_test_add_func ("/config/global-dns", test_config_global_dns);
-#if WITH_CONCHECK
 	g_test_add_func ("/config/connectivity-check", test_config_connectivity_check);
-#endif
 
 	g_test_add_func ("/config/signal", test_config_signal);
 


### PR DESCRIPTION
Rework of NMConnectivity.

This serves to purposes:

  - properly cancel asynchronous connectivity checks when NetworkManager is about to terminate. This is necessary if we want to cleanup and destruct all objects in a timely manner.

  - rework the API, so that it becomes simpler to schedule and cancel items. This will be useful for https://bugzilla.gnome.org/show_bug.cgi?id=792240 , where we no longer will schedule connectivity checks every 30 seconds, but after connectivity changes we will first check more frequently to better handle short outages.