### PR TITLE
th/wifi-gbytes-ssid

### DIFF
--- a/libnm-core/nm-core-internal.h
+++ b/libnm-core/nm-core-internal.h
@@ -328,6 +328,13 @@ gboolean _nm_dbus_error_has_name (GError     *error,
 
 /*****************************************************************************/
 
+char *_nm_utils_ssid_to_string_arr (const guint8 *ssid, gsize len);
+char *_nm_utils_ssid_to_string (GBytes *ssid);
+char *_nm_utils_ssid_to_utf8 (GBytes *ssid);
+gboolean _nm_utils_is_empty_ssid (GBytes *ssid);
+
+/*****************************************************************************/
+
 gboolean _nm_vpn_plugin_info_check_file (const char *filename,
                                          gboolean check_absolute,
                                          gboolean do_validate_filename,

--- a/libnm-core/nm-setting.c
+++ b/libnm-core/nm-setting.c
@@ -573,7 +573,7 @@ get_property_for_dbus (NMSetting *setting,
 	else if (g_type_is_a (prop_value.g_type, G_TYPE_FLAGS))
 		dbus_value = g_variant_new_uint32 (g_value_get_flags (&prop_value));
 	else if (prop_value.g_type == G_TYPE_BYTES)
-		dbus_value = _nm_utils_bytes_to_dbus (&prop_value);
+		dbus_value = nm_utils_gbytes_to_variant_ay (g_value_get_boxed (&prop_value));
 	else
 		dbus_value = g_dbus_gvalue_to_gvariant (&prop_value, variant_type_for_gtype (prop_value.g_type));
 	g_value_unset (&prop_value);

--- a/libnm-core/nm-utils-private.h
+++ b/libnm-core/nm-utils-private.h
@@ -74,7 +74,6 @@ GVariant *  _nm_utils_strdict_to_dbus   (const GValue *prop_value);
 void        _nm_utils_strdict_from_dbus (GVariant *dbus_value,
                                          GValue *prop_value);
 
-GVariant *  _nm_utils_bytes_to_dbus     (const GValue *prop_value);
 void        _nm_utils_bytes_from_dbus   (GVariant *dbus_value,
                                          GValue *prop_value);
 

--- a/libnm-core/nm-utils.c
+++ b/libnm-core/nm-utils.c
@@ -336,6 +336,18 @@ nm_utils_ssid_to_utf8 (const guint8 *ssid, gsize len)
 	return converted;
 }
 
+char *
+_nm_utils_ssid_to_utf8 (GBytes *ssid)
+{
+	const guint8 *p;
+	gsize l;
+
+	g_return_val_if_fail (ssid, NULL);
+
+	p = g_bytes_get_data (ssid, &l);
+	return nm_utils_ssid_to_utf8 (p, l);
+}
+
 /* Shamelessly ripped from the Linux kernel ieee80211 stack */
 /**
  * nm_utils_is_empty_ssid:
@@ -361,6 +373,18 @@ nm_utils_is_empty_ssid (const guint8 *ssid, gsize len)
 			return FALSE;
 	}
 	return TRUE;
+}
+
+gboolean
+_nm_utils_is_empty_ssid (GBytes *ssid)
+{
+	const guint8 *p;
+	gsize l;
+
+	g_return_val_if_fail (ssid, FALSE);
+
+	p = g_bytes_get_data (ssid, &l);
+	return nm_utils_is_empty_ssid (p, l);
 }
 
 #define ESSID_MAX_SIZE 32
@@ -402,6 +426,37 @@ nm_utils_escape_ssid (const guint8 *ssid, gsize len)
 	}
 	*d = '\0';
 	return escaped;
+}
+
+char *
+_nm_utils_ssid_to_string_arr (const guint8 *ssid, gsize len)
+{
+	char *s_copy;
+	const char *s_cnst;
+
+	if (len == 0)
+		return g_strdup ("(empty)");
+
+	s_cnst = nm_utils_buf_utf8safe_escape (ssid, len, NM_UTILS_STR_UTF8_SAFE_FLAG_ESCAPE_CTRL, &s_copy);
+	nm_assert (s_cnst);
+
+	if (nm_utils_is_empty_ssid (ssid, len))
+		return g_strdup_printf ("\"%s\" (hidden)", s_cnst);
+
+	return g_strdup_printf ("\"%s\"", s_cnst);
+}
+
+char *
+_nm_utils_ssid_to_string (GBytes *ssid)
+{
+	gconstpointer p;
+	gsize l;
+
+	if (!ssid)
+		return g_strdup ("(none)");
+
+	p = g_bytes_get_data (ssid, &l);
+	return _nm_utils_ssid_to_string_arr (p, l);
 }
 
 /**

--- a/libnm-core/nm-utils.c
+++ b/libnm-core/nm-utils.c
@@ -5654,7 +5654,7 @@ _nm_utils_team_config_get (const char *conf,
 				g_ptr_array_free (data, TRUE);
 
 		} else if (json_is_array (json_element)) {
-			GPtrArray *data = g_ptr_array_new_with_free_func ((GDestroyNotify) g_free);
+			GPtrArray *data = g_ptr_array_new_with_free_func (g_free);
 			json_t *str_element;
 			int index;
 

--- a/libnm-core/nm-utils.c
+++ b/libnm-core/nm-utils.c
@@ -647,23 +647,6 @@ _nm_utils_ptrarray_find_first (gconstpointer *list, gssize len, gconstpointer ne
 	return -1;
 }
 
-GVariant *
-_nm_utils_bytes_to_dbus (const GValue *prop_value)
-{
-	GBytes *bytes = g_value_get_boxed (prop_value);
-
-	if (bytes) {
-		return g_variant_new_fixed_array (G_VARIANT_TYPE_BYTE,
-		                                  g_bytes_get_data (bytes, NULL),
-		                                  g_bytes_get_size (bytes),
-		                                  1);
-	} else {
-		return g_variant_new_fixed_array (G_VARIANT_TYPE_BYTE,
-		                                  NULL, 0,
-		                                  1);
-	}
-}
-
 void
 _nm_utils_bytes_from_dbus (GVariant *dbus_value,
                            GValue *prop_value)

--- a/libnm-core/tests/test-setting.c
+++ b/libnm-core/tests/test-setting.c
@@ -1002,7 +1002,7 @@ test_runner_loadbalance_sync_from_config (void)
 {
 	gs_unref_ptrarray GPtrArray *tx_hash = NULL;
 
-	tx_hash = g_ptr_array_new_with_free_func ((GDestroyNotify) g_free);
+	tx_hash = g_ptr_array_new_with_free_func (g_free);
 	g_ptr_array_add (tx_hash, g_strdup ("eth"));
 	g_ptr_array_add (tx_hash, g_strdup ("ipv4"));
 	g_ptr_array_add (tx_hash, g_strdup ("ipv6"));
@@ -1039,7 +1039,7 @@ test_runner_lacp_sync_from_config (void)
 {
 	gs_unref_ptrarray GPtrArray *tx_hash = NULL;
 
-	tx_hash = g_ptr_array_new_with_free_func ((GDestroyNotify) g_free);
+	tx_hash = g_ptr_array_new_with_free_func (g_free);
 	g_ptr_array_add (tx_hash, g_strdup ("eth"));
 	g_ptr_array_add (tx_hash, g_strdup ("ipv4"));
 	g_ptr_array_add (tx_hash, g_strdup ("ipv6"));

--- a/libnm-util/nm-setting.c
+++ b/libnm-util/nm-setting.c
@@ -321,7 +321,7 @@ nm_setting_to_hash (NMSetting *setting, NMSettingHashFlags flags)
 	property_specs = g_object_class_list_properties (G_OBJECT_GET_CLASS (setting), &n_property_specs);
 
 	hash = g_hash_table_new_full (g_str_hash, g_str_equal,
-	                              (GDestroyNotify) g_free, destroy_gvalue);
+	                              g_free, destroy_gvalue);
 
 	for (i = 0; i < n_property_specs; i++) {
 		GParamSpec *prop_spec = property_specs[i];

--- a/libnm-util/nm-utils.c
+++ b/libnm-util/nm-utils.c
@@ -491,7 +491,7 @@ nm_utils_gvalue_hash_dup (GHashTable *hash)
 	g_return_val_if_fail (hash != NULL, NULL);
 
 	table = g_hash_table_new_full (g_str_hash, g_str_equal,
-	                               (GDestroyNotify) g_free,
+	                               g_free,
 	                               value_destroy);
 
 	g_hash_table_foreach (hash, value_dup, table);

--- a/shared/nm-utils/nm-shared-utils.c
+++ b/shared/nm-utils/nm-shared-utils.c
@@ -118,6 +118,37 @@ nm_utils_strbuf_append (char **buf, gsize *len, const char *format, ...)
 /*****************************************************************************/
 
 /**
+ * nm_utils_gbytes_equals:
+ * @bytes: (allow-none): a #GBytes array to compare. Note that
+ *   %NULL is treated like an #GBytes array of length zero.
+ * @arr: the data pointer with @arr_len bytes
+ * @arr_len: the length of the data pointer
+ *
+ * Returns: %TRUE if @bytes contains the same data as @arr. As a
+ *   special case, a %NULL @bytes is treated like an empty array.
+ */
+gboolean
+nm_utils_gbytes_equals (GBytes *bytes,
+                        gconstpointer arr,
+                        gsize arr_len)
+{
+	gconstpointer p;
+	gsize l;
+
+	if (!bytes) {
+		/* as a special case, let %NULL GBytes compare idential
+		 * to an empty array. */
+		return (arr_len == 0);
+	}
+
+	p = g_bytes_get_data (bytes, &l);
+	return    l == arr_len
+	       && memcmp (p, arr, arr_len) == 0;
+}
+
+/*****************************************************************************/
+
+/**
  * nm_strquote:
  * @buf: the output buffer of where to write the quoted @str argument.
  * @buf_len: the size of @buf.

--- a/shared/nm-utils/nm-shared-utils.c
+++ b/shared/nm-utils/nm-shared-utils.c
@@ -146,6 +146,21 @@ nm_utils_gbytes_equals (GBytes *bytes,
 	       && memcmp (p, arr, arr_len) == 0;
 }
 
+GVariant *
+nm_utils_gbytes_to_variant_ay (GBytes *bytes)
+{
+	const guint8 *p;
+	gsize l;
+
+	if (!bytes) {
+		/* for convenience, accept NULL to return an empty variant */
+		return g_variant_new_array (G_VARIANT_TYPE_BYTE, NULL, 0);
+	}
+
+	p = g_bytes_get_data (bytes, &l);
+	return g_variant_new_fixed_array (G_VARIANT_TYPE_BYTE, p, l, 1);
+}
+
 /*****************************************************************************/
 
 /**

--- a/shared/nm-utils/nm-shared-utils.h
+++ b/shared/nm-utils/nm-shared-utils.h
@@ -206,6 +206,8 @@ gboolean nm_utils_gbytes_equals (GBytes *bytes,
                                  gconstpointer arr,
                                  gsize arr_len);
 
+GVariant *nm_utils_gbytes_to_variant_ay (GBytes *bytes);
+
 /*****************************************************************************/
 
 const char *nm_utils_dbus_path_get_last_component (const char *dbus_path);

--- a/shared/nm-utils/nm-shared-utils.h
+++ b/shared/nm-utils/nm-shared-utils.h
@@ -202,6 +202,12 @@ nm_utils_is_separator (const char c)
 
 /*****************************************************************************/
 
+gboolean nm_utils_gbytes_equals (GBytes *bytes,
+                                 gconstpointer arr,
+                                 gsize arr_len);
+
+/*****************************************************************************/
+
 const char *nm_utils_dbus_path_get_last_component (const char *dbus_path);
 
 int nm_utils_dbus_path_cmp (const char *dbus_path_a, const char *dbus_path_b);

--- a/shared/nm-utils/nm-shared-utils.h
+++ b/shared/nm-utils/nm-shared-utils.h
@@ -476,6 +476,10 @@ typedef enum {
 	NM_UTILS_STR_UTF8_SAFE_FLAG_ESCAPE_NON_ASCII    = 0x0002,
 } NMUtilsStrUtf8SafeFlags;
 
+const char *nm_utils_buf_utf8safe_escape (gconstpointer buf, gssize buflen, NMUtilsStrUtf8SafeFlags flags, char **to_free);
+const char *nm_utils_buf_utf8safe_escape_bytes (GBytes *bytes, NMUtilsStrUtf8SafeFlags flags, char **to_free);
+gconstpointer nm_utils_buf_utf8safe_unescape (const char *str, gsize *out_len, gpointer *to_free);
+
 const char *nm_utils_str_utf8safe_escape   (const char *str, NMUtilsStrUtf8SafeFlags flags, char **to_free);
 const char *nm_utils_str_utf8safe_unescape (const char *str, char **to_free);
 

--- a/src/devices/nm-device.c
+++ b/src/devices/nm-device.c
@@ -8065,35 +8065,35 @@ static GBytes *
 generate_duid_llt (const guint8 *hwaddr /* ETH_ALEN bytes */,
                    gint64 time)
 {
-	GByteArray *duid_arr;
+	guint8 *arr;
 	const guint16 duid_type = htons (1);
 	const guint16 hw_type = htons (ARPHRD_ETHER);
 	const guint32 duid_time = htonl (NM_MAX (0, time - EPOCH_DATETIME_200001010000));
 
-	duid_arr = g_byte_array_sized_new (2 + 4 + 2 + ETH_ALEN);
+	arr = g_new (guint8, 2 + 2 + 4 + ETH_ALEN);
 
-	g_byte_array_append (duid_arr, (const guint8 *) &duid_type, 2);
-	g_byte_array_append (duid_arr, (const guint8 *) &hw_type, 2);
-	g_byte_array_append (duid_arr, (const guint8 *) &duid_time, 4);
-	g_byte_array_append (duid_arr, hwaddr, ETH_ALEN);
+	memcpy (&arr[0], &duid_type, 2);
+	memcpy (&arr[2], &hw_type, 2);
+	memcpy (&arr[4], &duid_time, 4);
+	memcpy (&arr[8], hwaddr, ETH_ALEN);
 
-	return g_byte_array_free_to_bytes (duid_arr);
+	return g_bytes_new_take (arr, 2 + 2 + 4 + ETH_ALEN);
 }
 
 static GBytes *
 generate_duid_ll (const guint8 *hwaddr /* ETH_ALEN bytes */)
 {
-	GByteArray *duid_arr;
+	guint8 *arr;
 	const guint16 duid_type = htons (3);
 	const guint16 hw_type = htons (ARPHRD_ETHER);
 
-	duid_arr = g_byte_array_sized_new (2 + 2 + ETH_ALEN);
+	arr = g_new (guint8, 2 + 2 + ETH_ALEN);
 
-	g_byte_array_append (duid_arr, (const guint8 *) &duid_type, 2);
-	g_byte_array_append (duid_arr, (const guint8 *) &hw_type, 2);
-	g_byte_array_append (duid_arr, hwaddr, ETH_ALEN);
+	memcpy (&arr[0], &duid_type, 2);
+	memcpy (&arr[2], &hw_type, 2);
+	memcpy (&arr[4], hwaddr, ETH_ALEN);
 
-	return g_byte_array_free_to_bytes (duid_arr);
+	return g_bytes_new_take (arr, 2 + 2 + ETH_ALEN);
 }
 
 static GBytes *

--- a/src/devices/wifi/nm-device-iwd.c
+++ b/src/devices/wifi/nm-device-iwd.c
@@ -296,8 +296,11 @@ get_ordered_networks_cb (GObject *source, GAsyncResult *res, gpointer user_data)
 		props = g_variant_new ("a{sv}", &builder);
 
 		ap = nm_wifi_ap_new_from_properties (path, props);
-		if (name[0] != '\0')
-			nm_wifi_ap_set_ssid (ap, (const guint8 *) name, strlen (name));
+
+		nm_wifi_ap_set_ssid_arr (ap,
+		                         (const guint8 *) name,
+		                         NM_MIN (32, strlen (name)));
+
 		nm_wifi_ap_set_strength (ap, nm_wifi_utils_level_to_quality (signal / 100));
 		nm_wifi_ap_set_freq (ap, 2417);
 		nm_wifi_ap_set_max_bitrate (ap, 65000);

--- a/src/devices/wifi/nm-device-iwd.c
+++ b/src/devices/wifi/nm-device-iwd.c
@@ -473,7 +473,7 @@ is_connection_known_network (NMConnection *connection)
 {
 	NMSettingWireless *s_wireless;
 	GBytes *ssid;
-	gs_free char *str_ssid = NULL;
+	gs_free char *ssid_utf8 = NULL;
 
 	s_wireless = nm_connection_get_setting_wireless (connection);
 	if (!s_wireless)
@@ -483,11 +483,9 @@ is_connection_known_network (NMConnection *connection)
 	if (!ssid)
 		return FALSE;
 
-	str_ssid = nm_utils_ssid_to_utf8 (g_bytes_get_data (ssid, NULL),
-	                                  g_bytes_get_size (ssid));
-
+	ssid_utf8 = _nm_utils_ssid_to_utf8 (ssid);
 	return nm_iwd_manager_is_known_network (nm_iwd_manager_get (),
-	                                        str_ssid,
+	                                        ssid_utf8,
 	                                        get_connection_iwd_security (connection));
 }
 
@@ -637,10 +635,9 @@ complete_connection (NMDevice *device,
 	NMDeviceIwdPrivate *priv = NM_DEVICE_IWD_GET_PRIVATE (self);
 	NMSettingWireless *s_wifi;
 	const char *setting_mac;
-	char *str_ssid = NULL;
+	gs_free char *ssid_utf8 = NULL;
 	NMWifiAP *ap;
-	const GByteArray *ssid = NULL;
-	GByteArray *tmp_ssid = NULL;
+	GBytes *ssid;
 	GBytes *setting_ssid = NULL;
 	const char *perm_hw_addr;
 	const char *mode;
@@ -704,8 +701,7 @@ complete_connection (NMDevice *device,
 	}
 
 	ssid = nm_wifi_ap_get_ssid (ap);
-
-	if (ssid == NULL) {
+	if (!ssid) {
 		g_set_error_literal (error,
 		                     NM_DEVICE_ERROR,
 		                     NM_DEVICE_ERROR_INVALID_CONNECTION,
@@ -716,25 +712,18 @@ complete_connection (NMDevice *device,
 	if (!nm_wifi_ap_complete_connection (ap,
 	                                     connection,
 	                                     nm_wifi_utils_is_manf_default_ssid (ssid),
-	                                     error)) {
-		if (tmp_ssid)
-			g_byte_array_unref (tmp_ssid);
+	                                     error))
 		return FALSE;
-	}
 
-	str_ssid = nm_utils_ssid_to_utf8 (ssid->data, ssid->len);
-
+	ssid_utf8 = _nm_utils_ssid_to_utf8 (ssid);
 	nm_utils_complete_generic (nm_device_get_platform (device),
 	                           connection,
 	                           NM_SETTING_WIRELESS_SETTING_NAME,
 	                           existing_connections,
-	                           str_ssid,
-	                           str_ssid,
+	                           ssid_utf8,
+	                           ssid_utf8,
 	                           NULL,
 	                           TRUE);
-	g_free (str_ssid);
-	if (tmp_ssid)
-		g_byte_array_unref (tmp_ssid);
 
 	/* 8021x networks can only be used if they've been provisioned on the IWD side and
 	 * thus are Known Networks.
@@ -1251,7 +1240,7 @@ network_connect_cb (GObject *source, GAsyncResult *res, gpointer user_data)
 	NMConnection *connection;
 	NMSettingWireless *s_wifi;
 	GBytes *ssid;
-	gs_free char *str_ssid = NULL;
+	gs_free char *ssid_utf8 = NULL;
 
 	if (!_nm_dbus_proxy_call_finish (G_DBUS_PROXY (source), res,
 	                                 G_VARIANT_TYPE ("()"),
@@ -1303,15 +1292,14 @@ network_connect_cb (GObject *source, GAsyncResult *res, gpointer user_data)
 	if (!ssid)
 		goto failed;
 
-	str_ssid = nm_utils_ssid_to_utf8 (g_bytes_get_data (ssid, NULL),
-	                                  g_bytes_get_size (ssid));
+	ssid_utf8 = _nm_utils_ssid_to_utf8 (ssid);
 
 	_LOGI (LOGD_DEVICE | LOGD_WIFI,
 	       "Activation: (wifi) Stage 2 of 5 (Device Configure) successful.  Connected to '%s'.",
-	       str_ssid);
+	       ssid_utf8);
 	nm_device_activate_schedule_stage3_ip_config_start (device);
 
-	nm_iwd_manager_network_connected (nm_iwd_manager_get (), str_ssid,
+	nm_iwd_manager_network_connected (nm_iwd_manager_get (), ssid_utf8,
 	                                  get_connection_iwd_security (connection));
 
 	return;

--- a/src/devices/wifi/nm-device-olpc-mesh.c
+++ b/src/devices/wifi/nm-device-olpc-mesh.c
@@ -95,7 +95,6 @@ complete_connection (NMDevice *device,
                      GError **error)
 {
 	NMSettingOlpcMesh *s_mesh;
-	GByteArray *tmp;
 
 	s_mesh = nm_connection_get_setting_olpc_mesh (connection);
 	if (!s_mesh) {
@@ -104,10 +103,10 @@ complete_connection (NMDevice *device,
 	}
 
 	if (!nm_setting_olpc_mesh_get_ssid (s_mesh)) {
-		tmp = g_byte_array_sized_new (strlen (DEFAULT_SSID));
-		g_byte_array_append (tmp, (const guint8 *) DEFAULT_SSID, strlen (DEFAULT_SSID));
-		g_object_set (G_OBJECT (s_mesh), NM_SETTING_OLPC_MESH_SSID, tmp, NULL);
-		g_byte_array_free (tmp, TRUE);
+		gs_unref_bytes GBytes *ssid = NULL;
+
+		ssid = g_bytes_new_static (DEFAULT_SSID, NM_STRLEN (DEFAULT_SSID));
+		g_object_set (G_OBJECT (s_mesh), NM_SETTING_OLPC_MESH_SSID, ssid, NULL);
 	}
 
 	if (!nm_setting_olpc_mesh_get_dhcp_anycast_address (s_mesh)) {

--- a/src/devices/wifi/nm-device-wifi.c
+++ b/src/devices/wifi/nm-device-wifi.c
@@ -1515,11 +1515,7 @@ try_fill_ssid_for_hidden_ap (NMDeviceWifi *self,
 		s_wifi = nm_connection_get_setting_wireless (connection);
 		if (s_wifi) {
 			if (nm_settings_connection_has_seen_bssid (NM_SETTINGS_CONNECTION (connection), bssid)) {
-				GBytes *ssid = nm_setting_wireless_get_ssid (s_wifi);
-
-				nm_wifi_ap_set_ssid (ap,
-				                     g_bytes_get_data (ssid, NULL),
-				                     g_bytes_get_size (ssid));
+				nm_wifi_ap_set_ssid (ap, nm_setting_wireless_get_ssid (s_wifi));
 				break;
 			}
 		}

--- a/src/devices/wifi/nm-wifi-ap.c
+++ b/src/devices/wifi/nm-wifi-ap.c
@@ -104,32 +104,56 @@ nm_wifi_ap_get_ssid (const NMWifiAP *ap)
 }
 
 gboolean
-nm_wifi_ap_set_ssid (NMWifiAP *ap, const guint8 *ssid, gsize len)
+nm_wifi_ap_set_ssid_arr (NMWifiAP *ap,
+                         const guint8 *ssid,
+                         gsize ssid_len)
 {
 	NMWifiAPPrivate *priv;
 
 	g_return_val_if_fail (NM_IS_WIFI_AP (ap), FALSE);
-	g_return_val_if_fail (ssid == NULL || len > 0, FALSE);
+
+	if (ssid_len > 32)
+		g_return_val_if_reached (FALSE);
 
 	priv = NM_WIFI_AP_GET_PRIVATE (ap);
 
-	/* same SSID */
-	if (priv->ssid) {
-		const guint8 *p;
-		gsize l;
-
-		p = g_bytes_get_data (priv->ssid, &l);
-		if (   l == len
-		    && !memcmp (p, ssid, len))
-			return FALSE;
-	} else {
-		if (len == 0)
-			return FALSE;
-	}
+	if (nm_utils_gbytes_equals (priv->ssid, ssid, ssid_len))
+		return FALSE;
 
 	nm_clear_pointer (&priv->ssid, g_bytes_unref);
-	if (len > 0)
-		priv->ssid = g_bytes_new (ssid, len);
+	if (ssid_len > 0)
+		priv->ssid = g_bytes_new (ssid, ssid_len);
+
+	_notify (ap, PROP_SSID);
+	return TRUE;
+}
+
+gboolean
+nm_wifi_ap_set_ssid (NMWifiAP *ap, GBytes *ssid)
+{
+	NMWifiAPPrivate *priv;
+	gsize l;
+
+	g_return_val_if_fail (NM_IS_WIFI_AP (ap), FALSE);
+
+	if (ssid) {
+		l = g_bytes_get_size (ssid);
+		if (l == 0 || l > 32)
+			g_return_val_if_reached (FALSE);
+	}
+
+	priv = NM_WIFI_AP_GET_PRIVATE (ap);
+
+	if (ssid == priv->ssid)
+		return FALSE;
+	if (   ssid
+	    && priv->ssid
+	    && g_bytes_equal (ssid, priv->ssid))
+		return FALSE;
+
+	nm_clear_pointer (&priv->ssid, g_bytes_unref);
+	if (ssid)
+		priv->ssid = g_bytes_ref (ssid);
 
 	_notify (ap, PROP_SSID);
 	return TRUE;
@@ -804,10 +828,16 @@ nm_wifi_ap_update_from_properties (NMWifiAP *ap,
 		len = MIN (32, len);
 
 		/* Stupid ieee80211 layer uses <hidden> */
-		if (   bytes && len
-		    && !(((len == 8) || (len == 9)) && !memcmp (bytes, "<hidden>", 8))
-		    && !nm_utils_is_empty_ssid (bytes, len))
-			changed |= nm_wifi_ap_set_ssid (ap, bytes, len);
+		if (   bytes
+		    && len
+		    && !(   NM_IN_SET (len, 8, 9)
+		         && memcmp (bytes, "<hidden>", len) == 0)
+		    && !nm_utils_is_empty_ssid (bytes, len)) {
+			/* good */
+		} else
+			len = 0;
+
+		changed |= nm_wifi_ap_set_ssid_arr (ap, bytes, len);
 
 		g_variant_unref (v);
 	}
@@ -1189,7 +1219,6 @@ nm_wifi_ap_new_fake_from_connection (NMConnection *connection)
 	NMWifiAPPrivate *priv;
 	NMSettingWireless *s_wireless;
 	NMSettingWirelessSecurity *s_wireless_sec;
-	GBytes *ssid;
 	const char *mode, *band, *key_mgmt;
 	guint32 channel;
 	NM80211ApSecurityFlags flags;
@@ -1200,14 +1229,12 @@ nm_wifi_ap_new_fake_from_connection (NMConnection *connection)
 	s_wireless = nm_connection_get_setting_wireless (connection);
 	g_return_val_if_fail (s_wireless != NULL, NULL);
 
-	ssid = nm_setting_wireless_get_ssid (s_wireless);
-	g_return_val_if_fail (ssid != NULL, NULL);
-	g_return_val_if_fail (g_bytes_get_size (ssid) > 0, NULL);
-
 	ap = (NMWifiAP *) g_object_new (NM_TYPE_WIFI_AP, NULL);
 	priv = NM_WIFI_AP_GET_PRIVATE (ap);
 	priv->fake = TRUE;
-	nm_wifi_ap_set_ssid (ap, g_bytes_get_data (ssid, NULL), g_bytes_get_size (ssid));
+
+	nm_wifi_ap_set_ssid (ap,
+	                     nm_setting_wireless_get_ssid (s_wireless));
 
 	// FIXME: bssid too?
 

--- a/src/devices/wifi/nm-wifi-ap.c
+++ b/src/devices/wifi/nm-wifi-ap.c
@@ -1039,7 +1039,7 @@ nm_wifi_ap_check_compatible (NMWifiAP *self,
 	if (   ssid && priv->ssid &&
 	    !nm_utils_same_ssid (g_bytes_get_data (ssid, NULL), g_bytes_get_size (ssid),
 	                         priv->ssid->data, priv->ssid->len,
-	                         TRUE))
+	                         FALSE))
 		return FALSE;
 
 	bssid = nm_setting_wireless_get_bssid (s_wireless);

--- a/src/devices/wifi/nm-wifi-ap.h
+++ b/src/devices/wifi/nm-wifi-ap.h
@@ -73,9 +73,11 @@ gboolean          nm_wifi_ap_complete_connection      (NMWifiAP *self,
 
 const char *      nm_wifi_ap_get_supplicant_path      (NMWifiAP *ap);
 GBytes           *nm_wifi_ap_get_ssid                 (const NMWifiAP *ap);
-gboolean          nm_wifi_ap_set_ssid                 (NMWifiAP *ap,
+gboolean          nm_wifi_ap_set_ssid_arr             (NMWifiAP *ap,
                                                        const guint8 *ssid,
-                                                       gsize len);
+                                                       gsize ssid_len);
+gboolean          nm_wifi_ap_set_ssid                 (NMWifiAP *ap,
+                                                       GBytes *ssid);
 const char *      nm_wifi_ap_get_address              (const NMWifiAP *ap);
 gboolean          nm_wifi_ap_set_address              (NMWifiAP *ap,
                                                        const char *addr);

--- a/src/devices/wifi/nm-wifi-ap.h
+++ b/src/devices/wifi/nm-wifi-ap.h
@@ -72,7 +72,7 @@ gboolean          nm_wifi_ap_complete_connection      (NMWifiAP *self,
                                                        GError **error);
 
 const char *      nm_wifi_ap_get_supplicant_path      (NMWifiAP *ap);
-const GByteArray *nm_wifi_ap_get_ssid                 (const NMWifiAP *ap);
+GBytes           *nm_wifi_ap_get_ssid                 (const NMWifiAP *ap);
 gboolean          nm_wifi_ap_set_ssid                 (NMWifiAP *ap,
                                                        const guint8 *ssid,
                                                        gsize len);

--- a/src/devices/wifi/nm-wifi-utils.h
+++ b/src/devices/wifi/nm-wifi-utils.h
@@ -27,7 +27,7 @@
 #include "nm-setting-wireless-security.h"
 #include "nm-setting-8021x.h"
 
-gboolean nm_wifi_utils_complete_connection (const GByteArray *ssid,
+gboolean nm_wifi_utils_complete_connection (GBytes *ssid,
                                             const char *bssid,
                                             NM80211Mode mode,
                                             guint32 flags,
@@ -39,6 +39,6 @@ gboolean nm_wifi_utils_complete_connection (const GByteArray *ssid,
 
 guint32 nm_wifi_utils_level_to_quality (int val);
 
-gboolean nm_wifi_utils_is_manf_default_ssid (const GByteArray *ssid);
+gboolean nm_wifi_utils_is_manf_default_ssid (GBytes *ssid);
 
 #endif  /* __NM_WIFI_UTILS_H__ */

--- a/src/devices/wifi/tests/test-general.c
+++ b/src/devices/wifi/tests/test-general.c
@@ -74,8 +74,7 @@ complete_connection (const char *ssid,
                      NMConnection *src,
                      GError **error)
 {
-	GByteArray *tmp;
-	gboolean success;
+	gs_unref_bytes GBytes *ssid_b = NULL;
 	NMSettingWireless *s_wifi;
 
 	/* Add a wifi setting if one doesn't exist */
@@ -85,20 +84,17 @@ complete_connection (const char *ssid,
 		nm_connection_add_setting (src, NM_SETTING (s_wifi));
 	}
 
-	tmp = g_byte_array_sized_new (strlen (ssid));
-	g_byte_array_append (tmp, (const guint8 *) ssid, strlen (ssid));
+	ssid_b = g_bytes_new (ssid, strlen (ssid));
 
-	success = nm_wifi_utils_complete_connection (tmp,
-	                                             bssid,
-	                                             mode,
-	                                             flags,
-	                                             wpa_flags,
-	                                             rsn_flags,
-	                                             src,
-	                                             lock_bssid,
-	                                             error);
-	g_byte_array_free (tmp, TRUE);
-	return success;
+	return nm_wifi_utils_complete_connection (ssid_b,
+	                                          bssid,
+	                                          mode,
+	                                          flags,
+	                                          wpa_flags,
+	                                          rsn_flags,
+	                                          src,
+	                                          lock_bssid,
+	                                          error);
 }
 
 typedef struct {

--- a/src/dhcp/nm-dhcp-dhclient-utils.c
+++ b/src/dhcp/nm-dhcp-dhclient-utils.c
@@ -530,6 +530,10 @@ nm_dhcp_dhclient_unescape_duid (const char *duid)
 	guint i, len;
 	guint8 octal;
 
+	/* FIXME: it's wrong to have an "unescape-duid" function. dhclient
+	 * defines a file format with escaping. So we need a general unescape
+	 * function that can handle dhclient syntax. */
+
 	len = strlen (duid);
 	unescaped = g_byte_array_sized_new (len);
 	for (i = 0; i < len; i++) {
@@ -543,6 +547,9 @@ nm_dhcp_dhclient_unescape_duid (const char *duid)
 				g_byte_array_append (unescaped, &octal, 1);
 				i += 2;
 			} else {
+				/* FIXME: don't warn on untrusted data. Either signal an error, or accept
+				 * it silently. */
+
 				/* One of ", ', $, `, \, |, or & */
 				g_warn_if_fail (p[i] == '"' || p[i] == '\'' || p[i] == '$' ||
 				                p[i] == '`' || p[i] == '\\' || p[i] == '|' ||

--- a/src/platform/nm-fake-platform.c
+++ b/src/platform/nm-fake-platform.c
@@ -887,12 +887,6 @@ wifi_get_bssid (NMPlatform *platform, int ifindex, guint8 *bssid)
 	return FALSE;
 }
 
-static GByteArray *
-wifi_get_ssid (NMPlatform *platform, int ifindex)
-{
-	return NULL;
-}
-
 static guint32
 wifi_get_frequency (NMPlatform *platform, int ifindex)
 {
@@ -1435,7 +1429,6 @@ nm_fake_platform_class_init (NMFakePlatformClass *klass)
 
 	platform_class->wifi_get_capabilities = wifi_get_capabilities;
 	platform_class->wifi_get_bssid = wifi_get_bssid;
-	platform_class->wifi_get_ssid = wifi_get_ssid;
 	platform_class->wifi_get_frequency = wifi_get_frequency;
 	platform_class->wifi_get_quality = wifi_get_quality;
 	platform_class->wifi_get_rate = wifi_get_rate;

--- a/src/platform/nm-platform.h
+++ b/src/platform/nm-platform.h
@@ -905,7 +905,6 @@ typedef struct {
 
 	gboolean    (*wifi_get_capabilities) (NMPlatform *, int ifindex, NMDeviceWifiCapabilities *caps);
 	gboolean    (*wifi_get_bssid)        (NMPlatform *, int ifindex, guint8 *bssid);
-	GByteArray *(*wifi_get_ssid)         (NMPlatform *, int ifindex);
 	guint32     (*wifi_get_frequency)    (NMPlatform *, int ifindex);
 	int         (*wifi_get_quality)      (NMPlatform *, int ifindex);
 	guint32     (*wifi_get_rate)         (NMPlatform *, int ifindex);

--- a/src/platform/wifi/nm-wifi-utils-wext.c
+++ b/src/platform/wifi/nm-wifi-utils-wext.c
@@ -41,6 +41,7 @@
 #include "nm-wifi-utils-private.h"
 #include "nm-utils.h"
 #include "platform/nm-platform-utils.h"
+#include "nm-core-internal.h"
 
 typedef struct {
 	NMWifiUtils parent;
@@ -506,11 +507,13 @@ wifi_wext_set_mesh_ssid (NMWifiUtils *data, const guint8 *ssid, gsize len)
 		return TRUE;
 
 	if (errno != ENODEV) {
+		gs_free char *ssid_str = NULL;
+
 		errsv = errno;
 		_LOGE (LOGD_PLATFORM | LOGD_WIFI | LOGD_OLPC,
 		       "(%s): error setting SSID to '%s': %s",
 		       ifname,
-		       ssid ? nm_utils_escape_ssid (ssid, len) : "(null)",
+		       (ssid_str = _nm_utils_ssid_to_string_arr (ssid, len)),
 		       strerror (errsv));
 	}
 

--- a/src/supplicant/nm-supplicant-config.c
+++ b/src/supplicant/nm-supplicant-config.c
@@ -94,11 +94,11 @@ nm_supplicant_config_init (NMSupplicantConfig * self)
 	NMSupplicantConfigPrivate *priv = NM_SUPPLICANT_CONFIG_GET_PRIVATE (self);
 
 	priv->config = g_hash_table_new_full (nm_str_hash, g_str_equal,
-	                                      (GDestroyNotify) g_free,
+	                                      g_free,
 	                                      (GDestroyNotify) config_option_free);
 
 	priv->blobs = g_hash_table_new_full (nm_str_hash, g_str_equal,
-	                                     (GDestroyNotify) g_free,
+	                                     g_free,
 	                                     (GDestroyNotify) g_bytes_unref);
 
 	priv->ap_scan = 1;

--- a/src/supplicant/nm-supplicant-interface.c
+++ b/src/supplicant/nm-supplicant-interface.c
@@ -1579,7 +1579,7 @@ assoc_add_network_cb (GDBusProxy *proxy, GAsyncResult *result, gpointer user_dat
 	GHashTable *blobs;
 	GHashTableIter iter;
 	const char *blob_name;
-	GByteArray *blob_data;
+	GBytes *blob_data;
 
 	assoc_data = add_network_data->assoc_data;
 	if (assoc_data)
@@ -1637,8 +1637,7 @@ assoc_add_network_cb (GDBusProxy *proxy, GAsyncResult *result, gpointer user_dat
 			                   "AddBlob",
 			                   g_variant_new ("(s@ay)",
 			                                  blob_name,
-			                                  g_variant_new_fixed_array (G_VARIANT_TYPE_BYTE,
-			                                                             blob_data->data, blob_data->len, 1)),
+			                                  nm_utils_gbytes_to_variant_ay (blob_data)),
 			                   G_DBUS_CALL_FLAGS_NONE,
 			                   -1,
 			                   priv->assoc_data->cancellable,

--- a/src/supplicant/nm-supplicant-interface.c
+++ b/src/supplicant/nm-supplicant-interface.c
@@ -1789,7 +1789,9 @@ scan_request_cb (GDBusProxy *proxy, GAsyncResult *result, gpointer user_data)
 }
 
 void
-nm_supplicant_interface_request_scan (NMSupplicantInterface *self, const GPtrArray *ssids)
+nm_supplicant_interface_request_scan (NMSupplicantInterface *self,
+                                      GBytes *const*ssids,
+                                      guint ssids_len)
 {
 	NMSupplicantInterfacePrivate *priv;
 	GVariantBuilder builder;
@@ -1803,15 +1805,14 @@ nm_supplicant_interface_request_scan (NMSupplicantInterface *self, const GPtrArr
 	g_variant_builder_init (&builder, G_VARIANT_TYPE_VARDICT);
 	g_variant_builder_add (&builder, "{sv}", "Type", g_variant_new_string ("active"));
 	g_variant_builder_add (&builder, "{sv}", "AllowRoam", g_variant_new_boolean (FALSE));
-	if (ssids) {
+	if (ssids_len > 0) {
 		GVariantBuilder ssids_builder;
 
 		g_variant_builder_init (&ssids_builder, G_VARIANT_TYPE_BYTESTRING_ARRAY);
-		for (i = 0; i < ssids->len; i++) {
-			GByteArray *ssid = g_ptr_array_index (ssids, i);
+		for (i = 0; i < ssids_len; i++) {
+			nm_assert (ssids[i]);
 			g_variant_builder_add (&ssids_builder, "@ay",
-			                       g_variant_new_fixed_array (G_VARIANT_TYPE_BYTE,
-			                                                  ssid->data, ssid->len, 1));
+			                       nm_utils_gbytes_to_variant_ay (ssids[i]));
 		}
 		g_variant_builder_add (&builder, "{sv}", "SSIDs", g_variant_builder_end (&ssids_builder));
 	}

--- a/src/supplicant/nm-supplicant-interface.h
+++ b/src/supplicant/nm-supplicant-interface.h
@@ -100,7 +100,9 @@ void nm_supplicant_interface_disconnect (NMSupplicantInterface * iface);
 
 const char *nm_supplicant_interface_get_object_path (NMSupplicantInterface * iface);
 
-void nm_supplicant_interface_request_scan (NMSupplicantInterface * self, const GPtrArray *ssids);
+void nm_supplicant_interface_request_scan (NMSupplicantInterface *self,
+                                           GBytes *const*ssids,
+                                           guint ssids_len);
 
 NMSupplicantInterfaceState nm_supplicant_interface_get_state (NMSupplicantInterface * self);
 


### PR DESCRIPTION
cleanup handling the SSID as a GBytes, instead of GByteArray.

For one, GBytes is immutable and ref-countable, which is nicer API.
Also, at various places, we treat the SSID as GBytes already. Differing types, requires lots of annoying conversions.