### PR TITLE
th/auth_chain

### DIFF
--- a/shared/nm-utils/nm-c-list.h
+++ b/shared/nm-utils/nm-c-list.h
@@ -26,6 +26,13 @@
 
 /*****************************************************************************/
 
+#define nm_c_list_contains_entry(list, what, member) \
+	({ \
+		typeof (what) _what = (what); \
+		\
+		_what && c_list_contains (list, &_what->member); \
+	})
+
 typedef struct {
 	CList lst;
 	void *data;

--- a/shared/nm-utils/nm-hash-utils.c
+++ b/shared/nm-utils/nm-hash-utils.c
@@ -159,3 +159,27 @@ nm_direct_hash (gconstpointer ptr)
 {
 	return nm_hash_ptr (ptr);
 }
+
+/*****************************************************************************/
+
+guint
+nm_pstr_hash (gconstpointer p)
+{
+	const char *const*s = p;
+
+	if (!s)
+		return nm_hash_static (101061439u);
+	return nm_hash_str (*s);
+}
+
+gboolean
+nm_pstr_equal (gconstpointer a, gconstpointer b)
+{
+	const char *const*s1 = a;
+	const char *const*s2 = b;
+
+	return (s1 == s2)
+	       || (   s1
+	           && s2
+	           && nm_streq0 (*s1, *s2));
+}

--- a/shared/nm-utils/nm-hash-utils.h
+++ b/shared/nm-utils/nm-hash-utils.h
@@ -209,4 +209,15 @@ guint nm_direct_hash (gconstpointer str);
 guint nm_hash_str (const char *str);
 guint nm_str_hash (gconstpointer str);
 
+/*****************************************************************************/
+
+/* nm_pstr_*() are for hashing keys that are pointers to strings,
+ * that is, "const char *const*" types, using strcmp(). */
+
+guint nm_pstr_hash (gconstpointer p);
+
+gboolean nm_pstr_equal (gconstpointer a, gconstpointer b);
+
+/*****************************************************************************/
+
 #endif /* __NM_HASH_UTILS_H__ */

--- a/src/nm-auth-subject.c
+++ b/src/nm-auth-subject.c
@@ -102,8 +102,6 @@ nm_auth_subject_to_string (NMAuthSubject *self, char *buf, gsize buf_len)
 	return buf;
 }
 
-#if WITH_POLKIT
-
 /* returns a floating variant */
 GVariant *
 nm_auth_subject_unix_process_to_polkit_gvariant (NMAuthSubject *self)
@@ -124,8 +122,6 @@ nm_auth_subject_unix_process_to_polkit_gvariant (NMAuthSubject *self)
 	ret = g_variant_new ("(s@a{sv})", "unix-process", dict);
 	return ret;
 }
-
-#endif
 
 NMAuthSubjectType
 nm_auth_subject_get_subject_type (NMAuthSubject *subject)

--- a/src/nm-auth-subject.h
+++ b/src/nm-auth-subject.h
@@ -68,10 +68,6 @@ gulong nm_auth_subject_get_unix_process_uid (NMAuthSubject *subject);
 
 const char *nm_auth_subject_to_string (NMAuthSubject *self, char *buf, gsize buf_len);
 
-#if WITH_POLKIT
-
 GVariant *  nm_auth_subject_unix_process_to_polkit_gvariant (NMAuthSubject *self);
-
-#endif
 
 #endif /* __NETWORKMANAGER_AUTH_SUBJECT_H__ */

--- a/src/nm-auth-utils.c
+++ b/src/nm-auth-utils.c
@@ -122,8 +122,8 @@ _get_data (NMAuthChain *self, const char *tag)
 gpointer
 nm_auth_chain_get_data (NMAuthChain *self, const char *tag)
 {
-	g_return_val_if_fail (self != NULL, NULL);
-	g_return_val_if_fail (tag != NULL, NULL);
+	g_return_val_if_fail (self, NULL);
+	g_return_val_if_fail (tag, NULL);
 
 	return _get_data (self, tag);
 }
@@ -146,8 +146,8 @@ nm_auth_chain_steal_data (NMAuthChain *self, const char *tag)
 	gpointer value = NULL;
 	void *orig_key;
 
-	g_return_val_if_fail (self != NULL, NULL);
-	g_return_val_if_fail (tag != NULL, NULL);
+	g_return_val_if_fail (self, NULL);
+	g_return_val_if_fail (tag, NULL);
 
 	if (g_hash_table_lookup_extended (self->data, tag, &orig_key, (gpointer)&tmp)) {
 		g_hash_table_steal (self->data, tag);
@@ -166,8 +166,8 @@ nm_auth_chain_set_data (NMAuthChain *self,
                         gpointer data,
                         GDestroyNotify data_destroy)
 {
-	g_return_if_fail (self != NULL);
-	g_return_if_fail (tag != NULL);
+	g_return_if_fail (self);
+	g_return_if_fail (tag);
 
 	if (data == NULL)
 		g_hash_table_remove (self->data, tag);
@@ -185,8 +185,8 @@ nm_auth_chain_get_result (NMAuthChain *self, const char *permission)
 {
 	gpointer data;
 
-	g_return_val_if_fail (self != NULL, NM_AUTH_CALL_RESULT_UNKNOWN);
-	g_return_val_if_fail (permission != NULL, NM_AUTH_CALL_RESULT_UNKNOWN);
+	g_return_val_if_fail (self, NM_AUTH_CALL_RESULT_UNKNOWN);
+	g_return_val_if_fail (permission, NM_AUTH_CALL_RESULT_UNKNOWN);
 
 	data = _get_data (self, permission);
 	return data ? GPOINTER_TO_UINT (data) : NM_AUTH_CALL_RESULT_UNKNOWN;
@@ -195,7 +195,7 @@ nm_auth_chain_get_result (NMAuthChain *self, const char *permission)
 NMAuthSubject *
 nm_auth_chain_get_subject (NMAuthChain *self)
 {
-	g_return_val_if_fail (self != NULL, NULL);
+	g_return_val_if_fail (self, NULL);
 
 	return self->subject;
 }
@@ -350,7 +350,7 @@ nm_auth_chain_new_context (GDBusMethodInvocation *context,
 	NMAuthSubject *subject;
 	NMAuthChain *chain;
 
-	g_return_val_if_fail (context != NULL, NULL);
+	g_return_val_if_fail (context, NULL);
 
 	subject = nm_auth_subject_new_unix_process_from_context (context);
 	if (!subject)
@@ -435,7 +435,7 @@ nm_auth_is_subject_in_acl (NMConnection *connection,
 	const char *user = NULL;
 	gulong uid;
 
-	g_return_val_if_fail (connection != NULL, FALSE);
+	g_return_val_if_fail (connection, FALSE);
 	g_return_val_if_fail (NM_IS_AUTH_SUBJECT (subject), FALSE);
 	g_return_val_if_fail (nm_auth_subject_is_internal (subject) || nm_auth_subject_is_unix_process (subject), FALSE);
 

--- a/src/nm-auth-utils.c
+++ b/src/nm-auth-utils.c
@@ -219,33 +219,6 @@ nm_auth_chain_set_data (NMAuthChain *self,
 	}
 }
 
-gulong
-nm_auth_chain_get_data_ulong (NMAuthChain *self, const char *tag)
-{
-	gulong *data;
-
-	g_return_val_if_fail (self != NULL, 0);
-	g_return_val_if_fail (tag != NULL, 0);
-
-	data = _get_data (self, tag);
-	return data ? *data : 0ul;
-}
-
-void
-nm_auth_chain_set_data_ulong (NMAuthChain *self,
-                              const char *tag,
-                              gulong data)
-{
-	gulong *ptr;
-
-	g_return_if_fail (self != NULL);
-	g_return_if_fail (tag != NULL);
-
-	ptr = g_malloc (sizeof (*ptr));
-	*ptr = data;
-	nm_auth_chain_set_data (self, tag, ptr, g_free);
-}
-
 NMAuthSubject *
 nm_auth_chain_get_subject (NMAuthChain *self)
 {

--- a/src/nm-auth-utils.h
+++ b/src/nm-auth-utils.h
@@ -55,12 +55,6 @@ void nm_auth_chain_set_data (NMAuthChain *chain,
                              gpointer data,
                              GDestroyNotify data_destroy);
 
-void nm_auth_chain_set_data_ulong (NMAuthChain *chain,
-                                   const char *tag,
-                                   gulong data);
-
-gulong nm_auth_chain_get_data_ulong (NMAuthChain *chain, const char *tag);
-
 NMAuthCallResult nm_auth_chain_get_result (NMAuthChain *chain,
                                            const char *permission);
 


### PR DESCRIPTION
We use NMAuthChain frequently, and I always felt it to be heavier than necessary. Some refactoring, with the overall goal to require less memory allocations, both to start the auth-request, and to track the additional data.