### PR TITLE
lr/compiler-options: sync with network-manager-applet

### DIFF
--- a/m4/compiler_options.m4
+++ b/m4/compiler_options.m4
@@ -92,7 +92,7 @@ if test "$GCC" = "yes" -a "$set_more_warnings" != "no"; then
 		      -Wno-unused-parameter \
 		      ; do
 		dnl GCC 4.4 does not warn when checking for -Wno-* flags (https://gcc.gnu.org/wiki/FAQ#wnowarning)
-		_NM_COMPILER_FLAG([$(printf '%s' "$option" | sed 's/^-Wno-/-W/')], [],
+		_NM_COMPILER_FLAG([-Wall $(printf '%s' "$option" | sed 's/^-Wno-/-W/')], [],
 		                  [CFLAGS_MORE_WARNINGS="$CFLAGS_MORE_WARNINGS $option"], [])
 	done
 	unset option

--- a/m4/introspection.m4
+++ b/m4/introspection.m4
@@ -25,46 +25,43 @@ m4_define([_GOBJECT_INTROSPECTION_CHECK_INTERNAL],
                                  [enable_introspection=auto])
     ])dnl
 
-    AC_MSG_CHECKING([for gobject-introspection])
-
-    dnl presence/version checking
-    AS_CASE([$enable_introspection],
-    [no], [dnl
-        found_introspection="no (disabled, use --enable-introspection to enable)"
-    ],dnl
-    [yes],[dnl
-        PKG_CHECK_EXISTS([gobject-introspection-1.0],,
-                         AC_MSG_ERROR([gobject-introspection-1.0 is not installed]))
-        PKG_CHECK_EXISTS([gobject-introspection-1.0 >= $1],
-                         found_introspection=yes,
-                         AC_MSG_ERROR([You need to have gobject-introspection >= $1 installed to build AC_PACKAGE_NAME]))
-    ],dnl
-    [auto],[dnl
-        PKG_CHECK_EXISTS([gobject-introspection-1.0 >= $1], found_introspection=yes, found_introspection=no)
-	dnl Canonicalize enable_introspection
-	enable_introspection=$found_introspection
-    ],dnl
-    [dnl
-        AC_MSG_ERROR([invalid argument passed to --enable-introspection, should be one of @<:@no/auto/yes@:>@])
-    ])dnl
-
-    AC_MSG_RESULT([$found_introspection])
-
     INTROSPECTION_SCANNER=
     INTROSPECTION_COMPILER=
     INTROSPECTION_GENERATE=
     INTROSPECTION_GIRDIR=
     INTROSPECTION_TYPELIBDIR=
-    if test "x$found_introspection" = "xyes"; then
-       INTROSPECTION_SCANNER=`$PKG_CONFIG --variable=g_ir_scanner gobject-introspection-1.0`
-       INTROSPECTION_COMPILER=`$PKG_CONFIG --variable=g_ir_compiler gobject-introspection-1.0`
-       INTROSPECTION_GENERATE=`$PKG_CONFIG --variable=g_ir_generate gobject-introspection-1.0`
-       INTROSPECTION_GIRDIR=`$PKG_CONFIG --variable=girdir gobject-introspection-1.0`
-       INTROSPECTION_TYPELIBDIR="$($PKG_CONFIG --variable=typelibdir gobject-introspection-1.0)"
-       INTROSPECTION_CFLAGS=`$PKG_CONFIG --cflags gobject-introspection-1.0`
-       INTROSPECTION_LIBS=`$PKG_CONFIG --libs gobject-introspection-1.0`
-       INTROSPECTION_MAKEFILE=`$PKG_CONFIG --variable=datadir gobject-introspection-1.0`/gobject-introspection-1.0/Makefile.introspection
+
+    if test "x$enable_introspection" == "xno"; then
+      found_introspection="no"
+    else
+       PKG_CHECK_EXISTS([gobject-introspection-1.0 >= $1], [
+           INTROSPECTION_SCANNER=`$PKG_CONFIG --variable=g_ir_scanner gobject-introspection-1.0`
+           INTROSPECTION_COMPILER=`$PKG_CONFIG --variable=g_ir_compiler gobject-introspection-1.0`
+           INTROSPECTION_GENERATE=`$PKG_CONFIG --variable=g_ir_generate gobject-introspection-1.0`
+           INTROSPECTION_GIRDIR=`$PKG_CONFIG --variable=girdir gobject-introspection-1.0`
+           INTROSPECTION_TYPELIBDIR="$($PKG_CONFIG --variable=typelibdir gobject-introspection-1.0)"
+           INTROSPECTION_CFLAGS=`$PKG_CONFIG --cflags gobject-introspection-1.0`
+           INTROSPECTION_LIBS=`$PKG_CONFIG --libs gobject-introspection-1.0`
+           INTROSPECTION_MAKEFILE=`$PKG_CONFIG --variable=datadir gobject-introspection-1.0`/gobject-introspection-1.0/Makefile.introspection
+
+           AC_MSG_CHECKING([if $INTROSPECTION_SCANNER works])
+           if CFLAGS="${CFLAGS} -Wno-error" "$INTROSPECTION_SCANNER" --namespace=test --library=c /dev/null --output /dev/null >&AS_MESSAGE_LOG_FD 2>&AS_MESSAGE_LOG_FD; then
+               found_introspection=yes
+           else
+               found_introspection="no (compiler failure -- check config.log)"
+           fi
+           AC_MSG_RESULT([$found_introspection])
+       ], [found_introspection="no (not installed)"])
+
+       if test "x$enable_introspection" == "xyes"; then
+          if test "x$found_introspection" != "xyes"; then
+              AC_MSG_ERROR([introspection enabled but can't be used])
+          fi
+       elif test "x$enable_introspection" != "xauto"; then
+          AC_MSG_ERROR([invalid argument passed to --enable-introspection, should be one of @<:@no/auto/yes@:>@])
+       fi
     fi
+
     AC_SUBST(INTROSPECTION_SCANNER, 'CFLAGS="${CFLAGS} -Wno-error" '"$INTROSPECTION_SCANNER")
     AC_SUBST(INTROSPECTION_COMPILER)
     AC_SUBST(INTROSPECTION_GENERATE)


### PR DESCRIPTION
Basically applies here too:

Before:

```
$ sh autogen.sh
...
checking whether "-Wformat-nonliteral" works as expected... not supported
checking whether "-Wformat-security" works as expected... not supported
checking whether "-Wno-format-y2k" works as expected... not supported
```

After:

```
$ sh autogen.sh
...
checking whether "-Wformat-nonliteral" works as expected... yes
checking whether "-Wformat-security" works as expected... yes
checking whether "-Wno-format-y2k" works as expected... yes
```
