### PR TITLE
checkpatch: fix perldoc heading

### DIFF
--- a/contrib/scripts/checkpatch.pl
+++ b/contrib/scripts/checkpatch.pl
@@ -20,7 +20,7 @@
 
 =head1 NAME
 
-checkpatch.pl - emulate a serial modem
+checkpatch.pl - check for common mistakes
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
The script does not actually emulate a serial modem (yet).