### PR TITLE
all: add support for thunderbolt networking

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3805,7 +3805,8 @@ if WITH_UDEV_DIR
 udevrulesdir = $(UDEV_DIR)/rules.d
 udevrules_DATA = \
 	data/84-nm-drivers.rules \
-	data/85-nm-unmanaged.rules
+	data/85-nm-unmanaged.rules \
+	data/90-nm-thunderbolt.rules
 endif
 
 data/server.conf: $(srcdir)/data/server.conf.in
@@ -3820,6 +3821,7 @@ EXTRA_DIST += \
 	data/org.freedesktop.NetworkManager.service.in \
 	data/84-nm-drivers.rules \
 	data/85-nm-unmanaged.rules \
+	data/90-nm-thunderbolt.rules \
 	data/server.conf.in \
 	data/meson.build
 

--- a/data/90-nm-thunderbolt.rules
+++ b/data/90-nm-thunderbolt.rules
@@ -1,0 +1,13 @@
+# Do not modify this file, it will get overwritten on updates.
+# To override or extend the rules place a file in /etc/udev/rules.d
+
+ACTION!="add", GOTO="nm_thunderbolt_end"
+
+# Load he thunderbolt-net driver if we a device of type thunderbolt_xdomain
+# is added.
+SUBSYSTEM=="thunderbolt", ENV{DEVTYPE}=="thunderbolt_xdomain", RUN{builtin}+="kmod load thunderbolt-net"
+
+# For all thunderbolt network devices, we want to enable link-local configuration
+SUBSYSTEM=="net", ENV{ID_NET_DRIVER}=="thunderbolt-net", ENV{NM_AUTO_DEFAULT_LINK_LOCAL_ONLY}="1"
+
+LABEL="nm_thunderbolt_end"

--- a/data/meson.build
+++ b/data/meson.build
@@ -50,7 +50,8 @@ endif
 if install_udev_dir
   data = files(
     '84-nm-drivers.rules',
-    '85-nm-unmanaged.rules'
+    '85-nm-unmanaged.rules',
+    '90-nm-thunderbolt.rules'
   )
 
   install_data(


### PR DESCRIPTION
First attempt to implement thunderbolt networking. Comments welcome.

Load the thunderbolt-net module if we see a host-to-host connection
and configure the resulting ethernet connection automatically to be
a link-local only one.