### PR TITLE
contrib/rpm: Use Open vSwitch instead of OpenVSwitch

### DIFF
--- a/contrib/fedora/rpm/NetworkManager.spec
+++ b/contrib/fedora/rpm/NetworkManager.spec
@@ -289,13 +289,13 @@ devices.
 
 %if %{with ovs}
 %package ovs
-Summary: OpenVSwitch device plugin for NetworkManager
+Summary: Open vSwitch device plugin for NetworkManager
 Group: System Environment/Base
 Requires: %{name}%{?_isa} = %{epoch}:%{version}-%{release}
 Requires: openvswitch
 
 %description ovs
-This package contains NetworkManager support for OpenVSwitch bridges.
+This package contains NetworkManager support for Open vSwitch bridges.
 %endif
 
 


### PR DESCRIPTION
The correct naming is Open vSwitch so use it instead of OpenVSwitch

Fixes: 830a5a14cb29ca00b73a9623c1ea7c5cd92f4d00