### PR TITLE
platform: wpan: fix compilation on s390x

### DIFF
--- a/src/platform/nm-netlink.h
+++ b/src/platform/nm-netlink.h
@@ -237,8 +237,8 @@ nla_put_string (struct nl_msg *msg, int attrtype, const char *str)
 
 #define NLA_PUT_TYPE(msg, type, attrtype, value) \
 	do { \
-		type __tmp = value; \
-		NLA_PUT(msg, attrtype, sizeof(type), &__tmp); \
+		type __nla_tmp = value; \
+		NLA_PUT(msg, attrtype, sizeof(type), &__nla_tmp); \
 	} while(0)
 
 #define NLA_PUT_U8(msg, attrtype, value) \


### PR DESCRIPTION
On s390x htole16() is defined as a macro that uses a __tmp variable
and conflicts with NLA_PUT_TYPE().

 In file included from src/platform/wpan/nm-wpan-utils.h:26:0,
                  from src/platform/wpan/nm-wpan-utils.c:22:
 src/platform/wpan/nm-wpan-utils.c: In function 'nm_wpan_utils_set_pan_id':
 src/platform/wpan/nm-wpan-utils.c:216:42: error: declaration of '__tmp' shadows a previous local [-Werror=shadow]
   NLA_PUT_U16 (msg, NL802154_ATTR_PAN_ID, htole16 (pan_id));
                                           ^
 ./src/platform/nm-netlink.h:240:16: note: in definition of macro 'NLA_PUT_TYPE'
    type __tmp = value; \
                 ^
 src/platform/wpan/nm-wpan-utils.c:216:2: note: in expansion of macro 'NLA_PUT_U16'
   NLA_PUT_U16 (msg, NL802154_ATTR_PAN_ID, htole16 (pan_id));
   ^
 ./src/platform/nm-netlink.h:240:8: error: shadowed declaration is here [-Werror=shadow]
    type __tmp = value; \
         ^
 ./src/platform/nm-netlink.h:251:2: note: in expansion of macro 'NLA_PUT_TYPE'
   NLA_PUT_TYPE(msg, uint16_t, attrtype, value)
   ^
 src/platform/wpan/nm-wpan-utils.c:216:2: note: in expansion of macro 'NLA_PUT_U16'
   NLA_PUT_U16 (msg, NL802154_ATTR_PAN_ID, htole16 (pan_id));
   ^
 src/platform/wpan/nm-wpan-utils.c: In function 'nm_wpan_utils_set_short_addr':

Fixes: 4120ad243198095ad4629982c849802c3a8b5f5c