### PR TITLE
th/clients-tests

### DIFF
--- a/clients/tests/test-client.check-on-disk/Makefile.am
+++ b/clients/tests/test-client.check-on-disk/Makefile.am
@@ -152,4 +152,25 @@ clients_tests_expected_files = \
 	clients/tests/test-client.check-on-disk/test_004-007.expected \
 	clients/tests/test-client.check-on-disk/test_004-008.expected \
 	clients/tests/test-client.check-on-disk/test_004-009.expected \
+	clients/tests/test-client.check-on-disk/test_004-010.expected \
+	clients/tests/test-client.check-on-disk/test_004-011.expected \
+	clients/tests/test-client.check-on-disk/test_004-012.expected \
+	clients/tests/test-client.check-on-disk/test_004-013.expected \
+	clients/tests/test-client.check-on-disk/test_004-014.expected \
+	clients/tests/test-client.check-on-disk/test_004-015.expected \
+	clients/tests/test-client.check-on-disk/test_004-016.expected \
+	clients/tests/test-client.check-on-disk/test_004-017.expected \
+	clients/tests/test-client.check-on-disk/test_004-018.expected \
+	clients/tests/test-client.check-on-disk/test_004-019.expected \
+	clients/tests/test-client.check-on-disk/test_004-020.expected \
+	clients/tests/test-client.check-on-disk/test_004-021.expected \
+	clients/tests/test-client.check-on-disk/test_004-022.expected \
+	clients/tests/test-client.check-on-disk/test_004-023.expected \
+	clients/tests/test-client.check-on-disk/test_004-024.expected \
+	clients/tests/test-client.check-on-disk/test_004-025.expected \
+	clients/tests/test-client.check-on-disk/test_004-026.expected \
+	clients/tests/test-client.check-on-disk/test_004-027.expected \
+	clients/tests/test-client.check-on-disk/test_004-028.expected \
+	clients/tests/test-client.check-on-disk/test_004-029.expected \
+	clients/tests/test-client.check-on-disk/test_004-030.expected \
 	$(NULL)

--- a/clients/tests/test-client.check-on-disk/Makefile.am
+++ b/clients/tests/test-client.check-on-disk/Makefile.am
@@ -149,4 +149,7 @@ clients_tests_expected_files = \
 	clients/tests/test-client.check-on-disk/test_004-004.expected \
 	clients/tests/test-client.check-on-disk/test_004-005.expected \
 	clients/tests/test-client.check-on-disk/test_004-006.expected \
+	clients/tests/test-client.check-on-disk/test_004-007.expected \
+	clients/tests/test-client.check-on-disk/test_004-008.expected \
+	clients/tests/test-client.check-on-disk/test_004-009.expected \
 	$(NULL)

--- a/clients/tests/test-client.check-on-disk/test_001-001.expected
+++ b/clients/tests/test-client.check-on-disk/test_001-001.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:651:test_001()/1
+location: clients/tests/test-client.py:656:test_001()/1
 cmd: $NMCLI 
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_001-002.expected
+++ b/clients/tests/test-client.check-on-disk/test_001-002.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:651:test_001()/2
+location: clients/tests/test-client.py:656:test_001()/2
 cmd: $NMCLI 
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_001-003.expected
+++ b/clients/tests/test-client.check-on-disk/test_001-003.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:653:test_001()/3
+location: clients/tests/test-client.py:658:test_001()/3
 cmd: $NMCLI -f AP -mode multiline -p d show wlan0
 lang: C
 returncode: 10

--- a/clients/tests/test-client.check-on-disk/test_001-004.expected
+++ b/clients/tests/test-client.check-on-disk/test_001-004.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:653:test_001()/4
+location: clients/tests/test-client.py:658:test_001()/4
 cmd: $NMCLI -f AP -mode multiline -p d show wlan0
 lang: pl_PL.UTF-8
 returncode: 10

--- a/clients/tests/test-client.check-on-disk/test_001-005.expected
+++ b/clients/tests/test-client.check-on-disk/test_001-005.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:655:test_001()/5
+location: clients/tests/test-client.py:660:test_001()/5
 cmd: $NMCLI c s
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_001-006.expected
+++ b/clients/tests/test-client.check-on-disk/test_001-006.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:655:test_001()/6
+location: clients/tests/test-client.py:660:test_001()/6
 cmd: $NMCLI c s
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_001-007.expected
+++ b/clients/tests/test-client.check-on-disk/test_001-007.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:657:test_001()/7
+location: clients/tests/test-client.py:662:test_001()/7
 cmd: $NMCLI bogus s
 lang: C
 returncode: 2

--- a/clients/tests/test-client.check-on-disk/test_001-008.expected
+++ b/clients/tests/test-client.check-on-disk/test_001-008.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:657:test_001()/8
+location: clients/tests/test-client.py:662:test_001()/8
 cmd: $NMCLI bogus s
 lang: pl_PL.UTF-8
 returncode: 2

--- a/clients/tests/test-client.check-on-disk/test_001-009.expected
+++ b/clients/tests/test-client.check-on-disk/test_001-009.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:665:test_001()/9
+location: clients/tests/test-client.py:670:test_001()/9
 cmd: $NMCLI general permissions
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_001-010.expected
+++ b/clients/tests/test-client.check-on-disk/test_001-010.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:665:test_001()/10
+location: clients/tests/test-client.py:670:test_001()/10
 cmd: $NMCLI general permissions
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_001-011.expected
+++ b/clients/tests/test-client.check-on-disk/test_001-011.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:665:test_001()/11
+location: clients/tests/test-client.py:670:test_001()/11
 cmd: $NMCLI --pretty general permissions
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_001-012.expected
+++ b/clients/tests/test-client.check-on-disk/test_001-012.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:665:test_001()/12
+location: clients/tests/test-client.py:670:test_001()/12
 cmd: $NMCLI --pretty general permissions
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_001-013.expected
+++ b/clients/tests/test-client.check-on-disk/test_001-013.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:665:test_001()/13
+location: clients/tests/test-client.py:670:test_001()/13
 cmd: $NMCLI --terse general permissions
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_001-014.expected
+++ b/clients/tests/test-client.check-on-disk/test_001-014.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:665:test_001()/14
+location: clients/tests/test-client.py:670:test_001()/14
 cmd: $NMCLI --terse general permissions
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_001-015.expected
+++ b/clients/tests/test-client.check-on-disk/test_001-015.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:665:test_001()/15
+location: clients/tests/test-client.py:670:test_001()/15
 cmd: $NMCLI --mode tabular general permissions
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_001-016.expected
+++ b/clients/tests/test-client.check-on-disk/test_001-016.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:665:test_001()/16
+location: clients/tests/test-client.py:670:test_001()/16
 cmd: $NMCLI --mode tabular general permissions
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_001-017.expected
+++ b/clients/tests/test-client.check-on-disk/test_001-017.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:665:test_001()/17
+location: clients/tests/test-client.py:670:test_001()/17
 cmd: $NMCLI --mode tabular --pretty general permissions
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_001-018.expected
+++ b/clients/tests/test-client.check-on-disk/test_001-018.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:665:test_001()/18
+location: clients/tests/test-client.py:670:test_001()/18
 cmd: $NMCLI --mode tabular --pretty general permissions
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_001-019.expected
+++ b/clients/tests/test-client.check-on-disk/test_001-019.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:665:test_001()/19
+location: clients/tests/test-client.py:670:test_001()/19
 cmd: $NMCLI --mode tabular --terse general permissions
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_001-020.expected
+++ b/clients/tests/test-client.check-on-disk/test_001-020.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:665:test_001()/20
+location: clients/tests/test-client.py:670:test_001()/20
 cmd: $NMCLI --mode tabular --terse general permissions
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_001-021.expected
+++ b/clients/tests/test-client.check-on-disk/test_001-021.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:665:test_001()/21
+location: clients/tests/test-client.py:670:test_001()/21
 cmd: $NMCLI --mode multiline general permissions
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_001-022.expected
+++ b/clients/tests/test-client.check-on-disk/test_001-022.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:665:test_001()/22
+location: clients/tests/test-client.py:670:test_001()/22
 cmd: $NMCLI --mode multiline general permissions
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_001-023.expected
+++ b/clients/tests/test-client.check-on-disk/test_001-023.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:665:test_001()/23
+location: clients/tests/test-client.py:670:test_001()/23
 cmd: $NMCLI --mode multiline --pretty general permissions
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_001-024.expected
+++ b/clients/tests/test-client.check-on-disk/test_001-024.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:665:test_001()/24
+location: clients/tests/test-client.py:670:test_001()/24
 cmd: $NMCLI --mode multiline --pretty general permissions
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_001-025.expected
+++ b/clients/tests/test-client.check-on-disk/test_001-025.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:665:test_001()/25
+location: clients/tests/test-client.py:670:test_001()/25
 cmd: $NMCLI --mode multiline --terse general permissions
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_001-026.expected
+++ b/clients/tests/test-client.check-on-disk/test_001-026.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:665:test_001()/26
+location: clients/tests/test-client.py:670:test_001()/26
 cmd: $NMCLI --mode multiline --terse general permissions
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_002-001.expected
+++ b/clients/tests/test-client.check-on-disk/test_002-001.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:670:test_002()/1
+location: clients/tests/test-client.py:675:test_002()/1
 cmd: $NMCLI d
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_002-002.expected
+++ b/clients/tests/test-client.check-on-disk/test_002-002.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:670:test_002()/2
+location: clients/tests/test-client.py:675:test_002()/2
 cmd: $NMCLI d
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_002-003.expected
+++ b/clients/tests/test-client.check-on-disk/test_002-003.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:672:test_002()/3
+location: clients/tests/test-client.py:677:test_002()/3
 cmd: $NMCLI -f all d
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_002-004.expected
+++ b/clients/tests/test-client.check-on-disk/test_002-004.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:672:test_002()/4
+location: clients/tests/test-client.py:677:test_002()/4
 cmd: $NMCLI -f all d
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_002-005.expected
+++ b/clients/tests/test-client.check-on-disk/test_002-005.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:674:test_002()/5
+location: clients/tests/test-client.py:679:test_002()/5
 cmd: $NMCLI 
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_002-006.expected
+++ b/clients/tests/test-client.check-on-disk/test_002-006.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:674:test_002()/6
+location: clients/tests/test-client.py:679:test_002()/6
 cmd: $NMCLI 
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_002-007.expected
+++ b/clients/tests/test-client.check-on-disk/test_002-007.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:676:test_002()/7
+location: clients/tests/test-client.py:681:test_002()/7
 cmd: $NMCLI -f AP -mode multiline d show wlan0
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_002-008.expected
+++ b/clients/tests/test-client.check-on-disk/test_002-008.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:676:test_002()/8
+location: clients/tests/test-client.py:681:test_002()/8
 cmd: $NMCLI -f AP -mode multiline d show wlan0
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_002-009.expected
+++ b/clients/tests/test-client.check-on-disk/test_002-009.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:677:test_002()/9
+location: clients/tests/test-client.py:682:test_002()/9
 cmd: $NMCLI -f AP -mode multiline -p d show wlan0
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_002-010.expected
+++ b/clients/tests/test-client.check-on-disk/test_002-010.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:677:test_002()/10
+location: clients/tests/test-client.py:682:test_002()/10
 cmd: $NMCLI -f AP -mode multiline -p d show wlan0
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_002-011.expected
+++ b/clients/tests/test-client.check-on-disk/test_002-011.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:678:test_002()/11
+location: clients/tests/test-client.py:683:test_002()/11
 cmd: $NMCLI -f AP -mode multiline -t d show wlan0
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_002-012.expected
+++ b/clients/tests/test-client.check-on-disk/test_002-012.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:678:test_002()/12
+location: clients/tests/test-client.py:683:test_002()/12
 cmd: $NMCLI -f AP -mode multiline -t d show wlan0
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_002-013.expected
+++ b/clients/tests/test-client.check-on-disk/test_002-013.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:679:test_002()/13
+location: clients/tests/test-client.py:684:test_002()/13
 cmd: $NMCLI -f AP -mode tabular d show wlan0
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_002-014.expected
+++ b/clients/tests/test-client.check-on-disk/test_002-014.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:679:test_002()/14
+location: clients/tests/test-client.py:684:test_002()/14
 cmd: $NMCLI -f AP -mode tabular d show wlan0
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_002-015.expected
+++ b/clients/tests/test-client.check-on-disk/test_002-015.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:680:test_002()/15
+location: clients/tests/test-client.py:685:test_002()/15
 cmd: $NMCLI -f AP -mode tabular -p d show wlan0
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_002-016.expected
+++ b/clients/tests/test-client.check-on-disk/test_002-016.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:680:test_002()/16
+location: clients/tests/test-client.py:685:test_002()/16
 cmd: $NMCLI -f AP -mode tabular -p d show wlan0
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_002-017.expected
+++ b/clients/tests/test-client.check-on-disk/test_002-017.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:681:test_002()/17
+location: clients/tests/test-client.py:686:test_002()/17
 cmd: $NMCLI -f AP -mode tabular -t d show wlan0
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_002-018.expected
+++ b/clients/tests/test-client.check-on-disk/test_002-018.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:681:test_002()/18
+location: clients/tests/test-client.py:686:test_002()/18
 cmd: $NMCLI -f AP -mode tabular -t d show wlan0
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_002-019.expected
+++ b/clients/tests/test-client.check-on-disk/test_002-019.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:683:test_002()/19
+location: clients/tests/test-client.py:688:test_002()/19
 cmd: $NMCLI -f ALL d wifi
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_002-020.expected
+++ b/clients/tests/test-client.check-on-disk/test_002-020.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:683:test_002()/20
+location: clients/tests/test-client.py:688:test_002()/20
 cmd: $NMCLI -f ALL d wifi
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_002-021.expected
+++ b/clients/tests/test-client.check-on-disk/test_002-021.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:685:test_002()/21
+location: clients/tests/test-client.py:690:test_002()/21
 cmd: $NMCLI c
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_002-022.expected
+++ b/clients/tests/test-client.check-on-disk/test_002-022.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:685:test_002()/22
+location: clients/tests/test-client.py:690:test_002()/22
 cmd: $NMCLI c
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_002-023.expected
+++ b/clients/tests/test-client.check-on-disk/test_002-023.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:687:test_002()/23
+location: clients/tests/test-client.py:692:test_002()/23
 cmd: $NMCLI c s con-1
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_002-024.expected
+++ b/clients/tests/test-client.check-on-disk/test_002-024.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:687:test_002()/24
+location: clients/tests/test-client.py:692:test_002()/24
 cmd: $NMCLI c s con-1
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-001.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-001.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:697:test_003()/1
+location: clients/tests/test-client.py:702:test_003()/1
 cmd: $NMCLI c add type ethernet ifname '*' con-name con-xx1
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-002.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-002.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:700:test_003()/2
+location: clients/tests/test-client.py:705:test_003()/2
 cmd: $NMCLI c s
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-003.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-003.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:700:test_003()/3
+location: clients/tests/test-client.py:705:test_003()/3
 cmd: $NMCLI c s
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-004.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-004.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:705:test_003()/4
+location: clients/tests/test-client.py:710:test_003()/4
 cmd: $NMCLI c add type ethernet ifname '*'
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-005.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-005.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:708:test_003()/5
+location: clients/tests/test-client.py:713:test_003()/5
 cmd: $NMCLI c s
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-006.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-006.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:708:test_003()/6
+location: clients/tests/test-client.py:713:test_003()/6
 cmd: $NMCLI c s
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-007.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-007.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:711:test_003()/7
+location: clients/tests/test-client.py:716:test_003()/7
 cmd: $NMCLI -f ALL c s
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-008.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-008.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:711:test_003()/8
+location: clients/tests/test-client.py:716:test_003()/8
 cmd: $NMCLI -f ALL c s
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-009.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-009.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:715:test_003()/9
+location: clients/tests/test-client.py:720:test_003()/9
 cmd: $NMCLI --complete-args -f ALL c s ''
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-010.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-010.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:715:test_003()/10
+location: clients/tests/test-client.py:720:test_003()/10
 cmd: $NMCLI --complete-args -f ALL c s ''
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-011.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-011.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:728:test_003()/11
+location: clients/tests/test-client.py:733:test_003()/11
 cmd: $NMCLI con up ethernet ifname eth0
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-012.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-012.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:731:test_003()/12
+location: clients/tests/test-client.py:736:test_003()/12
 cmd: $NMCLI con
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-013.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-013.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:731:test_003()/13
+location: clients/tests/test-client.py:736:test_003()/13
 cmd: $NMCLI con
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-014.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-014.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:734:test_003()/14
+location: clients/tests/test-client.py:739:test_003()/14
 cmd: $NMCLI -f ALL con
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-015.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-015.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:734:test_003()/15
+location: clients/tests/test-client.py:739:test_003()/15
 cmd: $NMCLI -f ALL con
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-016.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-016.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:737:test_003()/16
+location: clients/tests/test-client.py:742:test_003()/16
 cmd: $NMCLI -f ALL con s -a
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-017.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-017.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:737:test_003()/17
+location: clients/tests/test-client.py:742:test_003()/17
 cmd: $NMCLI -f ALL con s -a
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-018.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-018.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:740:test_003()/18
+location: clients/tests/test-client.py:745:test_003()/18
 cmd: $NMCLI -f ACTIVE-PATH,DEVICE,UUID con s -act
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-019.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-019.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:740:test_003()/19
+location: clients/tests/test-client.py:745:test_003()/19
 cmd: $NMCLI -f ACTIVE-PATH,DEVICE,UUID con s -act
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-020.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-020.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:743:test_003()/20
+location: clients/tests/test-client.py:748:test_003()/20
 cmd: $NMCLI -f UUID,NAME con s --active
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-021.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-021.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:743:test_003()/21
+location: clients/tests/test-client.py:748:test_003()/21
 cmd: $NMCLI -f UUID,NAME con s --active
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-022.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-022.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:746:test_003()/22
+location: clients/tests/test-client.py:751:test_003()/22
 cmd: $NMCLI -f ALL con s ethernet
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-023.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-023.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:746:test_003()/23
+location: clients/tests/test-client.py:751:test_003()/23
 cmd: $NMCLI -f ALL con s ethernet
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-024.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-024.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:749:test_003()/24
+location: clients/tests/test-client.py:754:test_003()/24
 cmd: $NMCLI -f GENERAL.STATE con s ethernet
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-025.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-025.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:749:test_003()/25
+location: clients/tests/test-client.py:754:test_003()/25
 cmd: $NMCLI -f GENERAL.STATE con s ethernet
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-026.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-026.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:752:test_003()/26
+location: clients/tests/test-client.py:757:test_003()/26
 cmd: $NMCLI con s ethernet
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-027.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-027.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:752:test_003()/27
+location: clients/tests/test-client.py:757:test_003()/27
 cmd: $NMCLI con s ethernet
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-028.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-028.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:755:test_003()/28
+location: clients/tests/test-client.py:760:test_003()/28
 cmd: $NMCLI -f ALL dev s eth0
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-029.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-029.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:755:test_003()/29
+location: clients/tests/test-client.py:760:test_003()/29
 cmd: $NMCLI -f ALL dev s eth0
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-030.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-030.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:758:test_003()/30
+location: clients/tests/test-client.py:763:test_003()/30
 cmd: $NMCLI -f ALL dev show eth0
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-031.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-031.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:758:test_003()/31
+location: clients/tests/test-client.py:763:test_003()/31
 cmd: $NMCLI -f ALL dev show eth0
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-032.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-032.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:728:test_003()/32
+location: clients/tests/test-client.py:733:test_003()/32
 cmd: $NMCLI con up ethernet ifname eth1
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-033.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-033.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:731:test_003()/33
+location: clients/tests/test-client.py:736:test_003()/33
 cmd: $NMCLI con
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-034.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-034.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:731:test_003()/34
+location: clients/tests/test-client.py:736:test_003()/34
 cmd: $NMCLI con
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-035.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-035.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:734:test_003()/35
+location: clients/tests/test-client.py:739:test_003()/35
 cmd: $NMCLI -f ALL con
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-036.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-036.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:734:test_003()/36
+location: clients/tests/test-client.py:739:test_003()/36
 cmd: $NMCLI -f ALL con
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-037.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-037.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:737:test_003()/37
+location: clients/tests/test-client.py:742:test_003()/37
 cmd: $NMCLI -f ALL con s -a
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-038.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-038.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:737:test_003()/38
+location: clients/tests/test-client.py:742:test_003()/38
 cmd: $NMCLI -f ALL con s -a
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-039.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-039.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:740:test_003()/39
+location: clients/tests/test-client.py:745:test_003()/39
 cmd: $NMCLI -f ACTIVE-PATH,DEVICE,UUID con s -act
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-040.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-040.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:740:test_003()/40
+location: clients/tests/test-client.py:745:test_003()/40
 cmd: $NMCLI -f ACTIVE-PATH,DEVICE,UUID con s -act
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-041.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-041.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:743:test_003()/41
+location: clients/tests/test-client.py:748:test_003()/41
 cmd: $NMCLI -f UUID,NAME con s --active
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-042.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-042.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:743:test_003()/42
+location: clients/tests/test-client.py:748:test_003()/42
 cmd: $NMCLI -f UUID,NAME con s --active
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-043.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-043.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:746:test_003()/43
+location: clients/tests/test-client.py:751:test_003()/43
 cmd: $NMCLI -f ALL con s ethernet
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-044.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-044.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:746:test_003()/44
+location: clients/tests/test-client.py:751:test_003()/44
 cmd: $NMCLI -f ALL con s ethernet
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-045.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-045.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:749:test_003()/45
+location: clients/tests/test-client.py:754:test_003()/45
 cmd: $NMCLI -f GENERAL.STATE con s ethernet
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-046.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-046.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:749:test_003()/46
+location: clients/tests/test-client.py:754:test_003()/46
 cmd: $NMCLI -f GENERAL.STATE con s ethernet
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-047.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-047.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:752:test_003()/47
+location: clients/tests/test-client.py:757:test_003()/47
 cmd: $NMCLI con s ethernet
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-048.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-048.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:752:test_003()/48
+location: clients/tests/test-client.py:757:test_003()/48
 cmd: $NMCLI con s ethernet
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-049.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-049.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:755:test_003()/49
+location: clients/tests/test-client.py:760:test_003()/49
 cmd: $NMCLI -f ALL dev s eth0
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-050.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-050.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:755:test_003()/50
+location: clients/tests/test-client.py:760:test_003()/50
 cmd: $NMCLI -f ALL dev s eth0
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-051.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-051.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:758:test_003()/51
+location: clients/tests/test-client.py:763:test_003()/51
 cmd: $NMCLI -f ALL dev show eth0
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-052.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-052.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:758:test_003()/52
+location: clients/tests/test-client.py:763:test_003()/52
 cmd: $NMCLI -f ALL dev show eth0
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-053.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-053.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:772:test_003()/53
+location: clients/tests/test-client.py:777:test_003()/53
 cmd: $NMCLI -f ALL con
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-054.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-054.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:772:test_003()/54
+location: clients/tests/test-client.py:777:test_003()/54
 cmd: $NMCLI -f ALL con
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-055.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-055.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:775:test_003()/55
+location: clients/tests/test-client.py:780:test_003()/55
 cmd: $NMCLI -f UUID,TYPE con
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-056.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-056.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:775:test_003()/56
+location: clients/tests/test-client.py:780:test_003()/56
 cmd: $NMCLI -f UUID,TYPE con
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-057.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-057.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:778:test_003()/57
+location: clients/tests/test-client.py:783:test_003()/57
 cmd: $NMCLI -f UUID,TYPE --mode multiline con
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-058.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-058.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:778:test_003()/58
+location: clients/tests/test-client.py:783:test_003()/58
 cmd: $NMCLI -f UUID,TYPE --mode multiline con
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-059.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-059.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:781:test_003()/59
+location: clients/tests/test-client.py:786:test_003()/59
 cmd: $NMCLI -f UUID,TYPE --mode multiline --terse con
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-060.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-060.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:781:test_003()/60
+location: clients/tests/test-client.py:786:test_003()/60
 cmd: $NMCLI -f UUID,TYPE --mode multiline --terse con
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-061.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-061.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:784:test_003()/61
+location: clients/tests/test-client.py:789:test_003()/61
 cmd: $NMCLI -f UUID,TYPE --mode multiline --pretty con
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-062.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-062.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:784:test_003()/62
+location: clients/tests/test-client.py:789:test_003()/62
 cmd: $NMCLI -f UUID,TYPE --mode multiline --pretty con
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-063.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-063.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:787:test_003()/63
+location: clients/tests/test-client.py:792:test_003()/63
 cmd: $NMCLI -f UUID,TYPE --mode tabular con
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-064.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-064.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:787:test_003()/64
+location: clients/tests/test-client.py:792:test_003()/64
 cmd: $NMCLI -f UUID,TYPE --mode tabular con
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-065.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-065.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:790:test_003()/65
+location: clients/tests/test-client.py:795:test_003()/65
 cmd: $NMCLI -f UUID,TYPE --mode tabular --terse con
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-066.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-066.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:790:test_003()/66
+location: clients/tests/test-client.py:795:test_003()/66
 cmd: $NMCLI -f UUID,TYPE --mode tabular --terse con
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-067.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-067.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:793:test_003()/67
+location: clients/tests/test-client.py:798:test_003()/67
 cmd: $NMCLI -f UUID,TYPE --mode tabular --pretty con
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-068.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-068.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:793:test_003()/68
+location: clients/tests/test-client.py:798:test_003()/68
 cmd: $NMCLI -f UUID,TYPE --mode tabular --pretty con
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-069.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-069.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:796:test_003()/69
+location: clients/tests/test-client.py:801:test_003()/69
 cmd: $NMCLI con s ethernet
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-070.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-070.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:796:test_003()/70
+location: clients/tests/test-client.py:801:test_003()/70
 cmd: $NMCLI con s ethernet
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-071.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-071.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:799:test_003()/71
+location: clients/tests/test-client.py:804:test_003()/71
 cmd: $NMCLI c s /org/freedesktop/NetworkManager/ActiveConnection/1
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-072.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-072.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:799:test_003()/72
+location: clients/tests/test-client.py:804:test_003()/72
 cmd: $NMCLI c s /org/freedesktop/NetworkManager/ActiveConnection/1
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-073.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-073.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:772:test_003()/73
+location: clients/tests/test-client.py:777:test_003()/73
 cmd: $NMCLI -f ALL con
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-074.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-074.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:772:test_003()/74
+location: clients/tests/test-client.py:777:test_003()/74
 cmd: $NMCLI -f ALL con
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-075.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-075.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:775:test_003()/75
+location: clients/tests/test-client.py:780:test_003()/75
 cmd: $NMCLI -f UUID,TYPE con
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-076.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-076.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:775:test_003()/76
+location: clients/tests/test-client.py:780:test_003()/76
 cmd: $NMCLI -f UUID,TYPE con
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-077.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-077.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:778:test_003()/77
+location: clients/tests/test-client.py:783:test_003()/77
 cmd: $NMCLI -f UUID,TYPE --mode multiline con
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-078.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-078.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:778:test_003()/78
+location: clients/tests/test-client.py:783:test_003()/78
 cmd: $NMCLI -f UUID,TYPE --mode multiline con
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-079.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-079.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:781:test_003()/79
+location: clients/tests/test-client.py:786:test_003()/79
 cmd: $NMCLI -f UUID,TYPE --mode multiline --terse con
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-080.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-080.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:781:test_003()/80
+location: clients/tests/test-client.py:786:test_003()/80
 cmd: $NMCLI -f UUID,TYPE --mode multiline --terse con
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-081.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-081.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:784:test_003()/81
+location: clients/tests/test-client.py:789:test_003()/81
 cmd: $NMCLI -f UUID,TYPE --mode multiline --pretty con
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-082.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-082.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:784:test_003()/82
+location: clients/tests/test-client.py:789:test_003()/82
 cmd: $NMCLI -f UUID,TYPE --mode multiline --pretty con
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-083.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-083.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:787:test_003()/83
+location: clients/tests/test-client.py:792:test_003()/83
 cmd: $NMCLI -f UUID,TYPE --mode tabular con
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-084.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-084.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:787:test_003()/84
+location: clients/tests/test-client.py:792:test_003()/84
 cmd: $NMCLI -f UUID,TYPE --mode tabular con
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-085.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-085.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:790:test_003()/85
+location: clients/tests/test-client.py:795:test_003()/85
 cmd: $NMCLI -f UUID,TYPE --mode tabular --terse con
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-086.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-086.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:790:test_003()/86
+location: clients/tests/test-client.py:795:test_003()/86
 cmd: $NMCLI -f UUID,TYPE --mode tabular --terse con
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-087.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-087.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:793:test_003()/87
+location: clients/tests/test-client.py:798:test_003()/87
 cmd: $NMCLI -f UUID,TYPE --mode tabular --pretty con
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-088.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-088.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:793:test_003()/88
+location: clients/tests/test-client.py:798:test_003()/88
 cmd: $NMCLI -f UUID,TYPE --mode tabular --pretty con
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-089.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-089.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:796:test_003()/89
+location: clients/tests/test-client.py:801:test_003()/89
 cmd: $NMCLI con s ethernet
 lang: C
 returncode: 10

--- a/clients/tests/test-client.check-on-disk/test_003-090.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-090.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:796:test_003()/90
+location: clients/tests/test-client.py:801:test_003()/90
 cmd: $NMCLI con s ethernet
 lang: pl_PL.UTF-8
 returncode: 10

--- a/clients/tests/test-client.check-on-disk/test_003-091.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-091.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:799:test_003()/91
+location: clients/tests/test-client.py:804:test_003()/91
 cmd: $NMCLI c s /org/freedesktop/NetworkManager/ActiveConnection/1
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_003-092.expected
+++ b/clients/tests/test-client.check-on-disk/test_003-092.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:799:test_003()/92
+location: clients/tests/test-client.py:804:test_003()/92
 cmd: $NMCLI c s /org/freedesktop/NetworkManager/ActiveConnection/1
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_004-001.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-001.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:809:test_004()/1
+location: clients/tests/test-client.py:814:test_004()/1
 cmd: $NMCLI c add type wifi ifname '*' ssid foobar con-name con-xx1
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_004-002.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-002.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:811:test_004()/2
+location: clients/tests/test-client.py:816:test_004()/2
 cmd: $NMCLI connection mod con-xx1 ip.gateway ''
 lang: C
 returncode: 2

--- a/clients/tests/test-client.check-on-disk/test_004-003.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-003.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:812:test_004()/3
+location: clients/tests/test-client.py:817:test_004()/3
 cmd: $NMCLI connection mod con-xx1 ipv4.gateway 172.16.0.1
 lang: pl_PL.UTF-8
 returncode: 1

--- a/clients/tests/test-client.check-on-disk/test_004-003.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-003.expected
@@ -1,12 +1,13 @@
 location: clients/tests/test-client.py:812:test_004()/3
 cmd: $NMCLI connection mod con-xx1 ipv4.gateway 172.16.0.1
 lang: C
-returncode: 0
+returncode: 1
 stdout: 0 bytes
 >>>
 
 <<<
-stderr: 0 bytes
+stderr: 119 bytes
 >>>
+Error: Failed to modify connection 'con-xx1': ipv4.gateway: gateway cannot be set if there are no addresses configured
 
 <<<

--- a/clients/tests/test-client.check-on-disk/test_004-003.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-003.expected
@@ -1,13 +1,13 @@
 location: clients/tests/test-client.py:812:test_004()/3
 cmd: $NMCLI connection mod con-xx1 ipv4.gateway 172.16.0.1
-lang: C
+lang: pl_PL.UTF-8
 returncode: 1
 stdout: 0 bytes
 >>>
 
 <<<
-stderr: 119 bytes
+stderr: 143 bytes
 >>>
-Error: Failed to modify connection 'con-xx1': ipv4.gateway: gateway cannot be set if there are no addresses configured
+Błąd: zmodyfikowanie połączenia „con-xx1” się nie powiodło: ipv4.gateway: gateway cannot be set if there are no addresses configured
 
 <<<

--- a/clients/tests/test-client.check-on-disk/test_004-004.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-004.expected
@@ -1,12 +1,13 @@
 location: clients/tests/test-client.py:813:test_004()/4
 cmd: $NMCLI connection mod con-xx1 ipv6.gateway ::99
 lang: C
-returncode: 0
+returncode: 1
 stdout: 0 bytes
 >>>
 
 <<<
-stderr: 0 bytes
+stderr: 119 bytes
 >>>
+Error: Failed to modify connection 'con-xx1': ipv6.gateway: gateway cannot be set if there are no addresses configured
 
 <<<

--- a/clients/tests/test-client.check-on-disk/test_004-004.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-004.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:813:test_004()/4
+location: clients/tests/test-client.py:818:test_004()/4
 cmd: $NMCLI connection mod con-xx1 ipv6.gateway ::99
 lang: C
 returncode: 1

--- a/clients/tests/test-client.check-on-disk/test_004-005.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-005.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:814:test_004()/5
+location: clients/tests/test-client.py:819:test_004()/5
 cmd: $NMCLI connection mod con-xx1 802.abc ''
 lang: C
 returncode: 2

--- a/clients/tests/test-client.check-on-disk/test_004-006.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-006.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:815:test_004()/6
+location: clients/tests/test-client.py:820:test_004()/6
 cmd: $NMCLI connection mod con-xx1 802-11-wireless.band a
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_004-007.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-007.expected
@@ -1,0 +1,12 @@
+location: clients/tests/test-client.py:816:test_004()/7
+cmd: $NMCLI connection mod con-xx1 ipv4.addresses 192.168.77.5/24 ipv4.routes '2.3.4.5/32 192.168.77.1' ipv6.addresses 1:2:3:4::6/64 ipv6.routes 1:2:3:4:5:6::5/128
+lang: C
+returncode: 0
+stdout: 0 bytes
+>>>
+
+<<<
+stderr: 0 bytes
+>>>
+
+<<<

--- a/clients/tests/test-client.check-on-disk/test_004-007.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-007.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:816:test_004()/7
+location: clients/tests/test-client.py:821:test_004()/7
 cmd: $NMCLI connection mod con-xx1 ipv4.addresses 192.168.77.5/24 ipv4.routes '2.3.4.5/32 192.168.77.1' ipv6.addresses 1:2:3:4::6/64 ipv6.routes 1:2:3:4:5:6::5/128
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_004-008.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-008.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:818:test_004()/8
+location: clients/tests/test-client.py:823:test_004()/8
 cmd: $NMCLI con s con-xx1
 lang: C
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_004-008.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-008.expected
@@ -1,0 +1,92 @@
+location: clients/tests/test-client.py:818:test_004()/8
+cmd: $NMCLI con s con-xx1
+lang: C
+returncode: 0
+stdout: 3713 bytes
+>>>
+connection.id:                          con-xx1
+connection.uuid:                        UUID-con-xx1-REPLACED-REPLACED-REPLA
+connection.stable-id:                   --
+connection.type:                        802-11-wireless
+connection.interface-name:              --
+connection.autoconnect:                 yes
+connection.autoconnect-priority:        0
+connection.autoconnect-retries:         -1 (default)
+connection.auth-retries:                -1
+connection.timestamp:                   0
+connection.read-only:                   no
+connection.permissions:                 --
+connection.zone:                        --
+connection.master:                      --
+connection.slave-type:                  --
+connection.autoconnect-slaves:          -1 (default)
+connection.secondaries:                 --
+connection.gateway-ping-timeout:        0
+connection.metered:                     unknown
+connection.lldp:                        default
+connection.mdns:                        -1 (default)
+802-11-wireless.ssid:                   foobar
+802-11-wireless.mode:                   infrastructure
+802-11-wireless.band:                   a
+802-11-wireless.channel:                0
+802-11-wireless.bssid:                  --
+802-11-wireless.rate:                   0
+802-11-wireless.tx-power:               0
+802-11-wireless.mac-address:            --
+802-11-wireless.cloned-mac-address:     --
+802-11-wireless.generate-mac-address-mask:--
+802-11-wireless.mac-address-blacklist:  --
+802-11-wireless.mac-address-randomization:default
+802-11-wireless.mtu:                    auto
+802-11-wireless.seen-bssids:            --
+802-11-wireless.hidden:                 no
+802-11-wireless.powersave:              0 (default)
+ipv4.method:                            auto
+ipv4.dns:                               --
+ipv4.dns-search:                        --
+ipv4.dns-options:                       ""
+ipv4.dns-priority:                      0
+ipv4.addresses:                         192.168.77.5/24
+ipv4.gateway:                           --
+ipv4.routes:                            { ip = 2.3.4.5/32, nh = 192.168.77.1 }
+ipv4.route-metric:                      -1
+ipv4.route-table:                       0 (unspec)
+ipv4.ignore-auto-routes:                no
+ipv4.ignore-auto-dns:                   no
+ipv4.dhcp-client-id:                    --
+ipv4.dhcp-timeout:                      0 (default)
+ipv4.dhcp-send-hostname:                yes
+ipv4.dhcp-hostname:                     --
+ipv4.dhcp-fqdn:                         --
+ipv4.never-default:                     no
+ipv4.may-fail:                          yes
+ipv4.dad-timeout:                       -1 (default)
+ipv6.method:                            auto
+ipv6.dns:                               --
+ipv6.dns-search:                        --
+ipv6.dns-options:                       ""
+ipv6.dns-priority:                      0
+ipv6.addresses:                         1:2:3:4::6/64
+ipv6.gateway:                           --
+ipv6.routes:                            { ip = 1:2:3:4:5:6:0:5/128 }
+ipv6.route-metric:                      -1
+ipv6.route-table:                       0 (unspec)
+ipv6.ignore-auto-routes:                no
+ipv6.ignore-auto-dns:                   no
+ipv6.never-default:                     no
+ipv6.may-fail:                          yes
+ipv6.ip6-privacy:                       -1 (unknown)
+ipv6.addr-gen-mode:                     stable-privacy
+ipv6.dhcp-send-hostname:                yes
+ipv6.dhcp-hostname:                     --
+ipv6.token:                             --
+proxy.method:                           none
+proxy.browser-only:                     no
+proxy.pac-url:                          --
+proxy.pac-script:                       --
+
+<<<
+stderr: 0 bytes
+>>>
+
+<<<

--- a/clients/tests/test-client.check-on-disk/test_004-009.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-009.expected
@@ -1,4 +1,4 @@
-location: clients/tests/test-client.py:818:test_004()/9
+location: clients/tests/test-client.py:823:test_004()/9
 cmd: $NMCLI con s con-xx1
 lang: pl_PL.UTF-8
 returncode: 0

--- a/clients/tests/test-client.check-on-disk/test_004-009.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-009.expected
@@ -1,0 +1,92 @@
+location: clients/tests/test-client.py:818:test_004()/9
+cmd: $NMCLI con s con-xx1
+lang: pl_PL.UTF-8
+returncode: 0
+stdout: 3731 bytes
+>>>
+connection.id:                          con-xx1
+connection.uuid:                        UUID-con-xx1-REPLACED-REPLACED-REPLA
+connection.stable-id:                   --
+connection.type:                        802-11-wireless
+connection.interface-name:              --
+connection.autoconnect:                 tak
+connection.autoconnect-priority:        0
+connection.autoconnect-retries:         -1 (default)
+connection.auth-retries:                -1
+connection.timestamp:                   0
+connection.read-only:                   nie
+connection.permissions:                 --
+connection.zone:                        --
+connection.master:                      --
+connection.slave-type:                  --
+connection.autoconnect-slaves:          -1 (default)
+connection.secondaries:                 --
+connection.gateway-ping-timeout:        0
+connection.metered:                     nieznane
+connection.lldp:                        default
+connection.mdns:                        -1 (default)
+802-11-wireless.ssid:                   foobar
+802-11-wireless.mode:                   infrastructure
+802-11-wireless.band:                   a
+802-11-wireless.channel:                0
+802-11-wireless.bssid:                  --
+802-11-wireless.rate:                   0
+802-11-wireless.tx-power:               0
+802-11-wireless.mac-address:            --
+802-11-wireless.cloned-mac-address:     --
+802-11-wireless.generate-mac-address-mask:--
+802-11-wireless.mac-address-blacklist:  --
+802-11-wireless.mac-address-randomization:default
+802-11-wireless.mtu:                    automatyczne
+802-11-wireless.seen-bssids:            --
+802-11-wireless.hidden:                 nie
+802-11-wireless.powersave:              0 (default)
+ipv4.method:                            auto
+ipv4.dns:                               --
+ipv4.dns-search:                        --
+ipv4.dns-options:                       ""
+ipv4.dns-priority:                      0
+ipv4.addresses:                         192.168.77.5/24
+ipv4.gateway:                           --
+ipv4.routes:                            { ip = 2.3.4.5/32, nh = 192.168.77.1 }
+ipv4.route-metric:                      -1
+ipv4.route-table:                       0 (unspec)
+ipv4.ignore-auto-routes:                nie
+ipv4.ignore-auto-dns:                   nie
+ipv4.dhcp-client-id:                    --
+ipv4.dhcp-timeout:                      0 (default)
+ipv4.dhcp-send-hostname:                tak
+ipv4.dhcp-hostname:                     --
+ipv4.dhcp-fqdn:                         --
+ipv4.never-default:                     nie
+ipv4.may-fail:                          tak
+ipv4.dad-timeout:                       -1 (default)
+ipv6.method:                            auto
+ipv6.dns:                               --
+ipv6.dns-search:                        --
+ipv6.dns-options:                       ""
+ipv6.dns-priority:                      0
+ipv6.addresses:                         1:2:3:4::6/64
+ipv6.gateway:                           --
+ipv6.routes:                            { ip = 1:2:3:4:5:6:0:5/128 }
+ipv6.route-metric:                      -1
+ipv6.route-table:                       0 (unspec)
+ipv6.ignore-auto-routes:                nie
+ipv6.ignore-auto-dns:                   nie
+ipv6.never-default:                     nie
+ipv6.may-fail:                          tak
+ipv6.ip6-privacy:                       -1 (unknown)
+ipv6.addr-gen-mode:                     stable-privacy
+ipv6.dhcp-send-hostname:                tak
+ipv6.dhcp-hostname:                     --
+ipv6.token:                             --
+proxy.method:                           none
+proxy.browser-only:                     nie
+proxy.pac-url:                          --
+proxy.pac-script:                       --
+
+<<<
+stderr: 0 bytes
+>>>
+
+<<<

--- a/clients/tests/test-client.check-on-disk/test_004-010.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-010.expected
@@ -1,0 +1,13 @@
+location: clients/tests/test-client.py:830:test_004()/10
+cmd: $NMCLI connection add type vpn con-name con-vpn-1 ifname '*' vpn-type openvpn vpn.data 'key1 = val1,   key2  = val2, key3=val3'
+lang: C
+returncode: 0
+stdout: 82 bytes
+>>>
+Connection 'con-vpn-1' (UUID-con-vpn-1-REPLACED-REPLACED-REP) successfully added.
+
+<<<
+stderr: 0 bytes
+>>>
+
+<<<

--- a/clients/tests/test-client.check-on-disk/test_004-011.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-011.expected
@@ -1,0 +1,16 @@
+location: clients/tests/test-client.py:833:test_004()/11
+cmd: $NMCLI con s
+lang: C
+returncode: 0
+stdout: 268 bytes
+>>>
+NAME       UUID                                  TYPE      DEVICE 
+con-1      5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  --     
+con-vpn-1  UUID-con-vpn-1-REPLACED-REPLACED-REP  vpn       --     
+con-xx1    UUID-con-xx1-REPLACED-REPLACED-REPLA  wifi      --     
+
+<<<
+stderr: 0 bytes
+>>>
+
+<<<

--- a/clients/tests/test-client.check-on-disk/test_004-012.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-012.expected
@@ -1,0 +1,16 @@
+location: clients/tests/test-client.py:833:test_004()/12
+cmd: $NMCLI con s
+lang: pl_PL.UTF-8
+returncode: 0
+stdout: 268 bytes
+>>>
+NAME       UUID                                  TYPE      DEVICE 
+con-1      5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  --     
+con-vpn-1  UUID-con-vpn-1-REPLACED-REPLACED-REP  vpn       --     
+con-xx1    UUID-con-xx1-REPLACED-REPLACED-REPLA  wifi      --     
+
+<<<
+stderr: 0 bytes
+>>>
+
+<<<

--- a/clients/tests/test-client.check-on-disk/test_004-013.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-013.expected
@@ -1,0 +1,82 @@
+location: clients/tests/test-client.py:835:test_004()/13
+cmd: $NMCLI con s con-vpn-1
+lang: C
+returncode: 0
+stdout: 3231 bytes
+>>>
+connection.id:                          con-vpn-1
+connection.uuid:                        UUID-con-vpn-1-REPLACED-REPLACED-REP
+connection.stable-id:                   --
+connection.type:                        vpn
+connection.interface-name:              --
+connection.autoconnect:                 yes
+connection.autoconnect-priority:        0
+connection.autoconnect-retries:         -1 (default)
+connection.auth-retries:                -1
+connection.timestamp:                   0
+connection.read-only:                   no
+connection.permissions:                 --
+connection.zone:                        --
+connection.master:                      --
+connection.slave-type:                  --
+connection.autoconnect-slaves:          -1 (default)
+connection.secondaries:                 --
+connection.gateway-ping-timeout:        0
+connection.metered:                     unknown
+connection.lldp:                        default
+connection.mdns:                        -1 (default)
+ipv4.method:                            auto
+ipv4.dns:                               --
+ipv4.dns-search:                        --
+ipv4.dns-options:                       ""
+ipv4.dns-priority:                      0
+ipv4.addresses:                         --
+ipv4.gateway:                           --
+ipv4.routes:                            --
+ipv4.route-metric:                      -1
+ipv4.route-table:                       0 (unspec)
+ipv4.ignore-auto-routes:                no
+ipv4.ignore-auto-dns:                   no
+ipv4.dhcp-client-id:                    --
+ipv4.dhcp-timeout:                      0 (default)
+ipv4.dhcp-send-hostname:                yes
+ipv4.dhcp-hostname:                     --
+ipv4.dhcp-fqdn:                         --
+ipv4.never-default:                     no
+ipv4.may-fail:                          yes
+ipv4.dad-timeout:                       -1 (default)
+ipv6.method:                            auto
+ipv6.dns:                               --
+ipv6.dns-search:                        --
+ipv6.dns-options:                       ""
+ipv6.dns-priority:                      0
+ipv6.addresses:                         --
+ipv6.gateway:                           --
+ipv6.routes:                            --
+ipv6.route-metric:                      -1
+ipv6.route-table:                       0 (unspec)
+ipv6.ignore-auto-routes:                no
+ipv6.ignore-auto-dns:                   no
+ipv6.never-default:                     no
+ipv6.may-fail:                          yes
+ipv6.ip6-privacy:                       -1 (unknown)
+ipv6.addr-gen-mode:                     stable-privacy
+ipv6.dhcp-send-hostname:                yes
+ipv6.dhcp-hostname:                     --
+ipv6.token:                             --
+vpn.service-type:                       org.freedesktop.NetworkManager.openvpn
+vpn.user-name:                          --
+vpn.data:                               key1 = val1, key2 = val2, key3 = val3
+vpn.secrets:                            <hidden>
+vpn.persistent:                         no
+vpn.timeout:                            0
+proxy.method:                           none
+proxy.browser-only:                     no
+proxy.pac-url:                          --
+proxy.pac-script:                       --
+
+<<<
+stderr: 0 bytes
+>>>
+
+<<<

--- a/clients/tests/test-client.check-on-disk/test_004-014.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-014.expected
@@ -1,0 +1,82 @@
+location: clients/tests/test-client.py:835:test_004()/14
+cmd: $NMCLI con s con-vpn-1
+lang: pl_PL.UTF-8
+returncode: 0
+stdout: 3241 bytes
+>>>
+connection.id:                          con-vpn-1
+connection.uuid:                        UUID-con-vpn-1-REPLACED-REPLACED-REP
+connection.stable-id:                   --
+connection.type:                        vpn
+connection.interface-name:              --
+connection.autoconnect:                 tak
+connection.autoconnect-priority:        0
+connection.autoconnect-retries:         -1 (default)
+connection.auth-retries:                -1
+connection.timestamp:                   0
+connection.read-only:                   nie
+connection.permissions:                 --
+connection.zone:                        --
+connection.master:                      --
+connection.slave-type:                  --
+connection.autoconnect-slaves:          -1 (default)
+connection.secondaries:                 --
+connection.gateway-ping-timeout:        0
+connection.metered:                     nieznane
+connection.lldp:                        default
+connection.mdns:                        -1 (default)
+ipv4.method:                            auto
+ipv4.dns:                               --
+ipv4.dns-search:                        --
+ipv4.dns-options:                       ""
+ipv4.dns-priority:                      0
+ipv4.addresses:                         --
+ipv4.gateway:                           --
+ipv4.routes:                            --
+ipv4.route-metric:                      -1
+ipv4.route-table:                       0 (unspec)
+ipv4.ignore-auto-routes:                nie
+ipv4.ignore-auto-dns:                   nie
+ipv4.dhcp-client-id:                    --
+ipv4.dhcp-timeout:                      0 (default)
+ipv4.dhcp-send-hostname:                tak
+ipv4.dhcp-hostname:                     --
+ipv4.dhcp-fqdn:                         --
+ipv4.never-default:                     nie
+ipv4.may-fail:                          tak
+ipv4.dad-timeout:                       -1 (default)
+ipv6.method:                            auto
+ipv6.dns:                               --
+ipv6.dns-search:                        --
+ipv6.dns-options:                       ""
+ipv6.dns-priority:                      0
+ipv6.addresses:                         --
+ipv6.gateway:                           --
+ipv6.routes:                            --
+ipv6.route-metric:                      -1
+ipv6.route-table:                       0 (unspec)
+ipv6.ignore-auto-routes:                nie
+ipv6.ignore-auto-dns:                   nie
+ipv6.never-default:                     nie
+ipv6.may-fail:                          tak
+ipv6.ip6-privacy:                       -1 (unknown)
+ipv6.addr-gen-mode:                     stable-privacy
+ipv6.dhcp-send-hostname:                tak
+ipv6.dhcp-hostname:                     --
+ipv6.token:                             --
+vpn.service-type:                       org.freedesktop.NetworkManager.openvpn
+vpn.user-name:                          --
+vpn.data:                               key1 = val1, key2 = val2, key3 = val3
+vpn.secrets:                            <hidden>
+vpn.persistent:                         nie
+vpn.timeout:                            0
+proxy.method:                           none
+proxy.browser-only:                     nie
+proxy.pac-url:                          --
+proxy.pac-script:                       --
+
+<<<
+stderr: 0 bytes
+>>>
+
+<<<

--- a/clients/tests/test-client.check-on-disk/test_004-015.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-015.expected
@@ -1,0 +1,13 @@
+location: clients/tests/test-client.py:837:test_004()/15
+cmd: $NMCLI con up con-xx1
+lang: C
+returncode: 0
+stdout: 106 bytes
+>>>
+Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/1)
+
+<<<
+stderr: 0 bytes
+>>>
+
+<<<

--- a/clients/tests/test-client.check-on-disk/test_004-016.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-016.expected
@@ -1,0 +1,16 @@
+location: clients/tests/test-client.py:839:test_004()/16
+cmd: $NMCLI con s
+lang: C
+returncode: 0
+stdout: 268 bytes
+>>>
+NAME       UUID                                  TYPE      DEVICE 
+con-xx1    UUID-con-xx1-REPLACED-REPLACED-REPLA  wifi      wlan0  
+con-1      5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  --     
+con-vpn-1  UUID-con-vpn-1-REPLACED-REPLACED-REP  vpn       --     
+
+<<<
+stderr: 0 bytes
+>>>
+
+<<<

--- a/clients/tests/test-client.check-on-disk/test_004-017.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-017.expected
@@ -1,0 +1,16 @@
+location: clients/tests/test-client.py:839:test_004()/17
+cmd: $NMCLI con s
+lang: pl_PL.UTF-8
+returncode: 0
+stdout: 268 bytes
+>>>
+NAME       UUID                                  TYPE      DEVICE 
+con-xx1    UUID-con-xx1-REPLACED-REPLACED-REPLA  wifi      wlan0  
+con-1      5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  --     
+con-vpn-1  UUID-con-vpn-1-REPLACED-REPLACED-REP  vpn       --     
+
+<<<
+stderr: 0 bytes
+>>>
+
+<<<

--- a/clients/tests/test-client.check-on-disk/test_004-018.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-018.expected
@@ -1,0 +1,13 @@
+location: clients/tests/test-client.py:841:test_004()/18
+cmd: $NMCLI con up con-vpn-1
+lang: C
+returncode: 0
+stdout: 106 bytes
+>>>
+Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/2)
+
+<<<
+stderr: 0 bytes
+>>>
+
+<<<

--- a/clients/tests/test-client.check-on-disk/test_004-019.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-019.expected
@@ -1,0 +1,16 @@
+location: clients/tests/test-client.py:843:test_004()/19
+cmd: $NMCLI con s
+lang: C
+returncode: 0
+stdout: 268 bytes
+>>>
+NAME       UUID                                  TYPE      DEVICE 
+con-vpn-1  UUID-con-vpn-1-REPLACED-REPLACED-REP  vpn       wlan0  
+con-xx1    UUID-con-xx1-REPLACED-REPLACED-REPLA  wifi      wlan0  
+con-1      5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  --     
+
+<<<
+stderr: 0 bytes
+>>>
+
+<<<

--- a/clients/tests/test-client.check-on-disk/test_004-020.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-020.expected
@@ -1,0 +1,16 @@
+location: clients/tests/test-client.py:843:test_004()/20
+cmd: $NMCLI con s
+lang: pl_PL.UTF-8
+returncode: 0
+stdout: 268 bytes
+>>>
+NAME       UUID                                  TYPE      DEVICE 
+con-vpn-1  UUID-con-vpn-1-REPLACED-REPLACED-REP  vpn       wlan0  
+con-xx1    UUID-con-xx1-REPLACED-REPLACED-REPLA  wifi      wlan0  
+con-1      5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  --     
+
+<<<
+stderr: 0 bytes
+>>>
+
+<<<

--- a/clients/tests/test-client.check-on-disk/test_004-021.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-021.expected
@@ -1,0 +1,102 @@
+location: clients/tests/test-client.py:845:test_004()/21
+cmd: $NMCLI con s con-vpn-1
+lang: C
+returncode: 0
+stdout: 4283 bytes
+>>>
+connection.id:                          con-vpn-1
+connection.uuid:                        UUID-con-vpn-1-REPLACED-REPLACED-REP
+connection.stable-id:                   --
+connection.type:                        vpn
+connection.interface-name:              --
+connection.autoconnect:                 yes
+connection.autoconnect-priority:        0
+connection.autoconnect-retries:         -1 (default)
+connection.auth-retries:                -1
+connection.timestamp:                   0
+connection.read-only:                   no
+connection.permissions:                 --
+connection.zone:                        --
+connection.master:                      --
+connection.slave-type:                  --
+connection.autoconnect-slaves:          -1 (default)
+connection.secondaries:                 --
+connection.gateway-ping-timeout:        0
+connection.metered:                     unknown
+connection.lldp:                        default
+connection.mdns:                        -1 (default)
+ipv4.method:                            auto
+ipv4.dns:                               --
+ipv4.dns-search:                        --
+ipv4.dns-options:                       ""
+ipv4.dns-priority:                      0
+ipv4.addresses:                         --
+ipv4.gateway:                           --
+ipv4.routes:                            --
+ipv4.route-metric:                      -1
+ipv4.route-table:                       0 (unspec)
+ipv4.ignore-auto-routes:                no
+ipv4.ignore-auto-dns:                   no
+ipv4.dhcp-client-id:                    --
+ipv4.dhcp-timeout:                      0 (default)
+ipv4.dhcp-send-hostname:                yes
+ipv4.dhcp-hostname:                     --
+ipv4.dhcp-fqdn:                         --
+ipv4.never-default:                     no
+ipv4.may-fail:                          yes
+ipv4.dad-timeout:                       -1 (default)
+ipv6.method:                            auto
+ipv6.dns:                               --
+ipv6.dns-search:                        --
+ipv6.dns-options:                       ""
+ipv6.dns-priority:                      0
+ipv6.addresses:                         --
+ipv6.gateway:                           --
+ipv6.routes:                            --
+ipv6.route-metric:                      -1
+ipv6.route-table:                       0 (unspec)
+ipv6.ignore-auto-routes:                no
+ipv6.ignore-auto-dns:                   no
+ipv6.never-default:                     no
+ipv6.may-fail:                          yes
+ipv6.ip6-privacy:                       -1 (unknown)
+ipv6.addr-gen-mode:                     stable-privacy
+ipv6.dhcp-send-hostname:                yes
+ipv6.dhcp-hostname:                     --
+ipv6.token:                             --
+vpn.service-type:                       org.freedesktop.NetworkManager.openvpn
+vpn.user-name:                          --
+vpn.data:                               key1 = val1, key2 = val2, key3 = val3
+vpn.secrets:                            <hidden>
+vpn.persistent:                         no
+vpn.timeout:                            0
+proxy.method:                           none
+proxy.browser-only:                     no
+proxy.pac-url:                          --
+proxy.pac-script:                       --
+GENERAL.NAME:                           con-vpn-1
+GENERAL.UUID:                           UUID-con-vpn-1-REPLACED-REPLACED-REP
+GENERAL.DEVICES:                        wlan0
+GENERAL.STATE:                          activated
+GENERAL.DEFAULT:                        no
+GENERAL.DEFAULT6:                       no
+GENERAL.SPEC-OBJECT:                    --
+GENERAL.VPN:                            yes
+GENERAL.DBUS-PATH:                      /org/freedesktop/NetworkManager/ActiveConnection/2
+GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/Settings/Connection/3
+GENERAL.ZONE:                           --
+GENERAL.MASTER-PATH:                    --
+VPN.TYPE:                               openvpn
+VPN.USERNAME:                           --
+VPN.GATEWAY:                            --
+VPN.BANNER:                             --
+VPN.VPN-STATE:                          0 - unknown
+VPN.CFG[1]:                             key1 = val1
+VPN.CFG[2]:                             key2 = val2
+VPN.CFG[3]:                             key3 = val3
+
+<<<
+stderr: 0 bytes
+>>>
+
+<<<

--- a/clients/tests/test-client.check-on-disk/test_004-022.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-022.expected
@@ -1,0 +1,102 @@
+location: clients/tests/test-client.py:845:test_004()/22
+cmd: $NMCLI con s con-vpn-1
+lang: pl_PL.UTF-8
+returncode: 0
+stdout: 4297 bytes
+>>>
+connection.id:                          con-vpn-1
+connection.uuid:                        UUID-con-vpn-1-REPLACED-REPLACED-REP
+connection.stable-id:                   --
+connection.type:                        vpn
+connection.interface-name:              --
+connection.autoconnect:                 tak
+connection.autoconnect-priority:        0
+connection.autoconnect-retries:         -1 (default)
+connection.auth-retries:                -1
+connection.timestamp:                   0
+connection.read-only:                   nie
+connection.permissions:                 --
+connection.zone:                        --
+connection.master:                      --
+connection.slave-type:                  --
+connection.autoconnect-slaves:          -1 (default)
+connection.secondaries:                 --
+connection.gateway-ping-timeout:        0
+connection.metered:                     nieznane
+connection.lldp:                        default
+connection.mdns:                        -1 (default)
+ipv4.method:                            auto
+ipv4.dns:                               --
+ipv4.dns-search:                        --
+ipv4.dns-options:                       ""
+ipv4.dns-priority:                      0
+ipv4.addresses:                         --
+ipv4.gateway:                           --
+ipv4.routes:                            --
+ipv4.route-metric:                      -1
+ipv4.route-table:                       0 (unspec)
+ipv4.ignore-auto-routes:                nie
+ipv4.ignore-auto-dns:                   nie
+ipv4.dhcp-client-id:                    --
+ipv4.dhcp-timeout:                      0 (default)
+ipv4.dhcp-send-hostname:                tak
+ipv4.dhcp-hostname:                     --
+ipv4.dhcp-fqdn:                         --
+ipv4.never-default:                     nie
+ipv4.may-fail:                          tak
+ipv4.dad-timeout:                       -1 (default)
+ipv6.method:                            auto
+ipv6.dns:                               --
+ipv6.dns-search:                        --
+ipv6.dns-options:                       ""
+ipv6.dns-priority:                      0
+ipv6.addresses:                         --
+ipv6.gateway:                           --
+ipv6.routes:                            --
+ipv6.route-metric:                      -1
+ipv6.route-table:                       0 (unspec)
+ipv6.ignore-auto-routes:                nie
+ipv6.ignore-auto-dns:                   nie
+ipv6.never-default:                     nie
+ipv6.may-fail:                          tak
+ipv6.ip6-privacy:                       -1 (unknown)
+ipv6.addr-gen-mode:                     stable-privacy
+ipv6.dhcp-send-hostname:                tak
+ipv6.dhcp-hostname:                     --
+ipv6.token:                             --
+vpn.service-type:                       org.freedesktop.NetworkManager.openvpn
+vpn.user-name:                          --
+vpn.data:                               key1 = val1, key2 = val2, key3 = val3
+vpn.secrets:                            <hidden>
+vpn.persistent:                         nie
+vpn.timeout:                            0
+proxy.method:                           none
+proxy.browser-only:                     nie
+proxy.pac-url:                          --
+proxy.pac-script:                       --
+GENERAL.NAME:                           con-vpn-1
+GENERAL.UUID:                           UUID-con-vpn-1-REPLACED-REPLACED-REP
+GENERAL.DEVICES:                        wlan0
+GENERAL.STATE:                          aktywowano
+GENERAL.DEFAULT:                        nie
+GENERAL.DEFAULT6:                       nie
+GENERAL.SPEC-OBJECT:                    --
+GENERAL.VPN:                            tak
+GENERAL.DBUS-PATH:                      /org/freedesktop/NetworkManager/ActiveConnection/2
+GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/Settings/Connection/3
+GENERAL.ZONE:                           --
+GENERAL.MASTER-PATH:                    --
+VPN.TYPE:                               openvpn
+VPN.USERNAME:                           --
+VPN.GATEWAY:                            --
+VPN.BANNER:                             --
+VPN.VPN-STATE:                          0 - nieznane
+VPN.CFG[1]:                             key1 = val1
+VPN.CFG[2]:                             key2 = val2
+VPN.CFG[3]:                             key3 = val3
+
+<<<
+stderr: 0 bytes
+>>>
+
+<<<

--- a/clients/tests/test-client.check-on-disk/test_004-023.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-023.expected
@@ -1,0 +1,102 @@
+location: clients/tests/test-client.py:854:test_004()/23
+cmd: $NMCLI con s con-vpn-1
+lang: C
+returncode: 0
+stdout: 4319 bytes
+>>>
+connection.id:                          con-vpn-1
+connection.uuid:                        UUID-con-vpn-1-REPLACED-REPLACED-REP
+connection.stable-id:                   --
+connection.type:                        vpn
+connection.interface-name:              --
+connection.autoconnect:                 yes
+connection.autoconnect-priority:        0
+connection.autoconnect-retries:         -1 (default)
+connection.auth-retries:                -1
+connection.timestamp:                   0
+connection.read-only:                   no
+connection.permissions:                 --
+connection.zone:                        --
+connection.master:                      --
+connection.slave-type:                  --
+connection.autoconnect-slaves:          -1 (default)
+connection.secondaries:                 --
+connection.gateway-ping-timeout:        0
+connection.metered:                     unknown
+connection.lldp:                        default
+connection.mdns:                        -1 (default)
+ipv4.method:                            auto
+ipv4.dns:                               --
+ipv4.dns-search:                        --
+ipv4.dns-options:                       ""
+ipv4.dns-priority:                      0
+ipv4.addresses:                         --
+ipv4.gateway:                           --
+ipv4.routes:                            --
+ipv4.route-metric:                      -1
+ipv4.route-table:                       0 (unspec)
+ipv4.ignore-auto-routes:                no
+ipv4.ignore-auto-dns:                   no
+ipv4.dhcp-client-id:                    --
+ipv4.dhcp-timeout:                      0 (default)
+ipv4.dhcp-send-hostname:                yes
+ipv4.dhcp-hostname:                     --
+ipv4.dhcp-fqdn:                         --
+ipv4.never-default:                     no
+ipv4.may-fail:                          yes
+ipv4.dad-timeout:                       -1 (default)
+ipv6.method:                            auto
+ipv6.dns:                               --
+ipv6.dns-search:                        --
+ipv6.dns-options:                       ""
+ipv6.dns-priority:                      0
+ipv6.addresses:                         --
+ipv6.gateway:                           --
+ipv6.routes:                            --
+ipv6.route-metric:                      -1
+ipv6.route-table:                       0 (unspec)
+ipv6.ignore-auto-routes:                no
+ipv6.ignore-auto-dns:                   no
+ipv6.never-default:                     no
+ipv6.may-fail:                          yes
+ipv6.ip6-privacy:                       -1 (unknown)
+ipv6.addr-gen-mode:                     stable-privacy
+ipv6.dhcp-send-hostname:                yes
+ipv6.dhcp-hostname:                     --
+ipv6.token:                             --
+vpn.service-type:                       org.freedesktop.NetworkManager.openvpn
+vpn.user-name:                          --
+vpn.data:                               key1 = val1, key2 = val2, key3 = val3
+vpn.secrets:                            <hidden>
+vpn.persistent:                         no
+vpn.timeout:                            0
+proxy.method:                           none
+proxy.browser-only:                     no
+proxy.pac-url:                          --
+proxy.pac-script:                       --
+GENERAL.NAME:                           con-vpn-1
+GENERAL.UUID:                           UUID-con-vpn-1-REPLACED-REPLACED-REP
+GENERAL.DEVICES:                        wlan0
+GENERAL.STATE:                          activated
+GENERAL.DEFAULT:                        no
+GENERAL.DEFAULT6:                       no
+GENERAL.SPEC-OBJECT:                    --
+GENERAL.VPN:                            yes
+GENERAL.DBUS-PATH:                      /org/freedesktop/NetworkManager/ActiveConnection/2
+GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/Settings/Connection/3
+GENERAL.ZONE:                           --
+GENERAL.MASTER-PATH:                    --
+VPN.TYPE:                               openvpn
+VPN.USERNAME:                           --
+VPN.GATEWAY:                            --
+VPN.BANNER:                             *** VPN connection con-vpn-1 ***
+VPN.VPN-STATE:                          5 - VPN connected
+VPN.CFG[1]:                             key1 = val1
+VPN.CFG[2]:                             key2 = val2
+VPN.CFG[3]:                             key3 = val3
+
+<<<
+stderr: 0 bytes
+>>>
+
+<<<

--- a/clients/tests/test-client.check-on-disk/test_004-024.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-024.expected
@@ -1,0 +1,102 @@
+location: clients/tests/test-client.py:854:test_004()/24
+cmd: $NMCLI con s con-vpn-1
+lang: pl_PL.UTF-8
+returncode: 0
+stdout: 4337 bytes
+>>>
+connection.id:                          con-vpn-1
+connection.uuid:                        UUID-con-vpn-1-REPLACED-REPLACED-REP
+connection.stable-id:                   --
+connection.type:                        vpn
+connection.interface-name:              --
+connection.autoconnect:                 tak
+connection.autoconnect-priority:        0
+connection.autoconnect-retries:         -1 (default)
+connection.auth-retries:                -1
+connection.timestamp:                   0
+connection.read-only:                   nie
+connection.permissions:                 --
+connection.zone:                        --
+connection.master:                      --
+connection.slave-type:                  --
+connection.autoconnect-slaves:          -1 (default)
+connection.secondaries:                 --
+connection.gateway-ping-timeout:        0
+connection.metered:                     nieznane
+connection.lldp:                        default
+connection.mdns:                        -1 (default)
+ipv4.method:                            auto
+ipv4.dns:                               --
+ipv4.dns-search:                        --
+ipv4.dns-options:                       ""
+ipv4.dns-priority:                      0
+ipv4.addresses:                         --
+ipv4.gateway:                           --
+ipv4.routes:                            --
+ipv4.route-metric:                      -1
+ipv4.route-table:                       0 (unspec)
+ipv4.ignore-auto-routes:                nie
+ipv4.ignore-auto-dns:                   nie
+ipv4.dhcp-client-id:                    --
+ipv4.dhcp-timeout:                      0 (default)
+ipv4.dhcp-send-hostname:                tak
+ipv4.dhcp-hostname:                     --
+ipv4.dhcp-fqdn:                         --
+ipv4.never-default:                     nie
+ipv4.may-fail:                          tak
+ipv4.dad-timeout:                       -1 (default)
+ipv6.method:                            auto
+ipv6.dns:                               --
+ipv6.dns-search:                        --
+ipv6.dns-options:                       ""
+ipv6.dns-priority:                      0
+ipv6.addresses:                         --
+ipv6.gateway:                           --
+ipv6.routes:                            --
+ipv6.route-metric:                      -1
+ipv6.route-table:                       0 (unspec)
+ipv6.ignore-auto-routes:                nie
+ipv6.ignore-auto-dns:                   nie
+ipv6.never-default:                     nie
+ipv6.may-fail:                          tak
+ipv6.ip6-privacy:                       -1 (unknown)
+ipv6.addr-gen-mode:                     stable-privacy
+ipv6.dhcp-send-hostname:                tak
+ipv6.dhcp-hostname:                     --
+ipv6.token:                             --
+vpn.service-type:                       org.freedesktop.NetworkManager.openvpn
+vpn.user-name:                          --
+vpn.data:                               key1 = val1, key2 = val2, key3 = val3
+vpn.secrets:                            <hidden>
+vpn.persistent:                         nie
+vpn.timeout:                            0
+proxy.method:                           none
+proxy.browser-only:                     nie
+proxy.pac-url:                          --
+proxy.pac-script:                       --
+GENERAL.NAME:                           con-vpn-1
+GENERAL.UUID:                           UUID-con-vpn-1-REPLACED-REPLACED-REP
+GENERAL.DEVICES:                        wlan0
+GENERAL.STATE:                          aktywowano
+GENERAL.DEFAULT:                        nie
+GENERAL.DEFAULT6:                       nie
+GENERAL.SPEC-OBJECT:                    --
+GENERAL.VPN:                            tak
+GENERAL.DBUS-PATH:                      /org/freedesktop/NetworkManager/ActiveConnection/2
+GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/Settings/Connection/3
+GENERAL.ZONE:                           --
+GENERAL.MASTER-PATH:                    --
+VPN.TYPE:                               openvpn
+VPN.USERNAME:                           --
+VPN.GATEWAY:                            --
+VPN.BANNER:                             *** VPN connection con-vpn-1 ***
+VPN.VPN-STATE:                          5 - Połączono z VPN
+VPN.CFG[1]:                             key1 = val1
+VPN.CFG[2]:                             key2 = val2
+VPN.CFG[3]:                             key3 = val3
+
+<<<
+stderr: 0 bytes
+>>>
+
+<<<

--- a/clients/tests/test-client.check-on-disk/test_004-025.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-025.expected
@@ -1,0 +1,82 @@
+location: clients/tests/test-client.py:857:test_004()/25
+cmd: $NMCLI -f ALL con s con-vpn-1
+lang: C
+returncode: 0
+stdout: 3231 bytes
+>>>
+connection.id:                          con-vpn-1
+connection.uuid:                        UUID-con-vpn-1-REPLACED-REPLACED-REP
+connection.stable-id:                   --
+connection.type:                        vpn
+connection.interface-name:              --
+connection.autoconnect:                 yes
+connection.autoconnect-priority:        0
+connection.autoconnect-retries:         -1 (default)
+connection.auth-retries:                -1
+connection.timestamp:                   0
+connection.read-only:                   no
+connection.permissions:                 --
+connection.zone:                        --
+connection.master:                      --
+connection.slave-type:                  --
+connection.autoconnect-slaves:          -1 (default)
+connection.secondaries:                 --
+connection.gateway-ping-timeout:        0
+connection.metered:                     unknown
+connection.lldp:                        default
+connection.mdns:                        -1 (default)
+ipv4.method:                            auto
+ipv4.dns:                               --
+ipv4.dns-search:                        --
+ipv4.dns-options:                       ""
+ipv4.dns-priority:                      0
+ipv4.addresses:                         --
+ipv4.gateway:                           --
+ipv4.routes:                            --
+ipv4.route-metric:                      -1
+ipv4.route-table:                       0 (unspec)
+ipv4.ignore-auto-routes:                no
+ipv4.ignore-auto-dns:                   no
+ipv4.dhcp-client-id:                    --
+ipv4.dhcp-timeout:                      0 (default)
+ipv4.dhcp-send-hostname:                yes
+ipv4.dhcp-hostname:                     --
+ipv4.dhcp-fqdn:                         --
+ipv4.never-default:                     no
+ipv4.may-fail:                          yes
+ipv4.dad-timeout:                       -1 (default)
+ipv6.method:                            auto
+ipv6.dns:                               --
+ipv6.dns-search:                        --
+ipv6.dns-options:                       ""
+ipv6.dns-priority:                      0
+ipv6.addresses:                         --
+ipv6.gateway:                           --
+ipv6.routes:                            --
+ipv6.route-metric:                      -1
+ipv6.route-table:                       0 (unspec)
+ipv6.ignore-auto-routes:                no
+ipv6.ignore-auto-dns:                   no
+ipv6.never-default:                     no
+ipv6.may-fail:                          yes
+ipv6.ip6-privacy:                       -1 (unknown)
+ipv6.addr-gen-mode:                     stable-privacy
+ipv6.dhcp-send-hostname:                yes
+ipv6.dhcp-hostname:                     --
+ipv6.token:                             --
+vpn.service-type:                       org.freedesktop.NetworkManager.openvpn
+vpn.user-name:                          --
+vpn.data:                               key1 = val1, key2 = val2, key3 = val3
+vpn.secrets:                            <hidden>
+vpn.persistent:                         no
+vpn.timeout:                            0
+proxy.method:                           none
+proxy.browser-only:                     no
+proxy.pac-url:                          --
+proxy.pac-script:                       --
+
+<<<
+stderr: 0 bytes
+>>>
+
+<<<

--- a/clients/tests/test-client.check-on-disk/test_004-026.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-026.expected
@@ -1,0 +1,82 @@
+location: clients/tests/test-client.py:857:test_004()/26
+cmd: $NMCLI -f ALL con s con-vpn-1
+lang: pl_PL.UTF-8
+returncode: 0
+stdout: 3241 bytes
+>>>
+connection.id:                          con-vpn-1
+connection.uuid:                        UUID-con-vpn-1-REPLACED-REPLACED-REP
+connection.stable-id:                   --
+connection.type:                        vpn
+connection.interface-name:              --
+connection.autoconnect:                 tak
+connection.autoconnect-priority:        0
+connection.autoconnect-retries:         -1 (default)
+connection.auth-retries:                -1
+connection.timestamp:                   0
+connection.read-only:                   nie
+connection.permissions:                 --
+connection.zone:                        --
+connection.master:                      --
+connection.slave-type:                  --
+connection.autoconnect-slaves:          -1 (default)
+connection.secondaries:                 --
+connection.gateway-ping-timeout:        0
+connection.metered:                     nieznane
+connection.lldp:                        default
+connection.mdns:                        -1 (default)
+ipv4.method:                            auto
+ipv4.dns:                               --
+ipv4.dns-search:                        --
+ipv4.dns-options:                       ""
+ipv4.dns-priority:                      0
+ipv4.addresses:                         --
+ipv4.gateway:                           --
+ipv4.routes:                            --
+ipv4.route-metric:                      -1
+ipv4.route-table:                       0 (unspec)
+ipv4.ignore-auto-routes:                nie
+ipv4.ignore-auto-dns:                   nie
+ipv4.dhcp-client-id:                    --
+ipv4.dhcp-timeout:                      0 (default)
+ipv4.dhcp-send-hostname:                tak
+ipv4.dhcp-hostname:                     --
+ipv4.dhcp-fqdn:                         --
+ipv4.never-default:                     nie
+ipv4.may-fail:                          tak
+ipv4.dad-timeout:                       -1 (default)
+ipv6.method:                            auto
+ipv6.dns:                               --
+ipv6.dns-search:                        --
+ipv6.dns-options:                       ""
+ipv6.dns-priority:                      0
+ipv6.addresses:                         --
+ipv6.gateway:                           --
+ipv6.routes:                            --
+ipv6.route-metric:                      -1
+ipv6.route-table:                       0 (unspec)
+ipv6.ignore-auto-routes:                nie
+ipv6.ignore-auto-dns:                   nie
+ipv6.never-default:                     nie
+ipv6.may-fail:                          tak
+ipv6.ip6-privacy:                       -1 (unknown)
+ipv6.addr-gen-mode:                     stable-privacy
+ipv6.dhcp-send-hostname:                tak
+ipv6.dhcp-hostname:                     --
+ipv6.token:                             --
+vpn.service-type:                       org.freedesktop.NetworkManager.openvpn
+vpn.user-name:                          --
+vpn.data:                               key1 = val1, key2 = val2, key3 = val3
+vpn.secrets:                            <hidden>
+vpn.persistent:                         nie
+vpn.timeout:                            0
+proxy.method:                           none
+proxy.browser-only:                     nie
+proxy.pac-url:                          --
+proxy.pac-script:                       --
+
+<<<
+stderr: 0 bytes
+>>>
+
+<<<

--- a/clients/tests/test-client.check-on-disk/test_004-027.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-027.expected
@@ -1,0 +1,18 @@
+location: clients/tests/test-client.py:863:test_004()/27
+cmd: $NMCLI -f VPN con s con-vpn-1
+lang: C
+returncode: 0
+stdout: 334 bytes
+>>>
+vpn.service-type:                       org.freedesktop.NetworkManager.openvpn
+vpn.user-name:                          --
+vpn.data:                               key1 = val1, key2 = val2, key3 = val3
+vpn.secrets:                            <hidden>
+vpn.persistent:                         no
+vpn.timeout:                            0
+
+<<<
+stderr: 0 bytes
+>>>
+
+<<<

--- a/clients/tests/test-client.check-on-disk/test_004-028.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-028.expected
@@ -1,0 +1,18 @@
+location: clients/tests/test-client.py:863:test_004()/28
+cmd: $NMCLI -f VPN con s con-vpn-1
+lang: pl_PL.UTF-8
+returncode: 0
+stdout: 335 bytes
+>>>
+vpn.service-type:                       org.freedesktop.NetworkManager.openvpn
+vpn.user-name:                          --
+vpn.data:                               key1 = val1, key2 = val2, key3 = val3
+vpn.secrets:                            <hidden>
+vpn.persistent:                         nie
+vpn.timeout:                            0
+
+<<<
+stderr: 0 bytes
+>>>
+
+<<<

--- a/clients/tests/test-client.check-on-disk/test_004-029.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-029.expected
@@ -1,0 +1,24 @@
+location: clients/tests/test-client.py:866:test_004()/29
+cmd: $NMCLI -f GENERAL con s con-vpn-1
+lang: C
+returncode: 0
+stdout: 667 bytes
+>>>
+GENERAL.NAME:                           con-vpn-1
+GENERAL.UUID:                           UUID-con-vpn-1-REPLACED-REPLACED-REP
+GENERAL.DEVICES:                        wlan0
+GENERAL.STATE:                          activated
+GENERAL.DEFAULT:                        no
+GENERAL.DEFAULT6:                       no
+GENERAL.SPEC-OBJECT:                    --
+GENERAL.VPN:                            yes
+GENERAL.DBUS-PATH:                      /org/freedesktop/NetworkManager/ActiveConnection/2
+GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/Settings/Connection/3
+GENERAL.ZONE:                           --
+GENERAL.MASTER-PATH:                    --
+
+<<<
+stderr: 0 bytes
+>>>
+
+<<<

--- a/clients/tests/test-client.check-on-disk/test_004-030.expected
+++ b/clients/tests/test-client.check-on-disk/test_004-030.expected
@@ -1,0 +1,24 @@
+location: clients/tests/test-client.py:866:test_004()/30
+cmd: $NMCLI -f GENERAL con s con-vpn-1
+lang: pl_PL.UTF-8
+returncode: 0
+stdout: 670 bytes
+>>>
+GENERAL.NAME:                           con-vpn-1
+GENERAL.UUID:                           UUID-con-vpn-1-REPLACED-REPLACED-REP
+GENERAL.DEVICES:                        wlan0
+GENERAL.STATE:                          aktywowano
+GENERAL.DEFAULT:                        nie
+GENERAL.DEFAULT6:                       nie
+GENERAL.SPEC-OBJECT:                    --
+GENERAL.VPN:                            tak
+GENERAL.DBUS-PATH:                      /org/freedesktop/NetworkManager/ActiveConnection/2
+GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/Settings/Connection/3
+GENERAL.ZONE:                           --
+GENERAL.MASTER-PATH:                    --
+
+<<<
+stderr: 0 bytes
+>>>
+
+<<<

--- a/clients/tests/test-client.py
+++ b/clients/tests/test-client.py
@@ -822,6 +822,48 @@ class TestNmcli(NmTestBase):
         self.call_nmcli_l(['con', 's', 'con-xx1'],
                           replace_stdout = replace_stdout)
 
+        self.async_wait()
+
+        replace_stdout.append((lambda: self.srv.findConnectionUuid('con-vpn-1'), 'UUID-con-vpn-1-REPLACED-REPLACED-REP'))
+
+        self.call_nmcli(['connection', 'add', 'type', 'vpn', 'con-name', 'con-vpn-1', 'ifname', '*', 'vpn-type', 'openvpn', 'vpn.data', 'key1 = val1,   key2  = val2, key3=val3'],
+                        replace_stdout = replace_stdout)
+
+        self.call_nmcli_l(['con', 's'],
+                          replace_stdout = replace_stdout)
+        self.call_nmcli_l(['con', 's', 'con-vpn-1'],
+                          replace_stdout = replace_stdout)
+
+        self.call_nmcli(['con', 'up', 'con-xx1'])
+        self.call_nmcli_l(['con', 's'],
+                          replace_stdout = replace_stdout)
+
+        self.call_nmcli(['con', 'up', 'con-vpn-1'])
+        self.call_nmcli_l(['con', 's'],
+                          replace_stdout = replace_stdout)
+        self.call_nmcli_l(['con', 's', 'con-vpn-1'],
+                          replace_stdout = replace_stdout)
+
+        self.async_wait()
+
+        self.srv.setProperty('/org/freedesktop/NetworkManager/ActiveConnection/2',
+                             'VpnState',
+                             dbus.UInt32(NM.VpnConnectionState.ACTIVATED))
+
+        self.call_nmcli_l(['con', 's', 'con-vpn-1'],
+                          replace_stdout = replace_stdout)
+
+        self.call_nmcli_l(['-f', 'ALL', 'con', 's', 'con-vpn-1'],
+                          replace_stdout = replace_stdout)
+
+        # This only filters 'vpn' settings from the connection profile.
+        # Contrary to '-f GENERAL' below, it does not show the properties of
+        # the activated VPN connection. This is a nmcli bug.
+        self.call_nmcli_l(['-f', 'VPN', 'con', 's', 'con-vpn-1'],
+                          replace_stdout = replace_stdout)
+
+        self.call_nmcli_l(['-f', 'GENERAL', 'con', 's', 'con-vpn-1'],
+                          replace_stdout = replace_stdout)
 
 ###############################################################################
 

--- a/clients/tests/test-client.py
+++ b/clients/tests/test-client.py
@@ -162,6 +162,11 @@ class Util:
             text = text2
         return b''.join([(t[0] if isinstance(t, tuple) else t) for t in text])
 
+    @staticmethod
+    def debug_dbus_interface():
+        # this is for printf debugging, not used in actual code.
+        os.system('busctl --user --verbose call org.freedesktop.NetworkManager /org/freedesktop org.freedesktop.DBus.ObjectManager GetManagedObjects')
+
 ###############################################################################
 
 class Configuration:

--- a/clients/tests/test-client.py
+++ b/clients/tests/test-client.py
@@ -280,8 +280,8 @@ class NMStubServer:
             raise AttributeError(member)
         return self._MethodProxy(self, member[3:])
 
-    def addConnection(self, connection, verify_connection = True):
-        return self.op_AddConnection(connection, verify_connection)
+    def addConnection(self, connection, do_verify_strict = True):
+        return self.op_AddConnection(connection, do_verify_strict)
 
     def findConnectionUuid(self, con_id):
         try:

--- a/clients/tests/test-client.py
+++ b/clients/tests/test-client.py
@@ -813,6 +813,10 @@ class TestNmcli(NmTestBase):
         self.call_nmcli(['connection', 'mod', 'con-xx1', 'ipv6.gateway', '::99'])
         self.call_nmcli(['connection', 'mod', 'con-xx1', '802.abc', ''])
         self.call_nmcli(['connection', 'mod', 'con-xx1', '802-11-wireless.band', 'a'])
+        self.call_nmcli(['connection', 'mod', 'con-xx1', 'ipv4.addresses', '192.168.77.5/24', 'ipv4.routes', '2.3.4.5/32 192.168.77.1', 'ipv6.addresses', '1:2:3:4::6/64', 'ipv6.routes', '1:2:3:4:5:6::5/128'])
+        self.call_nmcli_l(['con', 's', 'con-xx1'],
+                          replace_stdout = replace_stdout)
+
 
 ###############################################################################
 

--- a/clients/tests/test-client.py
+++ b/clients/tests/test-client.py
@@ -809,7 +809,7 @@ class TestNmcli(NmTestBase):
                         replace_stdout = replace_stdout)
 
         self.call_nmcli(['connection', 'mod', 'con-xx1', 'ip.gateway', ''])
-        self.call_nmcli(['connection', 'mod', 'con-xx1', 'ipv4.gateway', '172.16.0.1'])
+        self.call_nmcli(['connection', 'mod', 'con-xx1', 'ipv4.gateway', '172.16.0.1'], lang = 'pl')
         self.call_nmcli(['connection', 'mod', 'con-xx1', 'ipv6.gateway', '::99'])
         self.call_nmcli(['connection', 'mod', 'con-xx1', '802.abc', ''])
         self.call_nmcli(['connection', 'mod', 'con-xx1', '802-11-wireless.band', 'a'])

--- a/tools/test-networkmanager-service.py
+++ b/tools/test-networkmanager-service.py
@@ -43,14 +43,6 @@ class TestError(AssertionError):
 
 ###############################################################################
 
-IFACE_DBUS = 'org.freedesktop.DBus'
-
-class UnknownInterfaceException(dbus.DBusException):
-    _dbus_error_name = IFACE_DBUS + '.UnknownInterface'
-
-class UnknownPropertyException(dbus.DBusException):
-    _dbus_error_name = IFACE_DBUS + '.UnknownProperty'
-
 class Util:
 
     @staticmethod
@@ -86,6 +78,73 @@ class Util:
         else:
             r = tuple(Util.pseudorandom_stream(seed, 6))
         return '%02X:%02X:%02X:%02X:%02X:%02X' % r
+
+###############################################################################
+
+IFACE_DBUS              = 'org.freedesktop.DBus'
+IFACE_CONNECTION        = 'org.freedesktop.NetworkManager.Settings.Connection'
+IFACE_DEVICE            = 'org.freedesktop.NetworkManager.Device'
+IFACE_WIFI              = 'org.freedesktop.NetworkManager.Device.Wireless'
+IFACE_WIMAX             = 'org.freedesktop.NetworkManager.Device.WiMax'
+IFACE_TEST              = 'org.freedesktop.NetworkManager.LibnmGlibTest'
+IFACE_NM                = 'org.freedesktop.NetworkManager'
+IFACE_SETTINGS          = 'org.freedesktop.NetworkManager.Settings'
+IFACE_AGENT_MANAGER     = 'org.freedesktop.NetworkManager.AgentManager'
+IFACE_AGENT             = 'org.freedesktop.NetworkManager.SecretAgent'
+IFACE_WIRED             = 'org.freedesktop.NetworkManager.Device.Wired'
+IFACE_VLAN              = 'org.freedesktop.NetworkManager.Device.Vlan'
+IFACE_WIFI_AP           = 'org.freedesktop.NetworkManager.AccessPoint'
+IFACE_WIMAX_NSP         = 'org.freedesktop.NetworkManager.WiMax.Nsp'
+IFACE_ACTIVE_CONNECTION = 'org.freedesktop.NetworkManager.Connection.Active'
+IFACE_DNS_MANAGER       = 'org.freedesktop.NetworkManager.DnsManager'
+IFACE_OBJECT_MANAGER    = 'org.freedesktop.DBus.ObjectManager'
+
+###############################################################################
+
+class UnknownInterfaceException(dbus.DBusException):
+    _dbus_error_name = IFACE_DBUS + '.UnknownInterface'
+
+class UnknownPropertyException(dbus.DBusException):
+    _dbus_error_name = IFACE_DBUS + '.UnknownProperty'
+
+class InvalidPropertyException(dbus.DBusException):
+    _dbus_error_name = IFACE_CONNECTION + '.InvalidProperty'
+
+class MissingPropertyException(dbus.DBusException):
+    _dbus_error_name = IFACE_CONNECTION + '.MissingProperty'
+
+class InvalidSettingException(dbus.DBusException):
+    _dbus_error_name = IFACE_CONNECTION + '.InvalidSetting'
+
+class MissingSettingException(dbus.DBusException):
+    _dbus_error_name = IFACE_CONNECTION + '.MissingSetting'
+
+class NotSoftwareException(dbus.DBusException):
+    _dbus_error_name = IFACE_DEVICE + '.NotSoftware'
+
+class ApNotFoundException(dbus.DBusException):
+    _dbus_error_name = IFACE_WIFI + '.AccessPointNotFound'
+
+class NspNotFoundException(dbus.DBusException):
+    _dbus_error_name = IFACE_WIMAX + '.NspNotFound'
+
+class PermissionDeniedException(dbus.DBusException):
+    _dbus_error_name = IFACE_NM + '.PermissionDenied'
+
+class UnknownDeviceException(dbus.DBusException):
+    _dbus_error_name = IFACE_NM + '.UnknownDevice'
+
+class UnknownConnectionException(dbus.DBusException):
+    _dbus_error_name = IFACE_NM + '.UnknownConnection'
+
+class InvalidHostnameException(dbus.DBusException):
+    _dbus_error_name = IFACE_SETTINGS + '.InvalidHostname'
+
+class NoSecretsException(dbus.DBusException):
+    _dbus_error_name = IFACE_AGENT_MANAGER + '.NoSecrets'
+
+class UserCanceledException(dbus.DBusException):
+    _dbus_error_name = IFACE_AGENT_MANAGER + '.UserCanceled'
 
 ###############################################################################
 
@@ -232,11 +291,6 @@ class ExportedObj(dbus.service.Object):
 
 ###############################################################################
 
-IFACE_DEVICE = 'org.freedesktop.NetworkManager.Device'
-
-class NotSoftwareException(dbus.DBusException):
-    _dbus_error_name = IFACE_DEVICE + '.NotSoftware'
-
 PRP_DEVICE_UDI                   = "Udi"
 PRP_DEVICE_IFACE                 = "Interface"
 PRP_DEVICE_DRIVER                = "Driver"
@@ -300,8 +354,6 @@ class Device(ExportedObj):
 
 ###############################################################################
 
-IFACE_WIRED = 'org.freedesktop.NetworkManager.Device.Wired'
-
 PRP_WIRED_HW_ADDRESS       = "HwAddress"
 PRP_WIRED_PERM_HW_ADDRESS  = "PermHwAddress"
 PRP_WIRED_SPEED            = "Speed"
@@ -333,8 +385,6 @@ class WiredDevice(Device):
 
 ###############################################################################
 
-IFACE_VLAN = 'org.freedesktop.NetworkManager.Device.Vlan'
-
 PRP_VLAN_HW_ADDRESS = "HwAddress"
 PRP_VLAN_CARRIER    = "Carrier"
 PRP_VLAN_VLAN_ID    = "VlanId"
@@ -356,8 +406,6 @@ class VlanDevice(Device):
         pass
 
 ###############################################################################
-
-IFACE_WIFI_AP = 'org.freedesktop.NetworkManager.AccessPoint'
 
 PRP_WIFI_AP_FLAGS       = "Flags"
 PRP_WIFI_AP_WPA_FLAGS   = "WpaFlags"
@@ -425,11 +473,6 @@ class WifiAp(ExportedObj):
         pass
 
 ###############################################################################
-
-IFACE_WIFI = 'org.freedesktop.NetworkManager.Device.Wireless'
-
-class ApNotFoundException(dbus.DBusException):
-    _dbus_error_name = IFACE_WIFI + '.AccessPointNotFound'
 
 PRP_WIFI_HW_ADDRESS = "HwAddress"
 PRP_WIFI_PERM_HW_ADDRESS = "PermHwAddress"
@@ -509,8 +552,6 @@ class WifiDevice(Device):
 
 ###############################################################################
 
-IFACE_WIMAX_NSP = 'org.freedesktop.NetworkManager.WiMax.Nsp'
-
 PRP_WIMAX_NSP_NAME = "Name"
 PRP_WIMAX_NSP_SIGNAL_QUALITY = "SignalQuality"
 PRP_WIMAX_NSP_NETWORK_TYPE = "NetworkType"
@@ -548,11 +589,6 @@ class WimaxNsp(ExportedObj):
         pass
 
 ###############################################################################
-
-IFACE_WIMAX = 'org.freedesktop.NetworkManager.Device.WiMax'
-
-class NspNotFoundException(dbus.DBusException):
-    _dbus_error_name = IFACE_WIMAX + '.NspNotFound'
 
 PRP_WIMAX_NSPS = "Nsps"
 PRP_WIMAX_HW_ADDRESS = "HwAddress"
@@ -626,8 +662,6 @@ class WimaxDevice(Device):
         raise NspNotFoundException("NSP %s not found" % path)
 
 ###############################################################################
-
-IFACE_ACTIVE_CONNECTION = 'org.freedesktop.NetworkManager.Connection.Active'
 
 PRP_ACTIVE_CONNECTION_CONNECTION = "Connection"
 PRP_ACTIVE_CONNECTION_SPECIFIC_OBJECT = "SpecificObject"
@@ -719,18 +753,6 @@ class ActiveConnection(ExportedObj):
         pass
 
 ###############################################################################
-
-IFACE_TEST = 'org.freedesktop.NetworkManager.LibnmGlibTest'
-IFACE_NM = 'org.freedesktop.NetworkManager'
-
-class PermissionDeniedException(dbus.DBusException):
-    _dbus_error_name = IFACE_NM + '.PermissionDenied'
-
-class UnknownDeviceException(dbus.DBusException):
-    _dbus_error_name = IFACE_NM + '.UnknownDevice'
-
-class UnknownConnectionException(dbus.DBusException):
-    _dbus_error_name = IFACE_NM + '.UnknownConnection'
 
 PRP_NM_DEVICES                   = 'Devices'
 PRP_NM_ALL_DEVICES               = 'AllDevices'
@@ -1068,20 +1090,6 @@ class NetworkManager(ExportedObj):
 
 ###############################################################################
 
-IFACE_CONNECTION = 'org.freedesktop.NetworkManager.Settings.Connection'
-
-class InvalidPropertyException(dbus.DBusException):
-    _dbus_error_name = IFACE_CONNECTION + '.InvalidProperty'
-
-class MissingPropertyException(dbus.DBusException):
-    _dbus_error_name = IFACE_CONNECTION + '.MissingProperty'
-
-class InvalidSettingException(dbus.DBusException):
-    _dbus_error_name = IFACE_CONNECTION + '.InvalidSetting'
-
-class MissingSettingException(dbus.DBusException):
-    _dbus_error_name = IFACE_CONNECTION + '.MissingSetting'
-
 PRP_CONNECTION_UNSAVED = 'Unsaved'
 
 class Connection(ExportedObj):
@@ -1197,11 +1205,6 @@ class Connection(ExportedObj):
 
 ###############################################################################
 
-IFACE_SETTINGS = 'org.freedesktop.NetworkManager.Settings'
-
-class InvalidHostnameException(dbus.DBusException):
-    _dbus_error_name = IFACE_SETTINGS + '.InvalidHostname'
-
 PRP_SETTINGS_HOSTNAME = 'Hostname'
 PRP_SETTINGS_CAN_MODIFY = 'CanModify'
 PRP_SETTINGS_CONNECTIONS = 'Connections'
@@ -1301,8 +1304,6 @@ class Settings(ExportedObj):
 
 ###############################################################################
 
-IFACE_DNS_MANAGER = 'org.freedesktop.NetworkManager.DnsManager'
-
 PRP_DNS_MANAGER_MODE          = 'Mode'
 PRP_DNS_MANAGER_RC_MANAGER    = 'RcManager'
 PRP_DNS_MANAGER_CONFIGURATION = 'Configuration'
@@ -1331,20 +1332,11 @@ class DnsManager(ExportedObj):
 
 ###############################################################################
 
-IFACE_AGENT_MANAGER = 'org.freedesktop.NetworkManager.AgentManager'
-IFACE_AGENT = 'org.freedesktop.NetworkManager.SecretAgent'
-
 PATH_SECRET_AGENT = '/org/freedesktop/NetworkManager/SecretAgent'
 
 FLAG_ALLOW_INTERACTION = 0x1
 FLAG_REQUEST_NEW = 0x2
 FLAG_USER_REQUESTED = 0x4
-
-class NoSecretsException(dbus.DBusException):
-    _dbus_error_name = IFACE_AGENT_MANAGER + '.NoSecrets'
-
-class UserCanceledException(dbus.DBusException):
-    _dbus_error_name = IFACE_AGENT_MANAGER + '.UserCanceled'
 
 class AgentManager(dbus.service.Object):
     def __init__(self):
@@ -1389,8 +1381,6 @@ class AgentManager(dbus.service.Object):
         return secrets
 
 ###############################################################################
-
-IFACE_OBJECT_MANAGER = 'org.freedesktop.DBus.ObjectManager'
 
 class ObjectManager(dbus.service.Object):
     def __init__(self, object_path):

--- a/tools/test-networkmanager-service.py
+++ b/tools/test-networkmanager-service.py
@@ -101,50 +101,52 @@ IFACE_OBJECT_MANAGER    = 'org.freedesktop.DBus.ObjectManager'
 
 ###############################################################################
 
-class UnknownInterfaceException(dbus.DBusException):
-    _dbus_error_name = IFACE_DBUS + '.UnknownInterface'
+class BusErr:
 
-class UnknownPropertyException(dbus.DBusException):
-    _dbus_error_name = IFACE_DBUS + '.UnknownProperty'
+    class UnknownInterfaceException(dbus.DBusException):
+        _dbus_error_name = IFACE_DBUS + '.UnknownInterface'
 
-class InvalidPropertyException(dbus.DBusException):
-    _dbus_error_name = IFACE_CONNECTION + '.InvalidProperty'
+    class UnknownPropertyException(dbus.DBusException):
+        _dbus_error_name = IFACE_DBUS + '.UnknownProperty'
 
-class MissingPropertyException(dbus.DBusException):
-    _dbus_error_name = IFACE_CONNECTION + '.MissingProperty'
+    class InvalidPropertyException(dbus.DBusException):
+        _dbus_error_name = IFACE_CONNECTION + '.InvalidProperty'
 
-class InvalidSettingException(dbus.DBusException):
-    _dbus_error_name = IFACE_CONNECTION + '.InvalidSetting'
+    class MissingPropertyException(dbus.DBusException):
+        _dbus_error_name = IFACE_CONNECTION + '.MissingProperty'
 
-class MissingSettingException(dbus.DBusException):
-    _dbus_error_name = IFACE_CONNECTION + '.MissingSetting'
+    class InvalidSettingException(dbus.DBusException):
+        _dbus_error_name = IFACE_CONNECTION + '.InvalidSetting'
 
-class NotSoftwareException(dbus.DBusException):
-    _dbus_error_name = IFACE_DEVICE + '.NotSoftware'
+    class MissingSettingException(dbus.DBusException):
+        _dbus_error_name = IFACE_CONNECTION + '.MissingSetting'
 
-class ApNotFoundException(dbus.DBusException):
-    _dbus_error_name = IFACE_WIFI + '.AccessPointNotFound'
+    class NotSoftwareException(dbus.DBusException):
+        _dbus_error_name = IFACE_DEVICE + '.NotSoftware'
 
-class NspNotFoundException(dbus.DBusException):
-    _dbus_error_name = IFACE_WIMAX + '.NspNotFound'
+    class ApNotFoundException(dbus.DBusException):
+        _dbus_error_name = IFACE_WIFI + '.AccessPointNotFound'
 
-class PermissionDeniedException(dbus.DBusException):
-    _dbus_error_name = IFACE_NM + '.PermissionDenied'
+    class NspNotFoundException(dbus.DBusException):
+        _dbus_error_name = IFACE_WIMAX + '.NspNotFound'
 
-class UnknownDeviceException(dbus.DBusException):
-    _dbus_error_name = IFACE_NM + '.UnknownDevice'
+    class PermissionDeniedException(dbus.DBusException):
+        _dbus_error_name = IFACE_NM + '.PermissionDenied'
 
-class UnknownConnectionException(dbus.DBusException):
-    _dbus_error_name = IFACE_NM + '.UnknownConnection'
+    class UnknownDeviceException(dbus.DBusException):
+        _dbus_error_name = IFACE_NM + '.UnknownDevice'
 
-class InvalidHostnameException(dbus.DBusException):
-    _dbus_error_name = IFACE_SETTINGS + '.InvalidHostname'
+    class UnknownConnectionException(dbus.DBusException):
+        _dbus_error_name = IFACE_NM + '.UnknownConnection'
 
-class NoSecretsException(dbus.DBusException):
-    _dbus_error_name = IFACE_AGENT_MANAGER + '.NoSecrets'
+    class InvalidHostnameException(dbus.DBusException):
+        _dbus_error_name = IFACE_SETTINGS + '.InvalidHostname'
 
-class UserCanceledException(dbus.DBusException):
-    _dbus_error_name = IFACE_AGENT_MANAGER + '.UserCanceled'
+    class NoSecretsException(dbus.DBusException):
+        _dbus_error_name = IFACE_AGENT_MANAGER + '.NoSecrets'
+
+    class UserCanceledException(dbus.DBusException):
+        _dbus_error_name = IFACE_AGENT_MANAGER + '.UserCanceled'
 
 ###############################################################################
 
@@ -204,7 +206,7 @@ class ExportedObj(dbus.service.Object):
 
     def _dbus_interface_get(self, dbus_iface):
         if dbus_iface not in self._dbus_ifaces:
-            raise UnknownInterfaceException()
+            raise BusErr.UnknownInterfaceException()
         return self._dbus_ifaces[dbus_iface]
 
     def _dbus_interface_get_property(self, dbus_interface, propname = None):
@@ -212,7 +214,7 @@ class ExportedObj(dbus.service.Object):
         if propname is None:
             return props
         if propname not in props:
-            raise UnknownPropertyException()
+            raise BusErr.UnknownPropertyException()
         return props[propname]
 
     def _dbus_property_get(self, dbus_iface, propname = None):
@@ -342,7 +344,7 @@ class Device(ExportedObj):
     @dbus.service.method(dbus_interface=IFACE_DEVICE, in_signature='', out_signature='')
     def Delete(self):
         # We don't currently support any software device types, so...
-        raise NotSoftwareException()
+        raise BusErr.NotSoftwareException()
         pass
 
     @dbus.service.signal(IFACE_DEVICE, signature='a{sv}')
@@ -547,7 +549,7 @@ class WifiDevice(Device):
             if ap.path == path:
                 self.remove_ap(ap)
                 return
-        raise ApNotFoundException("AP %s not found" % path)
+        raise BusErr.ApNotFoundException("AP %s not found" % path)
 
 
 ###############################################################################
@@ -659,7 +661,7 @@ class WimaxDevice(Device):
             if nsp.path == path:
                 self.remove_nsp(nsp)
                 return
-        raise NspNotFoundException("NSP %s not found" % path)
+        raise BusErr.NspNotFoundException("NSP %s not found" % path)
 
 ###############################################################################
 
@@ -817,7 +819,7 @@ class NetworkManager(ExportedObj):
 
     @dbus.service.method(dbus_interface=IFACE_NM, in_signature='s', out_signature='o')
     def GetDeviceByIpIface(self, ip_iface):
-        d = self.find_device_first(ip_iface = ip_iface, require = UnknownDeviceException)
+        d = self.find_device_first(ip_iface = ip_iface, require = BusErr.UnknownDeviceException)
         return ExportedObj.to_path(d)
 
     @dbus.service.method(dbus_interface=IFACE_NM, in_signature='ooo', out_signature='o')
@@ -825,7 +827,7 @@ class NetworkManager(ExportedObj):
         try:
             con_inst = gl.settings.get_connection(conpath)
         except Exception as e:
-            raise UnknownConnectionException("Connection not found")
+            raise BusErr.UnknownConnectionException("Connection not found")
 
         con_hash = con_inst.con_hash
         s_con = con_hash[NM.SETTING_CONNECTION_SETTING_NAME]
@@ -836,7 +838,7 @@ class NetworkManager(ExportedObj):
             device = VlanDevice(ifname)
             self.add_device(device)
         if not device:
-            raise UnknownDeviceException("No device found for the requested iface.")
+            raise BusErr.UnknownDeviceException("No device found for the requested iface.")
 
         # See if we need secrets. For the moment, we only support WPA
         if '802-11-wireless-security' in con_hash:
@@ -844,12 +846,12 @@ class NetworkManager(ExportedObj):
             if (s_wsec['key-mgmt'] == 'wpa-psk' and 'psk' not in s_wsec):
                 secrets = gl.agent_manager.get_secrets(con_hash, conpath, '802-11-wireless-security')
                 if secrets is None:
-                    raise NoSecretsException("No secret agent available")
+                    raise BusErr.NoSecretsException("No secret agent available")
                 if '802-11-wireless-security' not in secrets:
-                    raise NoSecretsException("No secrets provided")
+                    raise BusErr.NoSecretsException("No secrets provided")
                 s_wsec = secrets['802-11-wireless-security']
                 if 'psk' not in s_wsec:
-                    raise NoSecretsException("No secrets provided")
+                    raise BusErr.NoSecretsException("No secrets provided")
 
         ac = ActiveConnection(device, con_inst, None)
         self.active_connection_add(ac)
@@ -877,7 +879,7 @@ class NetworkManager(ExportedObj):
 
     @dbus.service.method(dbus_interface=IFACE_NM, in_signature='a{sa{sv}}oo', out_signature='oo')
     def AddAndActivateConnection(self, con_hash, devpath, specific_object):
-        device = self.find_device_first(path = devpath, require = UnknownDeviceException)
+        device = self.find_device_first(path = devpath, require = BusErr.UnknownDeviceException)
         conpath = gl.settings.AddConnection(con_hash)
         return (conpath, self.ActivateConnection(conpath, devpath, specific_object))
 
@@ -924,7 +926,7 @@ class NetworkManager(ExportedObj):
 
     @dbus.service.method(dbus_interface=IFACE_NM, in_signature='', out_signature='u')
     def CheckConnectivity(self):
-        raise PermissionDeniedException("You fail")
+        raise BusErr.PermissionDeniedException("You fail")
 
     @dbus.service.signal(IFACE_NM, signature='o')
     def DeviceAdded(self, devpath):
@@ -956,7 +958,7 @@ class NetworkManager(ExportedObj):
         if r is None and require:
             if require is TestError:
                 raise TestError('Device not found')
-            raise UnknownDeviceException('Device not found')
+            raise BusErr.UnknownDeviceException('Device not found')
         return r
 
     def add_device(self, device):
@@ -1142,14 +1144,14 @@ class Connection(ExportedObj):
         if con_hash is None:
             con_hash = self.con_hash;
         if NM.SETTING_CONNECTION_SETTING_NAME not in con_hash:
-            raise MissingSettingException('connection: setting is required')
+            raise BusErr.MissingSettingException('connection: setting is required')
         s_con = con_hash[NM.SETTING_CONNECTION_SETTING_NAME]
         if NM.SETTING_CONNECTION_TYPE not in s_con:
-            raise MissingPropertyException('connection.type: property is required')
+            raise BusErr.MissingPropertyException('connection.type: property is required')
         if NM.SETTING_CONNECTION_UUID not in s_con:
-            raise MissingPropertyException('connection.uuid: property is required')
+            raise BusErr.MissingPropertyException('connection.uuid: property is required')
         if NM.SETTING_CONNECTION_ID not in s_con:
-            raise MissingPropertyException('connection.id: property is required')
+            raise BusErr.MissingPropertyException('connection.id: property is required')
 
         if not verify_strict:
             return;
@@ -1158,7 +1160,7 @@ class Connection(ExportedObj):
                       NM.SETTING_WIRELESS_SETTING_NAME,
                       NM.SETTING_VLAN_SETTING_NAME,
                       NM.SETTING_WIMAX_SETTING_NAME ]:
-            raise InvalidPropertyException('connection.type: unsupported connection type "%s"' % (t))
+            raise BusErr.InvalidPropertyException('connection.type: unsupported connection type "%s"' % (t))
 
     def update_connection(self, con_hash, verify_connection):
         self.verify(con_hash, verify_strict=verify_connection)
@@ -1166,7 +1168,7 @@ class Connection(ExportedObj):
         old_uuid = self.get_uuid()
         new_uuid = self.get_uuid(con_hash)
         if old_uuid != new_uuid:
-            raise InvalidPropertyException('connection.uuid: cannot change the uuid from %s to %s' % (old_uuid, new_uuid))
+            raise BusErr.InvalidPropertyException('connection.uuid: cannot change the uuid from %s to %s' % (old_uuid, new_uuid))
 
         self.con_hash = con_hash;
         self.Updated()
@@ -1174,7 +1176,7 @@ class Connection(ExportedObj):
     @dbus.service.method(dbus_interface=IFACE_CONNECTION, in_signature='', out_signature='a{sa{sv}}')
     def GetSettings(self):
         if not self.visible:
-            raise PermissionDeniedException()
+            raise BusErr.PermissionDeniedException()
         return self.con_hash
 
     @dbus.service.method(dbus_interface=IFACE_CONNECTION, in_signature='b', out_signature='')
@@ -1259,7 +1261,7 @@ class Settings(ExportedObj):
 
         uuid = con_inst.get_uuid()
         if uuid in [c.get_uuid() for c in self.connections.values()]:
-            raise InvalidSettingException('cannot add duplicate connection with uuid %s' % (uuid))
+            raise BusErr.InvalidSettingException('cannot add duplicate connection with uuid %s' % (uuid))
 
         con_inst.export()
         self.connections[con_inst.path] = con_inst
@@ -1274,7 +1276,7 @@ class Settings(ExportedObj):
 
     def update_connection(self, con_hash, path=None, verify_connection=True):
         if path not in self.connections:
-            raise UnknownConnectionException('Connection not found')
+            raise BusErr.UnknownConnectionException('Connection not found')
         self.connections[path].update_connection(con_hash, verify_connection)
 
     def delete_connection(self, con_inst):
@@ -1287,7 +1289,7 @@ class Settings(ExportedObj):
     def SaveHostname(self, hostname):
         # Arbitrary requirement to test error handling
         if hostname.find('.') == -1:
-            raise InvalidHostnameException()
+            raise BusErr.InvalidHostnameException()
         self._dbus_property_set(IFACE_SETTINGS, PRP_SETTINGS_HOSTNAME, hostname)
 
     @dbus.service.signal(IFACE_SETTINGS, signature='o')
@@ -1376,7 +1378,7 @@ class AgentManager(dbus.service.Object):
                 break
             except dbus.DBusException as e:
                 if e.get_dbus_name() == IFACE_AGENT + '.UserCanceled':
-                    raise UserCanceledException('User canceled')
+                    raise BusErr.UserCanceledException('User canceled')
                 continue
         return secrets
 

--- a/tools/test-networkmanager-service.py
+++ b/tools/test-networkmanager-service.py
@@ -109,7 +109,7 @@ class Util:
                 if val.signature == 'au':
                     return GLib.Variant('aau', [Util.variant_from_dbus(x) for x in val])
                 if val.signature == 'a{sv}':
-                    return GLib.Variant('aa{sv}', [(str(k), Util.variant_from_dbus(v)) for k, v in val])
+                    return GLib.Variant('aa{sv}', [collections.OrderedDict([(str(k), Util.variant_from_dbus(v)) for k, v in addr.items()]) for addr in val])
                 if val.signature == '(ayuay)':
                     return GLib.Variant('a(ayuay)', [Util.variant_from_dbus(x) for x in val])
                 if val.signature == '(ayuayu)':


### PR DESCRIPTION
Extend unit tests to verify connection using libnm.

This war rather cumbersome to do, because our `test-networkmanager-service.py` uses python's D-Bus library, while libnm uses GDBus. Hence, I first had to convert the dbus structure to a GVariant, which is surprisingly complicated.