### PR TITLE
rpm: prefer python3

### DIFF
--- a/contrib/fedora/rpm/NetworkManager.spec
+++ b/contrib/fedora/rpm/NetworkManager.spec
@@ -169,8 +169,15 @@ BuildRequires: ModemManager-glib-devel >= 1.0
 BuildRequires: newt-devel
 %endif
 BuildRequires: /usr/bin/dbus-launch
+%if 0%{?fedora} > 27 || 0%{?rhel} > 7
+BuildRequires: python3
+BuildRequires: python3-gobject-base
+BuildRequires: python3-dbus
+%else
+BuildRequires: python2
 BuildRequires: pygobject3-base
 BuildRequires: dbus-python
+%endif
 BuildRequires: libselinux-devel
 BuildRequires: polkit-devel
 BuildRequires: jansson-devel

--- a/contrib/fedora/rpm/build.sh
+++ b/contrib/fedora/rpm/build.sh
@@ -210,7 +210,10 @@ ls -dla \
     "$TEMP_LATEST"/SRPMS/*.rpm \
     2>/dev/null | sed 's/^/    /'
 LOG
-if [[ "$BUILDTYPE" != "SRPM" ]]; then
+if [[ "$BUILDTYPE" == "SRPM" ]]; then
+    LOG sudo $(which dnf &>/dev/null && echo dnf builddep || echo yum-builddep) $TEMP_LATEST/SRPMS/*.src.rpm
+    LOG
+else
     LOG "sudo $(which dnf &>/dev/null && echo dnf || echo yum) install '$TEMP_LATEST/RPMS'/*/*.rpm"
     LOG
 fi


### PR DESCRIPTION
From Fedora 28 on we can build without Python 2. That is good,
because it's eventually going to be removed.

Based on a change in Fedora dist-git by Iryna Shcherbina.