### PR TITLE
th/dns-rc-manager-file-always-follow

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -29,6 +29,8 @@ Notable changes included in this snapshot so far include:
   documentation. This represents a change in behavior since previous
   versions where the first character of the string was used as
   type. The internal client is not affected by the change.
+* DNS setting rc-manager=file now always follows dangling symlinks
+  instead of replacing /etc/resolv.conf with a plain file.
 
 The following features were backported to 1.10.x releases from 1.10.0 to
 1.10.8 are also present in NetworkManager-1.12:

--- a/man/NetworkManager.conf.xml
+++ b/man/NetworkManager.conf.xml
@@ -367,8 +367,10 @@ no-auto-default=*
         <para><literal>file</literal>: NetworkManager will write
         <filename>/etc/resolv.conf</filename> as file. If it finds
         a symlink to an existing target, it will follow the symlink and
-        update the target instead. If the symlink's target does not exist,
-        the symlink will be replaced by a file.</para>
+        update the target instead. In no case will an existing symlink
+        be replaced by a file. Note that older versions of NetworkManager
+        behaved differently and would replace dangling symlinks with a
+        plain file.</para>
         <para><literal>resolvconf</literal>: NetworkManager will run
         resolvconf to update the DNS configuration.</para>
         <para><literal>netconfig</literal>: NetworkManager will run


### PR DESCRIPTION
dns: change main.rc-manager=file behavior to always follow symlink

With "main.rc-manager=file", if /etc/resolv.conf is a symlink, NetworkManager
would follow the symlink and update the file instead.

However, note that realpath() only returns a target, if the file actually
exists. That means, if /etc/resolv.conf is a dangling symlink, NetworkManager
would replace the symlink with a file.

This was the only case in which NetworkManager would every change a symlink
resolv.conf to a file. I think this is undesired behavior.

This is a change in long established behavior. Although note that there were several
changes regarding rc-manager settings in the past. See for example commit [1] and [2].

Now, first still try using realpath() as before. Only if that fails, try
to resolve /etc/resolv.conf as a symlink with readlink().

Following the dangling symlink is likely not a problem for the user, it
probably is even desired. The part that most likely can cause problems
is if the destination file is not writable. That happens for example, if
the destination's parent directories are missing. In this case, NetworkManager
will now fail to write resolv.conf and log a warning. This has the potential of
breaking existing setups, but it really is a mis-configuration from the user's
side.

[1] 718fd2243690b8c72dd1cb32f67114f304542082
[2] 15177a34be297654086005f2d796e6a4c6a1b918