### PR TITLE
device: let Ethernet connection fail on supplicant timeout if no secrets are required

### DIFF
--- a/src/devices/nm-device-ethernet.c
+++ b/src/devices/nm-device-ethernet.c
@@ -671,8 +671,10 @@ handle_auth_or_fail (NMDeviceEthernet *self,
 		wired_secrets_get_secrets (self, setting_name,
 		                           NM_SECRET_AGENT_GET_SECRETS_FLAG_ALLOW_INTERACTION
 		                             | (new_secrets ? NM_SECRET_AGENT_GET_SECRETS_FLAG_REQUEST_NEW : 0));
-	} else
+	} else {
 		_LOGI (LOGD_DEVICE, "Cleared secrets, but setting didn't need any secrets.");
+		return NM_ACT_STAGE_RETURN_FAILURE;
+	}
 
 	return NM_ACT_STAGE_RETURN_POSTPONE;
 }


### PR DESCRIPTION
Without this patch an Ethernet connection attempt that encountered a supplicant
timeout was stuck in the needs-auth state even if it didn't require secrets.
This patch applies the respective WiFi behaviour also to Ethernet devices.