### PR TITLE
dhcp: don't enforce broadcast flag

### DIFF
--- a/src/dhcp/nm-dhcp-systemd.c
+++ b/src/dhcp/nm-dhcp-systemd.c
@@ -630,12 +630,6 @@ ip4_start (NMDhcpClient *client, const char *dhcp_anycast_addr, const char *last
 		goto error;
 	}
 
-	r = sd_dhcp_client_set_request_broadcast (priv->client4, true);
-	if (r < 0) {
-		_LOGW ("failed to enable broadcast mode (%d)", r);
-		goto error;
-	}
-
 	dhcp_lease_load (&lease, priv->lease_file);
 
 	if (last_ip4_address)


### PR DESCRIPTION
Requesting broadcast replies from the DHCP server can be problematic in
filtered environments like some wireless networks. Don't override the
default of using unicast. This matches the behaviour of the external DHCP
clients.