### PR TITLE
core/dbus: cache variants for D-Bus exported properties

### DIFF
--- a/src/nm-dbus-manager.h
+++ b/src/nm-dbus-manager.h
@@ -55,8 +55,6 @@ gboolean nm_dbus_manager_start (NMDBusManager *self,
 
 GDBusConnection *nm_dbus_manager_get_connection (NMDBusManager *self);
 
-NMDBusObject *nm_dbus_manager_lookup_object (NMDBusManager *self, const char *path);
-
 void _nm_dbus_manager_obj_export (NMDBusObject *obj);
 void _nm_dbus_manager_obj_unexport (NMDBusObject *obj);
 void _nm_dbus_manager_obj_notify (NMDBusObject *obj,

--- a/src/nm-dbus-utils.c
+++ b/src/nm-dbus-utils.c
@@ -35,7 +35,8 @@ const GDBusSignalInfo nm_signal_info_property_changed_legacy = NM_DEFINE_GDBUS_S
 
 GDBusPropertyInfo *
 nm_dbus_utils_interface_info_lookup_property (const GDBusInterfaceInfo *interface_info,
-                                              const char *property_name)
+                                              const char *property_name,
+                                              guint *property_idx)
 {
 	guint i;
 
@@ -48,8 +49,10 @@ nm_dbus_utils_interface_info_lookup_property (const GDBusInterfaceInfo *interfac
 		for (i = 0; interface_info->properties[i]; i++) {
 			GDBusPropertyInfo *info = interface_info->properties[i];
 
-			if (nm_streq (info->name, property_name))
+			if (nm_streq (info->name, property_name)) {
+				NM_SET_OUT (property_idx, i);
 				return info;
+			}
 		}
 	}
 

--- a/src/nm-dbus-utils.h
+++ b/src/nm-dbus-utils.h
@@ -152,7 +152,8 @@ extern const GDBusSignalInfo nm_signal_info_property_changed_legacy;
 /*****************************************************************************/
 
 GDBusPropertyInfo *nm_dbus_utils_interface_info_lookup_property (const GDBusInterfaceInfo *interface_info,
-                                                                 const char *property_name);
+                                                                 const char *property_name,
+                                                                 guint *property_idx);
 
 GDBusMethodInfo *nm_dbus_utils_interface_info_lookup_method (const GDBusInterfaceInfo *interface_info,
                                                              const char *method_name);


### PR DESCRIPTION
While the improvement is rather small, I think it is worth 41 extra lines of code.