### PR TITLE
th/dbus-auth-external-bgo793116

### DIFF
--- a/src/nm-dbus-manager.c
+++ b/src/nm-dbus-manager.c
@@ -305,6 +305,14 @@ private_server_authorize (GDBusAuthObserver *observer,
 	return g_credentials_get_unix_user (credentials, NULL) == 0;
 }
 
+static gboolean
+private_server_allow_mechanism (GDBusAuthObserver *observer,
+                                const char *mechanism,
+                                gpointer user_data)
+{
+	return NM_IN_STRSET (mechanism, "EXTERNAL");
+}
+
 static void
 private_server_free (gpointer ptr)
 {
@@ -362,6 +370,8 @@ nm_dbus_manager_private_server_register (NMDBusManager *self,
 	auth_observer = g_dbus_auth_observer_new ();
 	g_signal_connect (auth_observer, "authorize-authenticated-peer",
 	                  G_CALLBACK (private_server_authorize), NULL);
+	g_signal_connect (auth_observer, "allow-mechanism",
+	                  G_CALLBACK (private_server_allow_mechanism), NULL);
 	server = g_dbus_server_new_sync (address,
 	                                 G_DBUS_SERVER_FLAGS_NONE,
 	                                 guid,


### PR DESCRIPTION
 dbus: disable all but EXTERNAL D-Bus authentication for private sockets

We use a private D-Bus socket for example for DHCP clients to report back
at unix:path=/var/run/NetworkManager/private-dhcp.

By default, gdbus will enable the authentication mechanisms EXTERNAL
and DBUS_COOKIE_SHA1. However, DBUS_COOKIE_SHA1 requires a /root/.dbus-keyrings
directory, which is not available to NetworkManager as it is started with
ProtectHome=read-only. And writing to /root would be a bad idea anyway.

This leads to a warning

  NetworkManager[10962]: Error adding entry to keyring: Error creating directory “/root/.dbus-keyrings”: Read-only file system

Disable all but the EXTERNAL mechanism.

See-also: https://dbus.freedesktop.org/doc/dbus-specification.html#auth-mechanisms

https://bugzilla.gnome.org/show_bug.cgi?id=793116