### PR TITLE
th/fix_fake_connectivity_state

### DIFF
--- a/src/devices/nm-device.c
+++ b/src/devices/nm-device.c
@@ -180,6 +180,7 @@ enum {
 	REMOVED,
 	RECHECK_AUTO_ACTIVATE,
 	RECHECK_ASSUME,
+	CONNECTIVITY_CHANGED,
 	LAST_SIGNAL,
 };
 static guint signals[LAST_SIGNAL] = { 0 };
@@ -2457,6 +2458,7 @@ concheck_update_state (NMDevice *self, NMConnectivityState state, gboolean is_pe
 	priv->connectivity_state = state;
 
 	_notify (self, PROP_CONNECTIVITY);
+	g_signal_emit (self, signals[CONNECTIVITY_CHANGED], 0);
 
 	if (   priv->state == NM_DEVICE_STATE_ACTIVATED
 	    && !nm_device_sys_iface_state_is_external (self)) {
@@ -15743,5 +15745,13 @@ nm_device_class_init (NMDeviceClass *klass)
 	                  G_OBJECT_CLASS_TYPE (object_class),
 	                  G_SIGNAL_RUN_FIRST,
 	                  0, NULL, NULL, NULL,
+	                  G_TYPE_NONE, 0);
+
+	signals[CONNECTIVITY_CHANGED] =
+	    g_signal_new (NM_DEVICE_CONNECTIVITY_CHANGED,
+	                  G_OBJECT_CLASS_TYPE (object_class),
+	                  G_SIGNAL_RUN_FIRST,
+	                  0, NULL, NULL,
+	                  g_cclosure_marshal_VOID__VOID,
 	                  G_TYPE_NONE, 0);
 }

--- a/src/devices/nm-device.c
+++ b/src/devices/nm-device.c
@@ -2513,17 +2513,19 @@ concheck_cb (NMConnectivity *connectivity,
 	handle->c_handle = NULL;
 	self = g_object_ref (handle->self);
 
-	_LOGT (LOGD_CONCHECK, "connectivity: complete check (seq:%llu, state:%s%s%s%s)",
-	       (long long unsigned) handle->seq,
-	       nm_connectivity_state_to_string (state),
-	       NM_PRINT_FMT_QUOTED (error, ", error: ", error->message, "", ""));
-
 	if (nm_utils_error_is_cancelled (error, FALSE)) {
 		/* the only place where we nm_connectivity_check_cancel(@c_handle), is
 		 * from inside concheck_handle_event(). This is a recursive call,
 		 * nothing to do. */
+		_LOGT (LOGD_CONCHECK, "connectivity: complete check (seq:%llu, obsoleted by later request returning)",
+		       (long long unsigned) handle->seq);
 		return;
 	}
+
+	_LOGT (LOGD_CONCHECK, "connectivity: complete check (seq:%llu, state:%s%s%s%s)",
+	       (long long unsigned) handle->seq,
+	       nm_connectivity_state_to_string (state),
+	       NM_PRINT_FMT_QUOTED (error, ", error: ", error->message, "", ""));
 
 	/* we keep NMConnectivity instance alive. It cannot be disposing. */
 	nm_assert (!nm_utils_error_is_cancelled (error, TRUE));

--- a/src/devices/nm-device.c
+++ b/src/devices/nm-device.c
@@ -2499,7 +2499,8 @@ concheck_cb (NMConnectivity *connectivity,
              GError *error,
              gpointer user_data)
 {
-	gs_unref_object NMDevice *self = NULL;
+	_nm_unused gs_unref_object NMDevice *self_keep_alive = NULL;
+	NMDevice *self;
 	NMDevicePrivate *priv;
 	NMDeviceConnectivityHandle *handle;
 	NMDeviceConnectivityHandle *other_handle;
@@ -2511,7 +2512,7 @@ concheck_cb (NMConnectivity *connectivity,
 	nm_assert (NM_IS_DEVICE (handle->self));
 
 	handle->c_handle = NULL;
-	self = g_object_ref (handle->self);
+	self = handle->self;
 
 	if (nm_utils_error_is_cancelled (error, FALSE)) {
 		/* the only place where we nm_connectivity_check_cancel(@c_handle), is
@@ -2521,6 +2522,8 @@ concheck_cb (NMConnectivity *connectivity,
 		       (long long unsigned) handle->seq);
 		return;
 	}
+
+	self_keep_alive = g_object_ref (self);
 
 	_LOGT (LOGD_CONCHECK, "connectivity: complete check (seq:%llu, state:%s%s%s%s)",
 	       (long long unsigned) handle->seq,

--- a/src/devices/nm-device.h
+++ b/src/devices/nm-device.h
@@ -135,6 +135,7 @@ nm_device_state_reason_check (NMDeviceStateReason reason)
 #define NM_DEVICE_STATE_CHANGED         "state-changed"
 #define NM_DEVICE_LINK_INITIALIZED      "link-initialized"
 #define NM_DEVICE_AUTOCONNECT_ALLOWED   "autoconnect-allowed"
+#define NM_DEVICE_CONNECTIVITY_CHANGED  "connectivity-changed"
 
 #define NM_DEVICE_STATISTICS_REFRESH_RATE_MS "refresh-rate-ms"
 #define NM_DEVICE_STATISTICS_TX_BYTES        "tx-bytes"

--- a/src/nm-dispatcher.c
+++ b/src/nm-dispatcher.c
@@ -631,9 +631,7 @@ _dispatcher_call (NMDispatcherAction action,
 	if (!device_dhcp6_props)
 		device_dhcp6_props = g_variant_ref_sink (g_variant_new_array (G_VARIANT_TYPE ("{sv}"), NULL, 0));
 
-#if WITH_CONCHECK
 	connectivity_state_string = nm_connectivity_state_to_string (connectivity_state);
-#endif
 
 	/* Send the action to the dispatcher */
 	if (blocking) {

--- a/src/nm-manager.c
+++ b/src/nm-manager.c
@@ -2512,7 +2512,6 @@ device_realized (NMDevice *device,
 
 static void
 device_connectivity_changed (NMDevice *device,
-                             GParamSpec *pspec,
                              NMManager *self)
 {
 	NMManagerPrivate *priv = NM_MANAGER_GET_PRIVATE (self);
@@ -2646,7 +2645,7 @@ add_device (NMManager *self, NMDevice *device, GError **error)
 	                  G_CALLBACK (device_realized),
 	                  self);
 
-	g_signal_connect (device, "notify::" NM_DEVICE_CONNECTIVITY,
+	g_signal_connect (device, NM_DEVICE_CONNECTIVITY_CHANGED,
 	                  G_CALLBACK (device_connectivity_changed),
 	                  self);
 

--- a/src/nm-manager.c
+++ b/src/nm-manager.c
@@ -2519,11 +2519,20 @@ device_connectivity_changed (NMDevice *device,
 	NMConnectivityState state;
 	NMDevice *dev;
 
-	c_list_for_each_entry (dev, &priv->devices_lst_head, devices_lst) {
-		state = nm_device_get_connectivity_state (dev);
-		if (state > best_state)
+	best_state = nm_device_get_connectivity_state (device);
+	if (best_state < NM_CONNECTIVITY_FULL) {
+		c_list_for_each_entry (dev, &priv->devices_lst_head, devices_lst) {
+			state = nm_device_get_connectivity_state (dev);
+			if (state <= best_state)
+				continue;
 			best_state = state;
+			if (best_state >= NM_CONNECTIVITY_FULL) {
+				/* it doesn't get better than this. */
+				break;
+			}
+		}
 	}
+	nm_assert (best_state <= NM_CONNECTIVITY_FULL);
 
 	if (best_state != priv->connectivity_state) {
 		priv->connectivity_state = best_state;


### PR DESCRIPTION
Follow-up fixes for #70, which broke CI test `disable_connectivity_check`. That should be fixed now...