### PR TITLE
th/dhcp-options-sort

### DIFF
--- a/clients/cli/common.c
+++ b/clients/cli/common.c
@@ -293,7 +293,7 @@ static const NmcMetaGenericInfo *const metagen_ip6_config_group[] = {
 
 /*****************************************************************************/
 
-const NmcMetaGenericInfo *const nmc_fields_dhcp4_config[] = {
+const NmcMetaGenericInfo *const nmc_fields_dhcp_config[] = {
 	NMC_META_GENERIC ("GROUP"),    /* 0 */
 	NMC_META_GENERIC ("OPTION"),   /* 1 */
 	NULL,
@@ -306,12 +306,6 @@ const NmcMetaGenericInfo *const nmc_fields_ip6_config[] = {
 	NMC_META_GENERIC ("ROUTE"),     /* 3 */
 	NMC_META_GENERIC ("DNS"),       /* 4 */
 	NMC_META_GENERIC ("DOMAIN"),    /* 5 */
-	NULL,
-};
-
-const NmcMetaGenericInfo *const nmc_fields_dhcp6_config[] = {
-	NMC_META_GENERIC ("GROUP"),    /* 0 */
-	NMC_META_GENERIC ("OPTION"),   /* 1 */
 	NULL,
 };
 
@@ -367,19 +361,19 @@ print_ip6_config (NMIPConfig *cfg6,
 }
 
 gboolean
-print_dhcp4_config (NMDhcpConfig *dhcp4,
-                    const NmcConfig *nmc_config,
-                    const char *group_prefix,
-                    const char *one_field)
+print_dhcp_config (NMDhcpConfig *dhcp,
+                   const NmcConfig *nmc_config,
+                   const char *group_prefix,
+                   const char *one_field)
 {
 	GHashTable *table;
 	const NMMetaAbstractInfo *const*tmpl;
 	NmcOutputField *arr;
 
-	if (dhcp4 == NULL)
+	if (dhcp == NULL)
 		return FALSE;
 
-	table = nm_dhcp_config_get_options (dhcp4);
+	table = nm_dhcp_config_get_options (dhcp);
 	if (table) {
 		GHashTableIter table_iter;
 		gpointer key, value;
@@ -387,53 +381,7 @@ print_dhcp4_config (NMDhcpConfig *dhcp4,
 		int i = 0;
 		NMC_OUTPUT_DATA_DEFINE_SCOPED (out);
 
-		tmpl = (const NMMetaAbstractInfo *const*) nmc_fields_dhcp4_config;
-		out_indices = parse_output_fields (one_field,
-		                                   tmpl, FALSE, NULL, NULL);
-		arr = nmc_dup_fields_array (tmpl, NMC_OF_FLAG_FIELD_NAMES);
-		g_ptr_array_add (out.output_data, arr);
-
-		options_arr = g_new (char *, g_hash_table_size (table) + 1);
-		g_hash_table_iter_init (&table_iter, table);
-		while (g_hash_table_iter_next (&table_iter, &key, &value))
-			options_arr[i++] = g_strdup_printf ("%s = %s", (char *) key, (char *) value);
-		options_arr[i] = NULL;
-
-		arr = nmc_dup_fields_array (tmpl, NMC_OF_FLAG_SECTION_PREFIX);
-		set_val_strc (arr, 0, group_prefix);
-		set_val_arr  (arr, 1, options_arr);
-		g_ptr_array_add (out.output_data, arr);
-
-		print_data_prepare_width (out.output_data);
-		print_data (nmc_config, out_indices, NULL, 0, &out);
-
-		return TRUE;
-	}
-	return FALSE;
-}
-
-gboolean
-print_dhcp6_config (NMDhcpConfig *dhcp6,
-                    const NmcConfig *nmc_config,
-                    const char *group_prefix,
-                    const char *one_field)
-{
-	GHashTable *table;
-	const NMMetaAbstractInfo *const*tmpl;
-	NmcOutputField *arr;
-
-	if (dhcp6 == NULL)
-		return FALSE;
-
-	table = nm_dhcp_config_get_options (dhcp6);
-	if (table) {
-		GHashTableIter table_iter;
-		gpointer key, value;
-		char **options_arr = NULL;
-		int i = 0;
-		NMC_OUTPUT_DATA_DEFINE_SCOPED (out);
-
-		tmpl = (const NMMetaAbstractInfo *const*) nmc_fields_dhcp6_config;
+		tmpl = (const NMMetaAbstractInfo *const*) nmc_fields_dhcp_config;
 		out_indices = parse_output_fields (one_field,
 		                                   tmpl, FALSE, NULL, NULL);
 		arr = nmc_dup_fields_array (tmpl, NMC_OF_FLAG_FIELD_NAMES);

--- a/clients/cli/common.h
+++ b/clients/cli/common.h
@@ -27,8 +27,7 @@
 
 gboolean print_ip4_config (NMIPConfig *cfg4, const NmcConfig *nmc_config, const char *one_field);
 gboolean print_ip6_config (NMIPConfig *cfg6, const NmcConfig *nmc_config, const char *group_prefix, const char *one_field);
-gboolean print_dhcp4_config (NMDhcpConfig *dhcp4, const NmcConfig *nmc_config, const char *group_prefix, const char *one_field);
-gboolean print_dhcp6_config (NMDhcpConfig *dhcp6, const NmcConfig *nmc_config, const char *group_prefix, const char *one_field);
+gboolean print_dhcp_config (NMDhcpConfig *dhcp, const NmcConfig *nmc_config, const char *group_prefix, const char *one_field);
 
 NMConnection *nmc_find_connection (const GPtrArray *connections,
                                    const char *filter_type,
@@ -78,8 +77,7 @@ void nmc_complete_bool (const char *prefix);
 const char *nmc_error_get_simple_message (GError *error);
 
 extern const NmcMetaGenericInfo *const metagen_ip4_config[];
-extern const NmcMetaGenericInfo *const nmc_fields_dhcp4_config[];
 extern const NmcMetaGenericInfo *const nmc_fields_ip6_config[];
-extern const NmcMetaGenericInfo *const nmc_fields_dhcp6_config[];
+extern const NmcMetaGenericInfo *const nmc_fields_dhcp_config[];
 
 #endif /* NMC_COMMON_H */

--- a/clients/cli/connections.c
+++ b/clients/cli/connections.c
@@ -164,9 +164,9 @@ const NmcMetaGenericInfo *const nmc_fields_con_active_details_vpn[] = {
 const NmcMetaGenericInfo *const nmc_fields_con_active_details_groups[] = {
 	NMC_META_GENERIC_WITH_NESTED ("GENERAL", nmc_fields_con_active_details_general + 1), /* 0 */
 	NMC_META_GENERIC_WITH_NESTED ("IP4",     metagen_ip4_config),                        /* 1 */
-	NMC_META_GENERIC_WITH_NESTED ("DHCP4",   nmc_fields_dhcp4_config + 1),               /* 2 */
+	NMC_META_GENERIC_WITH_NESTED ("DHCP4",   nmc_fields_dhcp_config + 1),                /* 2 */
 	NMC_META_GENERIC_WITH_NESTED ("IP6",     nmc_fields_ip6_config + 1),                 /* 3 */
-	NMC_META_GENERIC_WITH_NESTED ("DHCP6",   nmc_fields_dhcp6_config + 1),               /* 4 */
+	NMC_META_GENERIC_WITH_NESTED ("DHCP6",   nmc_fields_dhcp_config + 1),                /* 4 */
 	NMC_META_GENERIC_WITH_NESTED ("VPN",     nmc_fields_con_active_details_vpn + 1),     /* 5 */
 	NULL,
 };
@@ -1203,7 +1203,7 @@ nmc_active_connection_details (NMActiveConnection *acon, NmCli *nmc)
 			gboolean b1 = FALSE;
 			NMDhcpConfig *dhcp4 = nm_active_connection_get_dhcp4_config (acon);
 
-			b1 = print_dhcp4_config (dhcp4, &nmc->nmc_config, "DHCP4", group_fld);
+			b1 = print_dhcp_config (dhcp4, &nmc->nmc_config, "DHCP4", group_fld);
 			was_output = was_output || b1;
 		}
 
@@ -1221,7 +1221,7 @@ nmc_active_connection_details (NMActiveConnection *acon, NmCli *nmc)
 			gboolean b1 = FALSE;
 			NMDhcpConfig *dhcp6 = nm_active_connection_get_dhcp6_config (acon);
 
-			b1 = print_dhcp6_config (dhcp6, &nmc->nmc_config, "DHCP6", group_fld);
+			b1 = print_dhcp_config (dhcp6, &nmc->nmc_config, "DHCP6", group_fld);
 			was_output = was_output || b1;
 		}
 

--- a/clients/cli/devices.c
+++ b/clients/cli/devices.c
@@ -210,9 +210,9 @@ const NmcMetaGenericInfo *const nmc_fields_dev_show_sections[] = {
 	NMC_META_GENERIC_WITH_NESTED ("WIMAX-PROPERTIES",  nmc_fields_dev_show_wimax_prop + 1),   /* 5 */
 	NMC_META_GENERIC_WITH_NESTED ("NSP",               nmc_fields_dev_wimax_list + 1),        /* 6 */
 	NMC_META_GENERIC_WITH_NESTED ("IP4",               metagen_ip4_config),                   /* 7 */
-	NMC_META_GENERIC_WITH_NESTED ("DHCP4",             nmc_fields_dhcp4_config + 1),          /* 8 */
+	NMC_META_GENERIC_WITH_NESTED ("DHCP4",             nmc_fields_dhcp_config + 1),           /* 8 */
 	NMC_META_GENERIC_WITH_NESTED ("IP6",               nmc_fields_ip6_config + 1),            /* 9 */
-	NMC_META_GENERIC_WITH_NESTED ("DHCP6",             nmc_fields_dhcp6_config + 1),          /* 10 */
+	NMC_META_GENERIC_WITH_NESTED ("DHCP6",             nmc_fields_dhcp_config + 1),           /* 10 */
 	NMC_META_GENERIC_WITH_NESTED ("BOND",              nmc_fields_dev_show_master_prop + 1),  /* 11 */
 	NMC_META_GENERIC_WITH_NESTED ("TEAM",              nmc_fields_dev_show_team_prop + 1),    /* 12 */
 	NMC_META_GENERIC_WITH_NESTED ("BRIDGE",            nmc_fields_dev_show_master_prop + 1),  /* 13 */
@@ -1329,7 +1329,7 @@ show_device_info (NMDevice *device, NmCli *nmc)
 
 		/* DHCP4 */
 		if (dhcp4 && !strcasecmp (nmc_fields_dev_show_sections[section_idx]->name, nmc_fields_dev_show_sections[8]->name))
-			was_output = print_dhcp4_config (dhcp4, &nmc->nmc_config, nmc_fields_dev_show_sections[8]->name, section_fld);
+			was_output = print_dhcp_config (dhcp4, &nmc->nmc_config, nmc_fields_dev_show_sections[8]->name, section_fld);
 
 		/* IP6 */
 		if (cfg6 && !strcasecmp (nmc_fields_dev_show_sections[section_idx]->name, nmc_fields_dev_show_sections[9]->name))
@@ -1337,7 +1337,7 @@ show_device_info (NMDevice *device, NmCli *nmc)
 
 		/* DHCP6 */
 		if (dhcp6 && !strcasecmp (nmc_fields_dev_show_sections[section_idx]->name, nmc_fields_dev_show_sections[10]->name))
-			was_output = print_dhcp6_config (dhcp6, &nmc->nmc_config, nmc_fields_dev_show_sections[10]->name, section_fld);
+			was_output = print_dhcp_config (dhcp6, &nmc->nmc_config, nmc_fields_dev_show_sections[10]->name, section_fld);
 
 		/* Bond specific information */
 		if (NM_IS_DEVICE_BOND (device)) {

--- a/clients/cli/nmcli.c
+++ b/clients/cli/nmcli.c
@@ -127,9 +127,8 @@ complete_fields (const char *option, const char *prefix)
 	h = g_hash_table_new_full (nm_str_hash, g_str_equal, g_free, NULL);
 
 	complete_field (h, metagen_ip4_config);
-	complete_field (h, nmc_fields_dhcp4_config);
+	complete_field (h, nmc_fields_dhcp_config);
 	complete_field (h, nmc_fields_ip6_config);
-	complete_field (h, nmc_fields_dhcp6_config);
 	complete_field (h, nmc_fields_con_show);
 	complete_field (h, nmc_fields_con_active_details_general);
 	complete_field (h, nmc_fields_con_active_details_vpn);

--- a/src/nm-core-utils.c
+++ b/src/nm-core-utils.c
@@ -4171,6 +4171,32 @@ nm_utils_parse_dns_domain (const char *domain, gboolean *is_routing)
 	return domain;
 }
 
+
+/*****************************************************************************/
+
+GVariant *
+nm_utils_strdict_to_variant (GHashTable *options)
+{
+	GVariantBuilder builder;
+	gs_free gs_free const char **keys = NULL;
+	guint i;
+	guint nkeys = 0;
+
+	if (options) {
+		keys = (const char **) g_hash_table_get_keys_as_array (options, &nkeys);
+		nm_utils_strv_sort (keys, nkeys);
+	}
+
+	g_variant_builder_init (&builder, G_VARIANT_TYPE ("a{sv}"));
+	for (i = 0; i < nkeys; i++) {
+		g_variant_builder_add (&builder,
+		                       "{sv}",
+		                       keys[i],
+		                       g_variant_new_string (g_hash_table_lookup (options, keys[i])));
+	}
+	return g_variant_builder_end (&builder);
+}
+
 /*****************************************************************************/
 
 NM_UTILS_ENUM2STR_DEFINE (nm_icmpv6_router_pref_to_string, NMIcmpv6RouterPref,

--- a/src/nm-core-utils.h
+++ b/src/nm-core-utils.h
@@ -432,6 +432,8 @@ gboolean nm_utils_validate_plugin (const char *path, struct stat *stat, GError *
 char **nm_utils_read_plugin_paths (const char *dirname, const char *prefix);
 char *nm_utils_format_con_diff_for_audit (GHashTable *diff);
 
+GVariant *nm_utils_strdict_to_variant (GHashTable *options);
+
 /*****************************************************************************/
 
 /* this enum is compatible with ICMPV6_ROUTER_PREF_* (from <linux/icmpv6.h>,

--- a/src/nm-dhcp4-config.c
+++ b/src/nm-dhcp4-config.c
@@ -27,6 +27,7 @@
 #include "nm-dbus-interface.h"
 #include "nm-utils.h"
 #include "nm-dbus-object.h"
+#include "nm-core-utils.h"
 
 /*****************************************************************************/
 
@@ -58,22 +59,14 @@ nm_dhcp4_config_set_options (NMDhcp4Config *self,
                              GHashTable *options)
 {
 	NMDhcp4ConfigPrivate *priv = NM_DHCP4_CONFIG_GET_PRIVATE (self);
-	GHashTableIter iter;
-	const char *key, *value;
-	GVariantBuilder builder;
+	GVariant *val;
 
 	g_return_if_fail (NM_IS_DHCP4_CONFIG (self));
-	g_return_if_fail (options != NULL);
+	g_return_if_fail (options);
 
+	val = nm_utils_strdict_to_variant (options);
 	g_variant_unref (priv->options);
-
-	g_variant_builder_init (&builder, G_VARIANT_TYPE ("a{sv}"));
-	g_hash_table_iter_init (&iter, options);
-	while (g_hash_table_iter_next (&iter, (gpointer) &key, (gpointer) &value))
-		g_variant_builder_add (&builder, "{sv}", key, g_variant_new_string (value));
-
-	priv->options = g_variant_builder_end (&builder);
-	g_variant_ref_sink (priv->options);
+	priv->options = g_variant_ref_sink (val);
 	_notify (self, PROP_OPTIONS);
 }
 

--- a/src/nm-dhcp6-config.c
+++ b/src/nm-dhcp6-config.c
@@ -27,6 +27,7 @@
 #include "nm-dbus-interface.h"
 #include "nm-utils.h"
 #include "nm-dbus-object.h"
+#include "nm-core-utils.h"
 
 /*****************************************************************************/
 
@@ -58,22 +59,14 @@ nm_dhcp6_config_set_options (NMDhcp6Config *self,
                              GHashTable *options)
 {
 	NMDhcp6ConfigPrivate *priv = NM_DHCP6_CONFIG_GET_PRIVATE (self);
-	GHashTableIter iter;
-	const char *key, *value;
-	GVariantBuilder builder;
+	GVariant *val;
 
 	g_return_if_fail (NM_IS_DHCP6_CONFIG (self));
-	g_return_if_fail (options != NULL);
+	g_return_if_fail (options);
 
+	val = nm_utils_strdict_to_variant (options);
 	g_variant_unref (priv->options);
-
-	g_variant_builder_init (&builder, G_VARIANT_TYPE ("a{sv}"));
-	g_hash_table_iter_init (&iter, options);
-	while (g_hash_table_iter_next (&iter, (gpointer) &key, (gpointer) &value))
-		g_variant_builder_add (&builder, "{sv}", key, g_variant_new_string (value));
-
-	priv->options = g_variant_builder_end (&builder);
-	g_variant_ref_sink (priv->options);
+	priv->options = g_variant_ref_sink (val);
 	_notify (self, PROP_OPTIONS);
 }
 


### PR DESCRIPTION
At several places, DHCP options are maintained in a hashtable.
Before serializing or printing them, sort them by name.