### PR TITLE
iwd secrets-related changes

### DIFF
--- a/clients/common/nm-secret-agent-simple.c
+++ b/clients/common/nm-secret-agent-simple.c
@@ -217,6 +217,21 @@ add_8021x_secrets (NMSecretAgentSimpleRequest *request,
 	const char *eap_method;
 	NMSecretAgentSimpleSecret *secret;
 
+	/* If hints are given, then always ask for what the hints require */
+	if (request->hints) {
+		char **iter;
+		for (iter = request->hints; *iter; iter++) {
+			secret = nm_secret_agent_simple_secret_new (NM_SECRET_AGENT_SECRET_TYPE_SECRET,
+			                                            _(*iter),
+			                                            NM_SETTING (s_8021x),
+			                                            *iter,
+			                                            NULL);
+			g_ptr_array_add (secrets, secret);
+		}
+
+		return TRUE;
+	}
+
 	eap_method = nm_setting_802_1x_get_eap_method (s_8021x, 0);
 	if (!eap_method)
 		return FALSE;

--- a/src/devices/wifi/nm-device-iwd.c
+++ b/src/devices/wifi/nm-device-iwd.c
@@ -1219,15 +1219,13 @@ act_stage1_prepare (NMDevice *device, NMDeviceStateReason *out_failure_reason)
 	ap = ap_path ? nm_wifi_ap_lookup_for_device (NM_DEVICE (self), ap_path) : NULL;
 	if (!ap) {
 		ap = nm_wifi_aps_find_first_compatible (&priv->aps_lst_head, connection);
-
-		/* TODO: assuming hidden networks aren't supported do we need
-		 * to consider the case of APs that are not in the scan list
-		 * yet, for which nm-device-wifi.c creates the temporary fake
-		 * AP object?
-		 */
+		if (!ap) {
+			NM_SET_OUT (out_failure_reason, NM_DEVICE_STATE_REASON_CONFIG_FAILED);
+			return NM_ACT_STAGE_RETURN_FAILURE;
+		}
 
 		nm_active_connection_set_specific_object (NM_ACTIVE_CONNECTION (req),
-	                                              nm_dbus_object_get_path (NM_DBUS_OBJECT (ap)));
+		                                          nm_dbus_object_get_path (NM_DBUS_OBJECT (ap)));
 	}
 
 	set_current_ap (self, ap, FALSE);

--- a/src/devices/wifi/nm-device-iwd.c
+++ b/src/devices/wifi/nm-device-iwd.c
@@ -545,7 +545,7 @@ check_connection_compatible (NMDevice *device, NMConnection *connection)
 		return FALSE;
 
 	mode = nm_setting_wireless_get_mode (s_wireless);
-	if (g_strcmp0 (mode, NM_SETTING_WIRELESS_MODE_INFRA) != 0)
+	if (mode && g_strcmp0 (mode, NM_SETTING_WIRELESS_MODE_INFRA) != 0)
 		return FALSE;
 
 	/* 8021x networks can only be used if they've been provisioned on the IWD side and
@@ -575,7 +575,7 @@ check_connection_available (NMDevice *device,
 
 	/* Only Infrastrusture mode at this time */
 	mode = nm_setting_wireless_get_mode (s_wifi);
-	if (g_strcmp0 (mode, NM_SETTING_WIRELESS_MODE_INFRA) != 0)
+	if (mode && g_strcmp0 (mode, NM_SETTING_WIRELESS_MODE_INFRA) != 0)
 		return FALSE;
 
 	/* Hidden SSIDs not supported yet */
@@ -630,7 +630,7 @@ complete_connection (NMDevice *device,
 
 	mode = s_wifi ? nm_setting_wireless_get_mode (s_wifi) : NULL;
 
-	if (s_wifi && !nm_streq0 (mode, NM_SETTING_WIRELESS_MODE_INFRA)) {
+	if (mode && !nm_streq0 (mode, NM_SETTING_WIRELESS_MODE_INFRA)) {
 		g_set_error_literal (error,
 		                     NM_DEVICE_ERROR,
 		                     NM_DEVICE_ERROR_INVALID_CONNECTION,
@@ -806,7 +806,7 @@ can_auto_connect (NMDevice *device,
 
 	/* Only Infrastrusture mode */
 	mode = nm_setting_wireless_get_mode (s_wifi);
-	if (g_strcmp0 (mode, NM_SETTING_WIRELESS_MODE_INFRA) != 0)
+	if (mode && g_strcmp0 (mode, NM_SETTING_WIRELESS_MODE_INFRA) != 0)
 		return FALSE;
 
 	/* Don't autoconnect to networks that have been tried at least once

--- a/src/devices/wifi/nm-device-iwd.h
+++ b/src/devices/wifi/nm-device-iwd.h
@@ -51,8 +51,8 @@ NMDevice *nm_device_iwd_new (const char *iface, NMDeviceWifiCapabilities capabil
 
 void nm_device_iwd_set_dbus_object (NMDeviceIwd *device, GDBusObject *object);
 
-gboolean nm_device_iwd_agent_psk_query (NMDeviceIwd *device,
-                                        GDBusMethodInvocation *invocation);
+gboolean nm_device_iwd_agent_query (NMDeviceIwd *device,
+                                    GDBusMethodInvocation *invocation);
 
 const CList *_nm_device_iwd_get_aps (NMDeviceIwd *self);
 


### PR DESCRIPTION
I'm attempting to make 802.1x networks work with the IWD backend.  These patches enable IWD agent requests for TLS/TTLS/PEAP private key passwords to be sent to the NM clients' secret agents. To convey which secrets IWD wants specifically, I'm using the setting_name and hints parameters in the GetSecrets call although I'm not 100% clear this is the intended use but it seems to be at least one of the allowed uses. If this is Ok, I'll need to separately make sure this works with nm-applet and the Gnome Shell.
The NMSettingsConnection change (last commit) was prompted by the settings plugin I sent to the list but this change can be seen as independent from the plugin too.