### PR TITLE
agent-manager: order newer agents befor the old one

### DIFF
--- a/src/settings/nm-agent-manager.c
+++ b/src/settings/nm-agent-manager.c
@@ -349,7 +349,7 @@ agent_register_permissions_done (NMAuthChain *chain,
 		priv->agent_version_id += 1;
 		sender = nm_secret_agent_get_dbus_owner (agent);
 		g_hash_table_insert (priv->agents, g_strdup (sender), agent);
-		_LOGD (agent, "agent registered");
+		_LOGI (agent, "agent registered");
 		g_dbus_method_invocation_return_value (context, NULL);
 
 		/* Signal an agent was registered */

--- a/src/settings/nm-agent-manager.c
+++ b/src/settings/nm-agent-manager.c
@@ -651,12 +651,14 @@ agent_compare_func (gconstpointer aa, gconstpointer bb, gpointer user_data)
 	NMSessionMonitor *sm;
 	gboolean a_active, b_active;
 	gulong a_pid, b_pid, requester;
+	guint64 a_start, b_start;
+
+	a_pid = nm_secret_agent_get_pid (a);
+	b_pid = nm_secret_agent_get_pid (b);
 
 	/* Prefer agents in the process the request came from */
 	if (nm_auth_subject_is_unix_process (req->subject)) {
 		requester = nm_auth_subject_get_unix_process_pid (req->subject);
-		a_pid = nm_secret_agent_get_pid (a);
-		b_pid = nm_secret_agent_get_pid (b);
 
 		if (a_pid != b_pid) {
 			if (a_pid == requester)
@@ -672,9 +674,15 @@ agent_compare_func (gconstpointer aa, gconstpointer bb, gpointer user_data)
 	b_active = nm_session_monitor_session_exists (sm, nm_secret_agent_get_owner_uid (b), TRUE);
 	if (a_active && !b_active)
 		return -1;
-	else if (a_active == b_active)
-		return 0;
 	else if (!a_active && b_active)
+		return 1;
+
+	/* Prefer agents launched later (this is essentially to ease agent debugging) */
+	a_start = nm_utils_get_start_time_for_pid (a_pid, NULL, NULL);
+	b_start = nm_utils_get_start_time_for_pid (b_pid, NULL, NULL);
+	if (a_start > b_start)
+		return -1;
+	else if (a_start < b_start)
 		return 1;
 
 	return 0;


### PR DESCRIPTION
This is a mere debugging convenience thing: e.g. if you run, but want to
check whether nm-applet or nmcli agent works fine, it's convenient that
the agent you run later gets a chance to deal with the secrets requests
first.

Is seems to do the job and is simpler that adding some more complicated
policy (e.g. introducing priorities or something).