### PR TITLE
systemd: make enablement of n-m-wait-online.service follow n-m.service

### DIFF
--- a/data/NetworkManager.service.in
+++ b/data/NetworkManager.service.in
@@ -27,3 +27,8 @@ WantedBy=multi-user.target
 Alias=dbus-org.freedesktop.NetworkManager.service
 Also=NetworkManager-dispatcher.service
 
+# We want to enable NetworkManager-wait-online.service whenever this service
+# is enabled. NetworkManager-wait-online.service has
+# WantedBy=network-online.target, so enabling it only has an effect if
+# network-online.target itself is enabled or pulled in by some other unit.
+Also=NetworkManager-wait-online.service


### PR DESCRIPTION
This is the approach used by systemd-networkd.  So I believe it is safe, but I haven't tested this.  You might consider this as a bug report, and if you are unable to accept it without me testing it, I can open an issue for it in the correct place.

I don't understand the logic that caused systemd-networkd to make the change -
https://github.com/systemd/systemd/commit/9e49656037717b96c06b1f1507a41550bdb2c795

Instead, I am suggesting it for consistency, and because it seems to me this is the exact correct behaviour.

Because if you enable NetworkManager, and rely on it to configure your network devices, then network mounts will not start correctly at boot time unless you also enable NetworkManager-wait-online.service.

Enabling NetworkManager-wait-online.service does not cause unnecessary serialization of the boot process; it is only pulled in if something else (like a network mount) pulls in network-online.target.

I am suggesting this in response to reading this user support request: https://unix.stackexchange.com/questions/429604/fstab-not-automatically-mounting-smb-storage