### PR TITLE
lr/hotspot hostname: default hotspot SSID to hostname

### DIFF
--- a/clients/common/nm-meta-setting-desc.c
+++ b/clients/common/nm-meta-setting-desc.c
@@ -7172,7 +7172,6 @@ static const NMMetaPropertyInfo *const property_infos_WIRELESS[] = {
 	PROPERTY_INFO_WITH_DESC (NM_SETTING_WIRELESS_SSID,
 	    .is_cli_option =                TRUE,
 	    .property_alias =               "ssid",
-	    .inf_flags =                    NM_META_PROPERTY_INF_FLAG_REQD,
 	    .prompt =                       N_("SSID"),
 	    .property_type = DEFINE_PROPERTY_TYPE (
 	        .get_fcn =                  _get_fcn_wireless_ssid,

--- a/libnm-core/nm-setting-wireless.c
+++ b/libnm-core/nm-setting-wireless.c
@@ -752,25 +752,6 @@ verify (NMSetting *setting, NMConnection *connection, GError **error)
 	gsize length;
 	GError *local = NULL;
 
-	if (!priv->ssid) {
-		g_set_error_literal (error,
-		                     NM_CONNECTION_ERROR,
-		                     NM_CONNECTION_ERROR_MISSING_PROPERTY,
-		                     _("property is missing"));
-		g_prefix_error (error, "%s.%s: ", NM_SETTING_WIRELESS_SETTING_NAME, NM_SETTING_WIRELESS_SSID);
-		return FALSE;
-	}
-
-	length = g_bytes_get_size (priv->ssid);
-	if (length == 0 || length > 32) {
-		g_set_error_literal (error,
-		                     NM_CONNECTION_ERROR,
-		                     NM_CONNECTION_ERROR_INVALID_PROPERTY,
-		                     _("SSID length is out of range <1-32> bytes"));
-		g_prefix_error (error, "%s.%s: ", NM_SETTING_WIRELESS_SETTING_NAME, NM_SETTING_WIRELESS_SSID);
-		return FALSE;
-	}
-
 	if (priv->mode && !g_strv_contains (valid_modes, priv->mode)) {
 		g_set_error (error,
 		             NM_CONNECTION_ERROR,
@@ -779,6 +760,29 @@ verify (NMSetting *setting, NMConnection *connection, GError **error)
 		             priv->mode);
 		g_prefix_error (error, "%s.%s: ", NM_SETTING_WIRELESS_SETTING_NAME, NM_SETTING_WIRELESS_MODE);
 		return FALSE;
+	}
+
+	if (!priv->mode || strcmp (priv->mode, NM_SETTING_WIRELESS_MODE_INFRA) == 0) {
+		if (!priv->ssid) {
+			g_set_error_literal (error,
+			                     NM_CONNECTION_ERROR,
+			                     NM_CONNECTION_ERROR_MISSING_PROPERTY,
+			                     _("property is missing"));
+			g_prefix_error (error, "%s.%s: ", NM_SETTING_WIRELESS_SETTING_NAME, NM_SETTING_WIRELESS_SSID);
+			return FALSE;
+		}
+	}
+
+	if (priv->ssid) {
+		length = g_bytes_get_size (priv->ssid);
+		if (length == 0 || length > 32) {
+			g_set_error_literal (error,
+			                     NM_CONNECTION_ERROR,
+			                     NM_CONNECTION_ERROR_INVALID_PROPERTY,
+			                     _("SSID length is out of range <1-32> bytes"));
+			g_prefix_error (error, "%s.%s: ", NM_SETTING_WIRELESS_SETTING_NAME, NM_SETTING_WIRELESS_SSID);
+			return FALSE;
+		}
 	}
 
 	if (priv->band && !g_strv_contains (valid_bands, priv->band)) {

--- a/src/devices/wifi/nm-device-wifi.c
+++ b/src/devices/wifi/nm-device-wifi.c
@@ -2614,6 +2614,7 @@ act_stage1_prepare (NMDevice *device, NMDeviceStateReason *out_failure_reason)
 	NMSettingWireless *s_wireless;
 	const char *mode;
 	const char *ap_path;
+	GBytes *ssid;
 
 	req = nm_device_get_act_request (NM_DEVICE (self));
 	g_return_val_if_fail (req, NM_ACT_STAGE_RETURN_FAILURE);
@@ -2667,12 +2668,11 @@ act_stage1_prepare (NMDevice *device, NMDeviceStateReason *out_failure_reason)
 		 * AP gets used until the real one is found in the scan list (Ad-Hoc or Hidden),
 		 * or until the device is deactivated (Hotspot).
 		 */
-		ap_fake = nm_wifi_ap_new_fake_from_connection (connection);
+		ssid = nm_setting_wireless_get_ssid (s_wireless);
+		ap_fake = nm_wifi_ap_new_fake (connection, ssid);
+
 		if (!ap_fake)
 			g_return_val_if_reached (NM_ACT_STAGE_RETURN_FAILURE);
-
-		if (nm_wifi_ap_is_hotspot (ap_fake))
-			nm_wifi_ap_set_address (ap_fake, nm_device_get_hw_address (device));
 
 		g_object_freeze_notify (G_OBJECT (self));
 		ap_add_remove (self, TRUE, ap_fake, TRUE);

--- a/src/devices/wifi/nm-device-wifi.c
+++ b/src/devices/wifi/nm-device-wifi.c
@@ -2072,15 +2072,10 @@ supplicant_iface_state_cb (NMSupplicantInterface *iface,
 		 * schedule the next activation stage.
 		 */
 		if (devstate == NM_DEVICE_STATE_CONFIG) {
-			NMSettingWireless *s_wifi;
 			GBytes *ssid;
 			gs_free char *ssid_str = NULL;
 
-			s_wifi = nm_device_get_applied_setting (NM_DEVICE (self), NM_TYPE_SETTING_WIRELESS);
-
-			g_return_if_fail (s_wifi);
-
-			ssid = nm_setting_wireless_get_ssid (s_wifi);
+			ssid = nm_wifi_ap_get_ssid (priv->current_ap);
 			g_return_if_fail (ssid);
 
 			_LOGI (LOGD_DEVICE | LOGD_WIFI,
@@ -2089,6 +2084,7 @@ supplicant_iface_state_cb (NMSupplicantInterface *iface,
 			       ? "Started Wi-Fi Hotspot"
 			       : "Connected to wireless network",
 			       (ssid_str = _nm_utils_ssid_to_string (ssid)));
+
 			nm_device_activate_schedule_stage3_ip_config_start (device);
 		} else if (devstate == NM_DEVICE_STATE_ACTIVATED)
 			periodic_update (self);
@@ -2457,6 +2453,7 @@ static NMSupplicantConfig *
 build_supplicant_config (NMDeviceWifi *self,
                          NMConnection *connection,
                          guint32 fixed_freq,
+                         GBytes *ssid,
                          GError **error)
 {
 	NMDeviceWifiPrivate *priv = NM_DEVICE_WIFI_GET_PRIVATE (self);
@@ -2486,6 +2483,7 @@ build_supplicant_config (NMDeviceWifi *self,
 	if (!nm_supplicant_config_add_setting_wireless (config,
 	                                                s_wireless,
 	                                                fixed_freq,
+	                                                ssid,
 	                                                error)) {
 		g_prefix_error (error, "802-11-wireless: ");
 		goto error;
@@ -2828,7 +2826,10 @@ act_stage2_config (NMDevice *device, NMDeviceStateReason *out_failure_reason)
 		set_powersave (device);
 
 	/* Build up the supplicant configuration */
-	config = build_supplicant_config (self, connection, nm_wifi_ap_get_freq (ap), &error);
+	config = build_supplicant_config (self, connection,
+	                                  nm_wifi_ap_get_freq (ap),
+	                                  nm_wifi_ap_get_ssid (ap),
+	                                  &error);
 	if (config == NULL) {
 		_LOGE (LOGD_DEVICE | LOGD_WIFI,
 		       "Activation: (wifi) couldn't build wireless configuration: %s",

--- a/src/devices/wifi/nm-device-wifi.c
+++ b/src/devices/wifi/nm-device-wifi.c
@@ -38,6 +38,7 @@
 #include "nm-wifi-common.h"
 #include "nm-core-internal.h"
 #include "nm-config.h"
+#include "nm-hostname-manager.h"
 
 #include "devices/nm-device-logging.h"
 _LOG_DECLARE_SELF(NMDeviceWifi);
@@ -2669,6 +2670,10 @@ act_stage1_prepare (NMDevice *device, NMDeviceStateReason *out_failure_reason)
 		 * or until the device is deactivated (Hotspot).
 		 */
 		ssid = nm_setting_wireless_get_ssid (s_wireless);
+		if (!ssid) {
+			const char *hostname = nm_hostname_manager_get_pretty_hostname (nm_hostname_manager_get ());
+			ssid = g_bytes_new (hostname, strlen (hostname));
+		}
 		ap_fake = nm_wifi_ap_new_fake (connection, ssid);
 
 		if (!ap_fake)

--- a/src/devices/wifi/nm-wifi-ap.h
+++ b/src/devices/wifi/nm-wifi-ap.h
@@ -40,9 +40,11 @@ typedef struct _NMWifiAPClass NMWifiAPClass;
 
 GType nm_wifi_ap_get_type (void);
 
-NMWifiAP *   nm_wifi_ap_new_from_properties      (const char *supplicant_path,
-                                                  GVariant *properties);
-NMWifiAP *   nm_wifi_ap_new_fake_from_connection (NMConnection *connection);
+NMWifiAP *        nm_wifi_ap_new_from_properties      (const char *supplicant_path,
+                                                       GVariant *properties);
+
+NMWifiAP *        nm_wifi_ap_new_fake                 (NMConnection *connection,
+                                                       GBytes *ssid);
 
 gboolean          nm_wifi_ap_update_from_properties   (NMWifiAP *ap,
                                                        const char *supplicant_path,

--- a/src/nm-hostname-manager.h
+++ b/src/nm-hostname-manager.h
@@ -42,6 +42,8 @@ void nm_hostname_manager_set_transient_hostname (NMHostnameManager *self,
 gboolean nm_hostname_manager_get_transient_hostname (NMHostnameManager *self,
                                                      char **hostname);
 
+const char *nm_hostname_manager_get_pretty_hostname (NMHostnameManager *self);
+
 gboolean nm_hostname_manager_validate_hostname (const char *hostname);
 
 #endif  /* __NM_HOSTNAME_MANAGER_H__ */

--- a/src/supplicant/nm-supplicant-config.c
+++ b/src/supplicant/nm-supplicant-config.c
@@ -447,13 +447,13 @@ gboolean
 nm_supplicant_config_add_setting_wireless (NMSupplicantConfig * self,
                                            NMSettingWireless * setting,
                                            guint32 fixed_freq,
+                                           GBytes *ssid,
                                            GError **error)
 {
 	NMSupplicantConfigPrivate *priv;
 	gboolean is_adhoc, is_ap, is_mesh;
 	const char *mode, *band;
 	guint32 channel;
-	GBytes *ssid;
 	const char *bssid;
 
 	g_return_val_if_fail (NM_IS_SUPPLICANT_CONFIG (self), FALSE);
@@ -471,7 +471,6 @@ nm_supplicant_config_add_setting_wireless (NMSupplicantConfig * self,
 	else
 		priv->ap_scan = 1;
 
-	ssid = nm_setting_wireless_get_ssid (setting);
 	if (!nm_supplicant_config_add_option (self, "ssid",
 	                                      (char *) g_bytes_get_data (ssid, NULL),
 	                                      g_bytes_get_size (ssid),

--- a/src/supplicant/nm-supplicant-config.h
+++ b/src/supplicant/nm-supplicant-config.h
@@ -39,6 +39,7 @@ GHashTable *nm_supplicant_config_get_blobs (NMSupplicantConfig *self);
 gboolean nm_supplicant_config_add_setting_wireless (NMSupplicantConfig *self,
                                                     NMSettingWireless *setting,
                                                     guint32 fixed_freq,
+                                                    GBytes *ssid,
                                                     GError **error);
 
 gboolean nm_supplicant_config_add_bgscan           (NMSupplicantConfig *self,

--- a/src/supplicant/tests/test-supplicant-config.c
+++ b/src/supplicant/tests/test-supplicant-config.c
@@ -100,9 +100,11 @@ build_supplicant_config (NMConnection *connection,
 
 	s_wifi = nm_connection_get_setting_wireless (connection);
 	g_assert (s_wifi);
+
 	success = nm_supplicant_config_add_setting_wireless (config,
 	                                                     s_wifi,
 	                                                     fixed_freq,
+	                                                     nm_setting_wireless_get_ssid (s_wifi),
 	                                                     &error);
 	g_assert_no_error (error);
 	g_assert (success);


### PR DESCRIPTION
Both Cinnamon and GNOME always forcibly set the hotspot SSID to a hostname on activation. They override what the user has set, which is not too nice. However they have no way of telling whether the actual wifi.ssid is what the user has set, or what the hostname was previously.

Make their lives easier -- allow keeping the SSID blank on hotspots and just tell supplicant to use a current (pretty) hostname.