### PR TITLE
lr/setting-plugin-props-cleanup: drop properties from setting plugin

### DIFF
--- a/src/settings/nm-settings-plugin.c
+++ b/src/settings/nm-settings-plugin.c
@@ -35,30 +35,6 @@ nm_settings_plugin_default_init (NMSettingsPluginInterface *g_iface)
 	if (initialized)
 		return;
 
-	/* Properties */
-	g_object_interface_install_property
-		(g_iface,
-		 g_param_spec_string (NM_SETTINGS_PLUGIN_NAME, "", "",
-		                      NULL,
-		                      G_PARAM_READABLE |
-		                      G_PARAM_STATIC_STRINGS));
-
-	g_object_interface_install_property
-		(g_iface,
-		 g_param_spec_string (NM_SETTINGS_PLUGIN_INFO, "", "",
-		                      NULL,
-		                      G_PARAM_READABLE |
-		                      G_PARAM_STATIC_STRINGS));
-
-	g_object_interface_install_property
-		(g_iface,
-		 g_param_spec_uint (NM_SETTINGS_PLUGIN_CAPABILITIES, "", "",
-		                    NM_SETTINGS_PLUGIN_CAP_NONE,
-		                    NM_SETTINGS_PLUGIN_CAP_MODIFY_CONNECTIONS,
-		                    NM_SETTINGS_PLUGIN_CAP_NONE,
-		                    G_PARAM_READABLE |
-		                    G_PARAM_STATIC_STRINGS));
-
 	/* Signals */
 	g_signal_new (NM_SETTINGS_PLUGIN_CONNECTION_ADDED,
 	              iface_type,

--- a/src/settings/nm-settings-plugin.h
+++ b/src/settings/nm-settings-plugin.h
@@ -34,30 +34,9 @@ GObject * nm_settings_plugin_factory (void);
 #define NM_IS_SETTINGS_PLUGIN(obj)            (G_TYPE_CHECK_INSTANCE_TYPE ((obj), NM_TYPE_SETTINGS_PLUGIN))
 #define NM_SETTINGS_PLUGIN_GET_INTERFACE(obj) (G_TYPE_INSTANCE_GET_INTERFACE ((obj), NM_TYPE_SETTINGS_PLUGIN, NMSettingsPluginInterface))
 
-#define NM_SETTINGS_PLUGIN_NAME "name"
-#define NM_SETTINGS_PLUGIN_INFO "info"
-#define NM_SETTINGS_PLUGIN_CAPABILITIES "capabilities"
-
 #define NM_SETTINGS_PLUGIN_UNMANAGED_SPECS_CHANGED "unmanaged-specs-changed"
 #define NM_SETTINGS_PLUGIN_UNRECOGNIZED_SPECS_CHANGED "unrecognized-specs-changed"
 #define NM_SETTINGS_PLUGIN_CONNECTION_ADDED "connection-added"
-
-typedef enum {
-	NM_SETTINGS_PLUGIN_CAP_NONE = 0x00000000,
-	NM_SETTINGS_PLUGIN_CAP_MODIFY_CONNECTIONS = 0x00000001,
-
-	/* When adding more capabilities, be sure to update the "Capabilities"
-	 * property max value in nm-settings-plugin.c.
-	 */
-} NMSettingsPluginCapabilities;
-
-typedef enum {
-	NM_SETTINGS_PLUGIN_PROP_FIRST = 0x1000,
-
-	NM_SETTINGS_PLUGIN_PROP_NAME = NM_SETTINGS_PLUGIN_PROP_FIRST,
-	NM_SETTINGS_PLUGIN_PROP_INFO,
-	NM_SETTINGS_PLUGIN_PROP_CAPABILITIES,
-} NMSettingsPluginProp;
 
 typedef struct _NMSettingsPlugin NMSettingsPlugin;
 

--- a/src/settings/nm-settings.c
+++ b/src/settings/nm-settings.c
@@ -666,6 +666,77 @@ find_plugin (GSList *list, const char *pname)
 	return obj;
 }
 
+static gboolean
+load_plugin (NMSettings *self, GSList *list, const char *pname, GError **error)
+{
+	gs_free char *full_name = NULL;
+	gs_free char *path = NULL;
+	GModule *plugin;
+	GObject * (*factory_func) (void);
+	GObject *obj;
+	struct stat st;
+	int errsv;
+
+	full_name = g_strdup_printf ("nm-settings-plugin-%s", pname);
+	path = g_module_build_path (NMPLUGINDIR, full_name);
+
+	if (stat (path, &st) != 0) {
+		errsv = errno;
+		_LOGW ("could not load plugin '%s' from file '%s': %s", pname, path, strerror (errsv));
+		return TRUE;
+	}
+	if (!S_ISREG (st.st_mode)) {
+		_LOGW ("could not load plugin '%s' from file '%s': not a file", pname, path);
+		return TRUE;
+	}
+	if (st.st_uid != 0) {
+		_LOGW ("could not load plugin '%s' from file '%s': file must be owned by root", pname, path);
+		return TRUE;
+	}
+	if (st.st_mode & (S_IWGRP | S_IWOTH | S_ISUID)) {
+		_LOGW ("could not load plugin '%s' from file '%s': invalid file permissions", pname, path);
+		return TRUE;
+	}
+
+	plugin = g_module_open (path, G_MODULE_BIND_LOCAL);
+	if (!plugin) {
+		_LOGW ("could not load plugin '%s' from file '%s': %s",
+		     pname, path, g_module_error ());
+		return TRUE;
+	}
+
+	/* errors after this point are fatal, because we loaded the shared library already. */
+
+	if (!g_module_symbol (plugin, "nm_settings_plugin_factory", (gpointer) (&factory_func))) {
+		g_set_error (error, NM_SETTINGS_ERROR, NM_SETTINGS_ERROR_FAILED,
+		             "Could not find plugin '%s' factory function.",
+		             pname);
+		g_module_close (plugin);
+		return FALSE;
+	}
+
+	/* after accessing the plugin we cannot unload it anymore, because the glib
+	 * types cannot be properly unregistered. */
+	g_module_make_resident (plugin);
+
+	obj = (*factory_func) ();
+	if (!obj || !NM_IS_SETTINGS_PLUGIN (obj)) {
+		g_set_error (error, NM_SETTINGS_ERROR, NM_SETTINGS_ERROR_FAILED,
+		             "Plugin '%s' returned invalid system config object.",
+		             pname);
+		return FALSE;
+	}
+
+	g_object_set_qdata_full (obj, plugin_module_path_quark (), path, g_free);
+	path = NULL;
+	if (add_plugin (self, NM_SETTINGS_PLUGIN (obj)))
+		list = g_slist_append (list, obj);
+	else
+		g_object_unref (obj);
+
+	return TRUE;
+}
+
 static void
 add_keyfile_plugin (NMSettings *self)
 {
@@ -696,7 +767,6 @@ load_plugins (NMSettings *self, const char **plugins, GError **error)
 
 	for (iter = plugins; iter && *iter; iter++) {
 		const char *pname = *iter;
-		GObject *obj;
 
 		if (!*pname || strchr (pname, '/')) {
 			_LOGW ("ignore invalid plugin \"%s\"", pname);
@@ -731,83 +801,21 @@ load_plugins (NMSettings *self, const char **plugins, GError **error)
 		}
 
 		if (find_plugin (list, pname))
-			continue;
+			return TRUE;
 
-load_plugin:
-		{
-			GModule *plugin;
-			gs_free char *full_name = NULL;
-			gs_free char *path = NULL;
-			GObject * (*factory_func) (void);
-			struct stat st;
-			int errsv;
+		success = load_plugin (self, list, pname, error);
+		if (!success)
+			break;
 
-			full_name = g_strdup_printf ("nm-settings-plugin-%s", pname);
-			path = g_module_build_path (NMPLUGINDIR, full_name);
-
-			if (stat (path, &st) != 0) {
-				errsv = errno;
-				_LOGW ("could not load plugin '%s' from file '%s': %s", pname, path, strerror (errsv));
-				goto next;
-			}
-			if (!S_ISREG (st.st_mode)) {
-				_LOGW ("could not load plugin '%s' from file '%s': not a file", pname, path);
-				goto next;
-			}
-			if (st.st_uid != 0) {
-				_LOGW ("could not load plugin '%s' from file '%s': file must be owned by root", pname, path);
-				goto next;
-			}
-			if (st.st_mode & (S_IWGRP | S_IWOTH | S_ISUID)) {
-				_LOGW ("could not load plugin '%s' from file '%s': invalid file permissions", pname, path);
-				goto next;
-			}
-
-			plugin = g_module_open (path, G_MODULE_BIND_LOCAL);
-			if (!plugin) {
-				_LOGW ("could not load plugin '%s' from file '%s': %s",
-				     pname, path, g_module_error ());
-				goto next;
-			}
-
-			/* errors after this point are fatal, because we loaded the shared library already. */
-
-			if (!g_module_symbol (plugin, "nm_settings_plugin_factory", (gpointer) (&factory_func))) {
-				g_set_error (error, NM_SETTINGS_ERROR, NM_SETTINGS_ERROR_FAILED,
-				             "Could not find plugin '%s' factory function.",
-				             pname);
-				success = FALSE;
-				g_module_close (plugin);
-				break;
-			}
-
-			/* after accessing the plugin we cannot unload it anymore, because the glib
-			 * types cannot be properly unregistered. */
-			g_module_make_resident (plugin);
-
-			obj = (*factory_func) ();
-			if (!obj || !NM_IS_SETTINGS_PLUGIN (obj)) {
-				g_set_error (error, NM_SETTINGS_ERROR, NM_SETTINGS_ERROR_FAILED,
-				             "Plugin '%s' returned invalid system config object.",
-				             pname);
-				success = FALSE;
-				break;
-			}
-
-			g_object_set_qdata_full (obj, plugin_module_path_quark (), path, g_free);
-			path = NULL;
-			if (add_plugin (self, NM_SETTINGS_PLUGIN (obj)))
-				list = g_slist_append (list, obj);
-			else
-				g_object_unref (obj);
-		}
-next:
 		if (add_ibft && !strcmp (pname, "ifcfg-rh")) {
 			/* The plugin ibft is not explicitly mentioned but we just enabled "ifcfg-rh".
 			 * Enable "ibft" by default after "ifcfg-rh". */
 			pname = "ibft";
 			add_ibft = FALSE;
-			goto load_plugin;
+
+			success = load_plugin (self, list, "ibft", error);
+			if (!success)
+				break;
 		}
 	}
 

--- a/src/settings/nm-settings.c
+++ b/src/settings/nm-settings.c
@@ -526,7 +526,7 @@ nm_settings_get_unmanaged_specs (NMSettings *self)
 }
 
 static NMSettingsPlugin *
-get_plugin (NMSettings *self, NMSettingsPluginCapabilities capability)
+get_plugin (NMSettings *self, gboolean has_add_connection)
 {
 	NMSettingsPrivate *priv = NM_SETTINGS_GET_PRIVATE (self);
 	GSList *iter;
@@ -535,11 +535,13 @@ get_plugin (NMSettings *self, NMSettingsPluginCapabilities capability)
 
 	/* Do any of the plugins support the given capability? */
 	for (iter = priv->plugins; iter; iter = iter->next) {
-		NMSettingsPluginCapabilities caps = NM_SETTINGS_PLUGIN_CAP_NONE;
+		NMSettingsPlugin *plugin = NM_SETTINGS_PLUGIN (iter->data);
 
-		g_object_get (G_OBJECT (iter->data), NM_SETTINGS_PLUGIN_CAPABILITIES, &caps, NULL);
-		if (NM_FLAGS_ALL (caps, capability))
-			return NM_SETTINGS_PLUGIN (iter->data);
+		if (!has_add_connection)
+			return plugin;
+
+		if (NM_SETTINGS_PLUGIN_GET_INTERFACE (iter->data)->add_connection != NULL)
+			return plugin;
 	}
 
 	return NULL;
@@ -1275,7 +1277,7 @@ nm_settings_add_connection_dbus (NMSettings *self,
 	}
 
 	/* Do any of the plugins support adding? */
-	if (!get_plugin (self, NM_SETTINGS_PLUGIN_CAP_MODIFY_CONNECTIONS)) {
+	if (!get_plugin (self, TRUE)) {
 		error = g_error_new_literal (NM_SETTINGS_ERROR,
 		                             NM_SETTINGS_ERROR_NOT_SUPPORTED,
 		                             "None of the registered plugins support add.");
@@ -1859,7 +1861,7 @@ get_property (GObject *object, guint prop_id,
 		                      : NULL);
 		break;
 	case PROP_CAN_MODIFY:
-		g_value_set_boolean (value, !!get_plugin (self, NM_SETTINGS_PLUGIN_CAP_MODIFY_CONNECTIONS));
+		g_value_set_boolean (value, !!get_plugin (self, TRUE));
 		break;
 	case PROP_CONNECTIONS:
 		if (priv->connections_loaded) {

--- a/src/settings/nm-settings.c
+++ b/src/settings/nm-settings.c
@@ -609,8 +609,6 @@ static gboolean
 add_plugin (NMSettings *self, NMSettingsPlugin *plugin)
 {
 	NMSettingsPrivate *priv;
-	char *pname = NULL;
-	char *pinfo = NULL;
 	const char *path;
 
 	g_return_val_if_fail (NM_IS_SETTINGS (self), FALSE);
@@ -626,17 +624,10 @@ add_plugin (NMSettings *self, NMSettingsPlugin *plugin)
 	priv->plugins = g_slist_append (priv->plugins, g_object_ref (plugin));
 	nm_settings_plugin_init (plugin);
 
-	g_object_get (G_OBJECT (plugin),
-	              NM_SETTINGS_PLUGIN_NAME, &pname,
-	              NM_SETTINGS_PLUGIN_INFO, &pinfo,
-	              NULL);
 
 	path = g_object_get_qdata (G_OBJECT (plugin), plugin_module_path_quark ());
 
-	_LOGI ("loaded plugin %s: %s%s%s%s", pname, pinfo,
-	       NM_PRINT_FMT_QUOTED (path, " (", path, ")", ""));
-	g_free (pname);
-	g_free (pinfo);
+	_LOGI ("Loaded settings plugin: %s (%s)", G_OBJECT_TYPE_NAME (plugin), path ?: "internal");
 
 	return TRUE;
 }

--- a/src/settings/plugins/ibft/nms-ibft-plugin.c
+++ b/src/settings/plugins/ibft/nms-ibft-plugin.c
@@ -121,28 +121,6 @@ get_connections (NMSettingsPlugin *config)
 /*****************************************************************************/
 
 static void
-get_property (GObject *object, guint prop_id,
-              GValue *value, GParamSpec *pspec)
-{
-	switch (prop_id) {
-	case NM_SETTINGS_PLUGIN_PROP_NAME:
-		g_value_set_string (value, "iBFT");
-		break;
-	case NM_SETTINGS_PLUGIN_PROP_INFO:
-		g_value_set_string (value, "(c) 2014 Red Hat, Inc.  To report bugs please use the NetworkManager mailing list.");
-		break;
-	case NM_SETTINGS_PLUGIN_PROP_CAPABILITIES:
-		g_value_set_uint (value, NM_SETTINGS_PLUGIN_CAP_NONE);
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
-}
-
-/*****************************************************************************/
-
-static void
 init (NMSettingsPlugin *config)
 {
 }
@@ -175,19 +153,6 @@ nms_ibft_plugin_class_init (NMSIbftPluginClass *req_class)
 	GObjectClass *object_class = G_OBJECT_CLASS (req_class);
 
 	object_class->dispose = dispose;
-	object_class->get_property = get_property;
-
-	g_object_class_override_property (object_class,
-	                                  NM_SETTINGS_PLUGIN_PROP_NAME,
-	                                  NM_SETTINGS_PLUGIN_NAME);
-
-	g_object_class_override_property (object_class,
-	                                  NM_SETTINGS_PLUGIN_PROP_INFO,
-	                                  NM_SETTINGS_PLUGIN_INFO);
-
-	g_object_class_override_property (object_class,
-	                                  NM_SETTINGS_PLUGIN_PROP_CAPABILITIES,
-	                                  NM_SETTINGS_PLUGIN_CAPABILITIES);
 }
 
 static void

--- a/src/settings/plugins/ifcfg-rh/nms-ifcfg-rh-common.h
+++ b/src/settings/plugins/ifcfg-rh/nms-ifcfg-rh-common.h
@@ -38,9 +38,6 @@
 
 #define IFCFG_DIR SYSCONFDIR "/sysconfig/network-scripts"
 
-#define IFCFG_PLUGIN_NAME "ifcfg-rh"
-#define IFCFG_PLUGIN_INFO "(c) 2007 - 2015 Red Hat, Inc.  To report bugs please use the NetworkManager mailing list."
-
 #define TYPE_ETHERNET   "Ethernet"
 #define TYPE_WIRELESS   "Wireless"
 #define TYPE_INFINIBAND "InfiniBand"

--- a/src/settings/plugins/ifcfg-rh/nms-ifcfg-rh-plugin.c
+++ b/src/settings/plugins/ifcfg-rh/nms-ifcfg-rh-plugin.c
@@ -998,28 +998,6 @@ config_changed_cb (NMConfig *config,
 /*****************************************************************************/
 
 static void
-get_property (GObject *object, guint prop_id,
-              GValue *value, GParamSpec *pspec)
-{
-	switch (prop_id) {
-	case NM_SETTINGS_PLUGIN_PROP_NAME:
-		g_value_set_string (value, IFCFG_PLUGIN_NAME);
-		break;
-	case NM_SETTINGS_PLUGIN_PROP_INFO:
-		g_value_set_string (value, IFCFG_PLUGIN_INFO);
-		break;
-	case NM_SETTINGS_PLUGIN_PROP_CAPABILITIES:
-		g_value_set_uint (value, NM_SETTINGS_PLUGIN_CAP_MODIFY_CONNECTIONS);
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
-}
-
-/*****************************************************************************/
-
-static void
 init (NMSettingsPlugin *config)
 {
 }
@@ -1087,19 +1065,6 @@ settings_plugin_ifcfg_class_init (SettingsPluginIfcfgClass *req_class)
 
 	object_class->constructed = constructed;
 	object_class->dispose = dispose;
-	object_class->get_property = get_property;
-
-	g_object_class_override_property (object_class,
-	                                  NM_SETTINGS_PLUGIN_PROP_NAME,
-	                                  NM_SETTINGS_PLUGIN_NAME);
-
-	g_object_class_override_property (object_class,
-	                                  NM_SETTINGS_PLUGIN_PROP_INFO,
-	                                  NM_SETTINGS_PLUGIN_INFO);
-
-	g_object_class_override_property (object_class,
-	                                  NM_SETTINGS_PLUGIN_PROP_CAPABILITIES,
-	                                  NM_SETTINGS_PLUGIN_CAPABILITIES);
 }
 
 static void

--- a/src/settings/plugins/ifupdown/nms-ifupdown-plugin.c
+++ b/src/settings/plugins/ifupdown/nms-ifupdown-plugin.c
@@ -50,9 +50,6 @@
 
 #define ENI_INTERFACES_FILE "/etc/network/interfaces"
 
-#define IFUPDOWN_PLUGIN_NAME "ifupdown"
-#define IFUPDOWN_PLUGIN_INFO "(C) 2008 Canonical Ltd.  To report bugs please use the NetworkManager mailing list."
-
 #define IFUPDOWN_UNMANAGE_WELL_KNOWN_DEFAULT TRUE
 
 /* #define ALWAYS_UNMANAGE TRUE */
@@ -303,28 +300,6 @@ get_unmanaged_specs (NMSettingsPlugin *config)
 /*****************************************************************************/
 
 static void
-get_property (GObject *object, guint prop_id,
-              GValue *value, GParamSpec *pspec)
-{
-	switch (prop_id) {
-	case NM_SETTINGS_PLUGIN_PROP_NAME:
-		g_value_set_string (value, IFUPDOWN_PLUGIN_NAME);
-		break;
-	case NM_SETTINGS_PLUGIN_PROP_INFO:
-		g_value_set_string (value, IFUPDOWN_PLUGIN_INFO);
-		break;
-	case NM_SETTINGS_PLUGIN_PROP_CAPABILITIES:
-		g_value_set_uint (value, NM_SETTINGS_PLUGIN_CAP_NONE);
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
-}
-
-/*****************************************************************************/
-
-static void
 _udev_device_unref (gpointer ptr)
 {
 	udev_device_unref (ptr);
@@ -513,19 +488,6 @@ settings_plugin_ifupdown_class_init (SettingsPluginIfupdownClass *req_class)
 	GObjectClass *object_class = G_OBJECT_CLASS (req_class);
 
 	object_class->dispose = dispose;
-	object_class->get_property = get_property;
-
-	g_object_class_override_property (object_class,
-	                                  NM_SETTINGS_PLUGIN_PROP_NAME,
-	                                  NM_SETTINGS_PLUGIN_NAME);
-
-	g_object_class_override_property (object_class,
-	                                  NM_SETTINGS_PLUGIN_PROP_INFO,
-	                                  NM_SETTINGS_PLUGIN_INFO);
-
-	g_object_class_override_property (object_class,
-	                                  NM_SETTINGS_PLUGIN_PROP_CAPABILITIES,
-	                                  NM_SETTINGS_PLUGIN_CAPABILITIES);
 }
 
 static void

--- a/src/settings/plugins/keyfile/nms-keyfile-plugin.c
+++ b/src/settings/plugins/keyfile/nms-keyfile-plugin.c
@@ -562,28 +562,6 @@ get_unmanaged_specs (NMSettingsPlugin *config)
 /*****************************************************************************/
 
 static void
-get_property (GObject *object, guint prop_id,
-            GValue *value, GParamSpec *pspec)
-{
-	switch (prop_id) {
-	case NM_SETTINGS_PLUGIN_PROP_NAME:
-		g_value_set_string (value, NMS_KEYFILE_PLUGIN_NAME);
-		break;
-	case NM_SETTINGS_PLUGIN_PROP_INFO:
-		g_value_set_string (value, NMS_KEYFILE_PLUGIN_INFO);
-		break;
-	case NM_SETTINGS_PLUGIN_PROP_CAPABILITIES:
-		g_value_set_uint (value, NM_SETTINGS_PLUGIN_CAP_MODIFY_CONNECTIONS);
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
-}
-
-/*****************************************************************************/
-
-static void
 nms_keyfile_plugin_init (NMSKeyfilePlugin *plugin)
 {
 	NMSKeyfilePluginPrivate *priv = NMS_KEYFILE_PLUGIN_GET_PRIVATE (plugin);
@@ -644,19 +622,6 @@ nms_keyfile_plugin_class_init (NMSKeyfilePluginClass *req_class)
 
 	object_class->constructed = constructed;
 	object_class->dispose = dispose;
-	object_class->get_property = get_property;
-
-	g_object_class_override_property (object_class,
-	                                  NM_SETTINGS_PLUGIN_PROP_NAME,
-	                                  NM_SETTINGS_PLUGIN_NAME);
-
-	g_object_class_override_property (object_class,
-	                                  NM_SETTINGS_PLUGIN_PROP_INFO,
-	                                  NM_SETTINGS_PLUGIN_INFO);
-
-	g_object_class_override_property (object_class,
-	                                  NM_SETTINGS_PLUGIN_PROP_CAPABILITIES,
-	                                  NM_SETTINGS_PLUGIN_CAPABILITIES);
 }
 
 static void

--- a/src/settings/plugins/keyfile/nms-keyfile-utils.h
+++ b/src/settings/plugins/keyfile/nms-keyfile-utils.h
@@ -23,9 +23,6 @@
 
 #include "NetworkManagerUtils.h"
 
-#define NMS_KEYFILE_PLUGIN_NAME "keyfile"
-#define NMS_KEYFILE_PLUGIN_INFO "(c) 2007 - 2016 Red Hat, Inc.  To report bugs please use the NetworkManager mailing list."
-
 #define NMS_KEYFILE_CONNECTION_LOG_PATH(path)  ((path) ?: "in-memory")
 #define NMS_KEYFILE_CONNECTION_LOG_FMT         "%s (%s,\"%s\")"
 #define NMS_KEYFILE_CONNECTION_LOG_ARG(con)    NMS_KEYFILE_CONNECTION_LOG_PATH (nm_settings_connection_get_filename ((NMSettingsConnection *) (con))), nm_connection_get_uuid ((NMConnection *) (con)), nm_connection_get_id ((NMConnection *) (con))


### PR DESCRIPTION
The initial motivation was to get rid of the ugly logging on a plugin load. Turns out all of the properties are straight out useless. This saves quite some line noise.