### PR TITLE
IWD KnownNetwork changes

### DIFF
--- a/libnm-core/nm-setting-8021x.c
+++ b/libnm-core/nm-setting-8021x.c
@@ -3086,6 +3086,7 @@ static EAPMethodsTable eap_methods_table[] = {
 	{ "sim", need_secrets_sim, NULL },
 	{ "gtc", need_secrets_password, verify_identity },
 	{ "otp", NULL, NULL },  // FIXME: implement
+	{ "external", NULL, NULL },
 	{ NULL, NULL, NULL }
 };
 
@@ -3201,7 +3202,7 @@ verify (NMSetting *setting, NMConnection *connection, GError **error)
 {
 	NMSetting8021x *self = NM_SETTING_802_1X (setting);
 	NMSetting8021xPrivate *priv = NM_SETTING_802_1X_GET_PRIVATE (self);
-	const char *valid_eap[] = { "leap", "md5", "tls", "peap", "ttls", "sim", "fast", "pwd", NULL };
+	const char *valid_eap[] = { "leap", "md5", "tls", "peap", "ttls", "sim", "fast", "pwd", "external", NULL };
 	const char *valid_phase1_peapver[] = { "0", "1", NULL };
 	const char *valid_phase1_peaplabel[] = { "0", "1", NULL };
 	const char *valid_phase1_fast_pac[] = { "0", "1", "2", "3", NULL };

--- a/src/devices/wifi/nm-device-iwd.c
+++ b/src/devices/wifi/nm-device-iwd.c
@@ -1328,9 +1328,6 @@ network_connect_cb (GObject *source, GAsyncResult *res, gpointer user_data)
 	       ssid_utf8);
 	nm_device_activate_schedule_stage3_ip_config_start (device);
 
-	nm_iwd_manager_network_connected (nm_iwd_manager_get (), ssid_utf8,
-	                                  get_connection_iwd_security (connection));
-
 	return;
 
 failed:

--- a/src/devices/wifi/nm-device-iwd.c
+++ b/src/devices/wifi/nm-device-iwd.c
@@ -773,6 +773,32 @@ complete_connection (NMDevice *device,
 }
 
 static gboolean
+get_variant_boolean (GVariant *v, const char *property)
+{
+	if (!v || !g_variant_is_of_type (v, G_VARIANT_TYPE_BOOLEAN)) {
+		nm_log_warn (LOGD_DEVICE | LOGD_WIFI,
+		             "Property %s not cached or not boolean type", property);
+
+		return FALSE;
+	}
+
+	return g_variant_get_boolean (v);
+}
+
+static const char *
+get_variant_state (GVariant *v)
+{
+	if (!v || !g_variant_is_of_type (v, G_VARIANT_TYPE_STRING)) {
+		nm_log_warn (LOGD_DEVICE | LOGD_WIFI,
+		             "State property not cached or not a string");
+
+		return "unknown";
+	}
+
+	return g_variant_get_string (v, NULL);
+}
+
+static gboolean
 is_available (NMDevice *device, NMDeviceCheckDevAvailableFlags flags)
 {
 	NMDeviceIwd *self = NM_DEVICE_IWD (device);
@@ -783,7 +809,7 @@ is_available (NMDevice *device, NMDeviceCheckDevAvailableFlags flags)
 		return FALSE;
 
 	value = g_dbus_proxy_get_cached_property (priv->dbus_proxy, "Powered");
-	return g_variant_get_boolean (value);
+	return get_variant_boolean (value, "Powered");
 }
 
 static gboolean
@@ -1753,7 +1779,8 @@ state_changed (NMDeviceIwd *self, const char *new_state)
 	                                 NM_DEVICE_STATE_REASON_SUPPLICANT_DISCONNECT);
 
 		return;
-	}
+	} else if (nm_streq (new_state, "unknown"))
+		return;
 
 	_LOGE (LOGD_WIFI, "State %s unknown", new_state);
 }
@@ -1799,13 +1826,13 @@ properties_changed (GDBusProxy *proxy, GVariant *changed_properties,
 	g_variant_get (changed_properties, "a{sv}", &iter);
 	while (g_variant_iter_next (iter, "{&sv}", &key, &value)) {
 		if (!strcmp (key, "State"))
-			state_changed (self, g_variant_get_string (value, NULL));
+			state_changed (self, get_variant_state (value));
 
 		if (!strcmp (key, "Scanning"))
-			scanning_changed (self, g_variant_get_boolean (value));
+			scanning_changed (self, get_variant_boolean (value, "Scanning"));
 
 		if (!strcmp (key, "Powered"))
-			powered_changed (self, g_variant_get_boolean (value));
+			powered_changed (self, get_variant_boolean (value, "Powered"));
 
 		g_variant_unref (value);
 	}
@@ -1846,12 +1873,12 @@ nm_device_iwd_set_dbus_object (NMDeviceIwd *self, GDBusObject *object)
 	priv->dbus_proxy = G_DBUS_PROXY (interface);
 
 	value = g_dbus_proxy_get_cached_property (priv->dbus_proxy, "Scanning");
-	priv->scanning = g_variant_get_boolean (value);
+	priv->scanning = get_variant_boolean (value, "Scanning");
 	g_variant_unref (value);
 	priv->scan_requested = FALSE;
 
 	value = g_dbus_proxy_get_cached_property (priv->dbus_proxy, "State");
-	state_changed (self, g_variant_get_string (value, NULL));
+	state_changed (self, get_variant_state (value));
 	g_variant_unref (value);
 
 	g_signal_connect (priv->dbus_proxy, "g-properties-changed",

--- a/src/devices/wifi/nm-device-iwd.c
+++ b/src/devices/wifi/nm-device-iwd.c
@@ -448,33 +448,12 @@ deactivate_async (NMDevice *device,
 	                   G_DBUS_CALL_FLAGS_NONE, -1, cancellable, disconnect_cb, ctx);
 }
 
-static NMIwdNetworkSecurity
-get_connection_iwd_security (NMConnection *connection)
-{
-	NMSettingWirelessSecurity *s_wireless_sec;
-	const char *key_mgmt = NULL;
-
-	s_wireless_sec = nm_connection_get_setting_wireless_security (connection);
-	if (!s_wireless_sec)
-		return NM_IWD_NETWORK_SECURITY_NONE;
-
-	key_mgmt = nm_setting_wireless_security_get_key_mgmt (s_wireless_sec);
-	nm_assert (key_mgmt);
-
-	if (!strcmp (key_mgmt, "none") || !strcmp (key_mgmt, "ieee8021x"))
-		return NM_IWD_NETWORK_SECURITY_WEP;
-
-	if (!strcmp (key_mgmt, "wpa-psk"))
-		return NM_IWD_NETWORK_SECURITY_PSK;
-
-	nm_assert (!strcmp (key_mgmt, "wpa-eap"));
-	return NM_IWD_NETWORK_SECURITY_8021X;
-}
-
 static gboolean
 is_connection_known_network (NMConnection *connection)
 {
 	NMSettingWireless *s_wireless;
+	NMIwdNetworkSecurity security;
+	gboolean security_ok;
 	GBytes *ssid;
 	gs_free char *ssid_utf8 = NULL;
 
@@ -487,9 +466,13 @@ is_connection_known_network (NMConnection *connection)
 		return FALSE;
 
 	ssid_utf8 = _nm_utils_ssid_to_utf8 (ssid);
+
+	security = nm_wifi_connection_get_iwd_security (connection, &security_ok);
+	if (!security_ok)
+		return FALSE;
+
 	return nm_iwd_manager_is_known_network (nm_iwd_manager_get (),
-	                                        ssid_utf8,
-	                                        get_connection_iwd_security (connection));
+	                                        ssid_utf8, security);
 }
 
 static gboolean
@@ -543,7 +526,7 @@ check_connection_compatible (NMDevice *device, NMConnection *connection, GError 
 	/* 8021x networks can only be used if they've been provisioned on the IWD side and
 	 * thus are Known Networks.
 	 */
-	if (get_connection_iwd_security (connection) == NM_IWD_NETWORK_SECURITY_8021X) {
+	if (nm_wifi_connection_get_iwd_security (connection, NULL) == NM_IWD_NETWORK_SECURITY_8021X) {
 		if (!is_connection_known_network (connection)) {
 			nm_utils_error_set_literal (error, NM_UTILS_ERROR_CONNECTION_AVAILABLE_TEMPORARY,
 			                            "802.1x profile is not a known network");
@@ -587,7 +570,7 @@ check_connection_available (NMDevice *device,
 	/* 8021x networks can only be used if they've been provisioned on the IWD side and
 	 * thus are Known Networks.
 	 */
-	if (get_connection_iwd_security (connection) == NM_IWD_NETWORK_SECURITY_8021X) {
+	if (nm_wifi_connection_get_iwd_security (connection, NULL) == NM_IWD_NETWORK_SECURITY_8021X) {
 		if (!is_connection_known_network (connection)) {
 			nm_utils_error_set_literal (error, NM_UTILS_ERROR_CONNECTION_AVAILABLE_TEMPORARY,
 			                            "network is not known to iwd");
@@ -731,7 +714,7 @@ complete_connection (NMDevice *device,
 	/* 8021x networks can only be used if they've been provisioned on the IWD side and
 	 * thus are Known Networks.
 	 */
-	if (get_connection_iwd_security (connection) == NM_IWD_NETWORK_SECURITY_8021X) {
+	if (nm_wifi_connection_get_iwd_security (connection, NULL) == NM_IWD_NETWORK_SECURITY_8021X) {
 		if (!is_connection_known_network (connection)) {
 			g_set_error_literal (error,
 			                     NM_CONNECTION_ERROR,
@@ -858,7 +841,7 @@ can_auto_connect (NMDevice *device,
 	/* 8021x networks can only be used if they've been provisioned on the IWD side and
 	 * thus are Known Networks.
 	 */
-	if (get_connection_iwd_security (connection) == NM_IWD_NETWORK_SECURITY_8021X) {
+	if (nm_wifi_connection_get_iwd_security (connection, NULL) == NM_IWD_NETWORK_SECURITY_8021X) {
 		if (!is_connection_known_network (connection))
 			return FALSE;
 	}

--- a/src/devices/wifi/nm-iwd-manager.c
+++ b/src/devices/wifi/nm-iwd-manager.c
@@ -83,6 +83,32 @@ G_DEFINE_TYPE (NMIwdManager, nm_iwd_manager, G_TYPE_OBJECT)
 
 /*****************************************************************************/
 
+static const char *
+get_variant_string_or_null (GVariant *v)
+{
+	if (!v)
+		return NULL;
+
+	if (   !g_variant_is_of_type (v, G_VARIANT_TYPE_STRING)
+	    && !g_variant_is_of_type (v, G_VARIANT_TYPE_OBJECT_PATH))
+		return NULL;
+
+	return g_variant_get_string (v, NULL);
+}
+
+static const char *
+get_property_string_or_null (GDBusProxy *proxy, const char *property)
+{
+	gs_unref_variant GVariant *value = NULL;
+
+	if (!proxy || !property)
+		return NULL;
+
+	value = g_dbus_proxy_get_cached_property (proxy, property);
+
+	return get_variant_string_or_null (value);
+}
+
 static void
 agent_dbus_method_cb (GDBusConnection *connection,
                       const char *sender, const char *object_path,
@@ -95,7 +121,6 @@ agent_dbus_method_cb (GDBusConnection *connection,
 	NMIwdManagerPrivate *priv = NM_IWD_MANAGER_GET_PRIVATE (self);
 	const char *network_path, *device_path, *ifname;
 	gs_unref_object GDBusInterface *network = NULL, *device_obj = NULL;
-	gs_unref_variant GVariant *value = NULL;
 	int ifindex;
 	NMDevice *device;
 	gs_free char *name_owner = NULL;
@@ -113,9 +138,8 @@ agent_dbus_method_cb (GDBusConnection *connection,
 	network = g_dbus_object_manager_get_interface (priv->object_manager,
 	                                               network_path,
 	                                               NM_IWD_NETWORK_INTERFACE);
-	value = g_dbus_proxy_get_cached_property (G_DBUS_PROXY (network), "Device");
-	device_path = g_variant_get_string (value, NULL);
 
+	device_path = get_property_string_or_null (G_DBUS_PROXY (network), "Device");
 	if (!device_path) {
 		_LOGD ("agent-request: device not cached for network %s in IWD Agent request",
 		       network_path);
@@ -125,10 +149,8 @@ agent_dbus_method_cb (GDBusConnection *connection,
 	device_obj = g_dbus_object_manager_get_interface (priv->object_manager,
 	                                                  device_path,
 	                                                  NM_IWD_DEVICE_INTERFACE);
-	g_variant_unref (value);
-	value = g_dbus_proxy_get_cached_property (G_DBUS_PROXY (device_obj), "Name");
-	ifname = g_variant_get_string (value, NULL);
 
+	ifname = get_property_string_or_null (G_DBUS_PROXY (device_obj), "Name");
 	if (!ifname) {
 		_LOGD ("agent-request: name not cached for device %s in IWD Agent request",
 		       device_path);
@@ -257,7 +279,6 @@ set_device_dbus_object (NMIwdManager *self, GDBusInterface *interface,
 {
 	NMIwdManagerPrivate *priv = NM_IWD_MANAGER_GET_PRIVATE (self);
 	GDBusProxy *proxy;
-	GVariant *value;
 	const char *ifname;
 	int ifindex;
 	NMDevice *device;
@@ -273,16 +294,14 @@ set_device_dbus_object (NMIwdManager *self, GDBusInterface *interface,
 	            NM_IWD_DEVICE_INTERFACE))
 		return;
 
-	value = g_dbus_proxy_get_cached_property (proxy, "Name");
-	if (!value) {
+	ifname = get_property_string_or_null (proxy, "Name");
+	if (!ifname) {
 		_LOGE ("Name not cached for Device at %s",
 		       g_dbus_proxy_get_object_path (proxy));
 		return;
 	}
 
-	ifname = g_variant_get_string (value, NULL);
 	ifindex = if_nametoindex (ifname);
-	g_variant_unref (value);
 
 	if (!ifindex) {
 		_LOGE ("if_nametoindex failed for Name %s for Device at %s: %i",
@@ -388,10 +407,10 @@ list_known_networks_cb (GObject *source, GAsyncResult *res, gpointer user_data)
 
 		while (g_variant_iter_next (props, "{&sv}", &key, &val)) {
 			if (!strcmp (key, "Name"))
-				name = g_variant_get_string (val, NULL);
+				name = get_variant_string_or_null (val);
 
 			if (!strcmp (key, "Type"))
-				type = g_variant_get_string (val, NULL);
+				type = get_variant_string_or_null (val);
 
 			g_variant_unref (val);
 		}
@@ -492,28 +511,14 @@ device_added (NMManager *manager, NMDevice *device, gpointer user_data)
 	objects = g_dbus_object_manager_get_objects (priv->object_manager);
 	for (iter = objects; iter; iter = iter->next) {
 		GDBusObject *object = G_DBUS_OBJECT (iter->data);
-		GDBusInterface *interface;
-		GDBusProxy *proxy;
-		GVariant *value;
+		gs_unref_object GDBusInterface *interface;
 		const char *obj_ifname;
 
 		interface = g_dbus_object_get_interface (object,
 		                                         NM_IWD_DEVICE_INTERFACE);
-		if (!interface)
-			continue;
+		obj_ifname = get_property_string_or_null ((GDBusProxy *) interface, "Name");
 
-		proxy = G_DBUS_PROXY (interface);
-		value = g_dbus_proxy_get_cached_property (proxy, "Name");
-		if (!value) {
-			g_object_unref (interface);
-			continue;
-		}
-
-		obj_ifname = g_variant_get_string (value, NULL);
-		g_variant_unref (value);
-		g_object_unref (interface);
-
-		if (strcmp (nm_device_get_iface (device), obj_ifname))
+		if (!obj_ifname || strcmp (nm_device_get_iface (device), obj_ifname))
 			continue;
 
 		nm_device_iwd_set_dbus_object (NM_DEVICE_IWD (device), object);

--- a/src/devices/wifi/nm-iwd-manager.c
+++ b/src/devices/wifi/nm-iwd-manager.c
@@ -527,22 +527,6 @@ nm_iwd_manager_is_known_network (NMIwdManager *self, const char *name,
 	return false;
 }
 
-void
-nm_iwd_manager_network_connected (NMIwdManager *self, const char *name,
-                                  NMIwdNetworkSecurity security)
-{
-	NMIwdManagerPrivate *priv = NM_IWD_MANAGER_GET_PRIVATE (self);
-	KnownNetworkData *network_data;
-
-	if (nm_iwd_manager_is_known_network (self, name, security))
-		return;
-
-	network_data = g_new (KnownNetworkData, 1);
-	network_data->name = g_strdup (name);
-	network_data->security = security;
-	priv->known_networks = g_slist_append (priv->known_networks, network_data);
-}
-
 /*****************************************************************************/
 
 NM_DEFINE_SINGLETON_GETTER (NMIwdManager, nm_iwd_manager_get,

--- a/src/devices/wifi/nm-iwd-manager.c
+++ b/src/devices/wifi/nm-iwd-manager.c
@@ -29,7 +29,9 @@
 #include "nm-core-internal.h"
 #include "nm-manager.h"
 #include "nm-device-iwd.h"
+#include "nm-wifi-utils.h"
 #include "nm-utils/nm-random-utils.h"
+#include "settings/nm-settings.h"
 
 /*****************************************************************************/
 
@@ -41,6 +43,7 @@ typedef struct {
 
 typedef struct {
 	GDBusProxy *known_network;
+	NMSettingsConnection *mirror_connection;
 } KnownNetworkData;
 
 typedef struct {
@@ -311,6 +314,8 @@ known_network_data_free (KnownNetworkData *network)
 		return;
 
 	g_object_unref (network->known_network);
+	if (network->mirror_connection)
+		g_object_unref (network->mirror_connection);
 	g_slice_free (KnownNetworkData, network);
 }
 
@@ -347,6 +352,100 @@ set_device_dbus_object (NMIwdManager *self, GDBusProxy *proxy,
 	}
 
 	nm_device_iwd_set_dbus_object (NM_DEVICE_IWD (device), object);
+}
+
+/* Create an in-memory NMConnection for a WPA2-Enterprise network that
+ * has been preprovisioned with an IWD config file so that NM autoconnect
+ * mechanism and the clients know this networks needs no additional EAP
+ * configuration from the user.  Only do this if no existing connection
+ * SSID and security type match that network yet.
+ */
+static void
+mirror_8021x_connection (NMIwdManager *self, KnownNetworkId *id,
+                         KnownNetworkData *data)
+{
+	NMSettings *settings = NM_SETTINGS_GET;
+	NMSettingsConnection *const *iter;
+	NMConnection *connection;
+	NMSettingsConnection *settings_connection;
+	char uuid[37];
+	NMSetting *setting;
+	GBytes *ssid;
+	GError *error = NULL;
+
+	for (iter = nm_settings_get_connections (settings, NULL); *iter; iter++) {
+		const NMSettingsConnection *conn = *iter;
+		NMIwdNetworkSecurity security;
+		gs_free char *name = NULL;
+		NMSettingWireless *s_wifi;
+
+		security = nm_wifi_connection_get_iwd_security (NM_CONNECTION (conn), NULL);
+		if (security != NM_IWD_NETWORK_SECURITY_8021X)
+			continue;
+
+		s_wifi = nm_connection_get_setting_wireless (NM_CONNECTION (conn));
+		if (!s_wifi)
+			continue;
+
+		ssid = nm_setting_wireless_get_ssid (s_wifi);
+		if (!ssid)
+			continue;
+
+		name = nm_utils_ssid_to_utf8 (g_bytes_get_data (ssid, NULL),
+		                              g_bytes_get_size (ssid));
+
+		/* We already have an NMSettingsConnection matching this
+		 * KnownNetwork, whether it's saved or an in-memory connection
+		 * potentially created by ourselves.  Nothing to do here.
+		 */
+		if (!strcmp (name, id->name))
+			return;
+	}
+
+	connection = nm_simple_connection_new ();
+
+	setting = NM_SETTING (g_object_new (NM_TYPE_SETTING_CONNECTION,
+	                                    NM_SETTING_CONNECTION_TYPE, NM_SETTING_WIRELESS_SETTING_NAME,
+	                                    NM_SETTING_CONNECTION_ID, id->name,
+	                                    NM_SETTING_CONNECTION_UUID, nm_utils_uuid_generate_buf (uuid),
+	                                    NM_SETTING_CONNECTION_READ_ONLY, TRUE,
+	                                    NULL));
+	nm_connection_add_setting (connection, setting);
+
+	ssid = g_bytes_new (id->name, strlen (id->name));
+	setting = NM_SETTING (g_object_new (NM_TYPE_SETTING_WIRELESS,
+	                                    NM_SETTING_WIRELESS_SSID, ssid,
+	                                    NM_SETTING_WIRELESS_MODE, NM_SETTING_WIRELESS_MODE_INFRA,
+	                                    NULL));
+	nm_connection_add_setting (connection, setting);
+
+	setting = NM_SETTING (g_object_new (NM_TYPE_SETTING_WIRELESS_SECURITY,
+	                                    NM_SETTING_WIRELESS_SECURITY_AUTH_ALG, "open",
+	                                    NM_SETTING_WIRELESS_SECURITY_KEY_MGMT, "wpa-eap",
+	                                    NULL));
+	nm_connection_add_setting (connection, setting);
+
+	setting = NM_SETTING (g_object_new (NM_TYPE_SETTING_802_1X, NULL));
+	nm_setting_802_1x_add_eap_method (NM_SETTING_802_1X (setting), "external");
+	nm_connection_add_setting (connection, setting);
+
+	settings_connection = nm_settings_add_connection (settings, connection,
+	                                                  FALSE, &error);
+	g_object_unref (connection);
+
+	if (!settings_connection) {
+		_LOGW ("failed to add a mirror NMConnection for IWD's Known Network '%s': %s",
+		       id->name, NM_G_ERROR_MSG (error));
+		g_clear_error (&error);
+		return;
+	}
+
+	nm_settings_connection_set_flags (settings_connection,
+	                                  NM_SETTINGS_CONNECTION_INT_FLAGS_NM_GENERATED |
+	                                  NM_SETTINGS_CONNECTION_INT_FLAGS_UNSAVED,
+	                                  TRUE);
+
+	data->mirror_connection = g_object_ref (settings_connection);
 }
 
 static void
@@ -393,9 +492,13 @@ interface_added (GDBusObjectManager *object_manager, GDBusObject *object,
 
 		id = known_network_id_new (name, security);
 
-		data = g_slice_new (KnownNetworkData);
+		data = g_slice_new0 (KnownNetworkData);
 		data->known_network = (GDBusProxy *) g_object_ref (proxy);
 		g_hash_table_insert (priv->known_networks, id, data);
+
+		if (security == NM_IWD_NETWORK_SECURITY_8021X)
+			mirror_8021x_connection (self, id, data);
+
 		return;
 	}
 }
@@ -421,6 +524,7 @@ interface_removed (GDBusObjectManager *object_manager, GDBusObject *object,
 
 	if (nm_streq (iface_name, NM_IWD_KNOWN_NETWORK_INTERFACE)) {
 		KnownNetworkId id;
+		KnownNetworkData *data;
 		const char *type_str;
 
 		type_str = get_property_string_or_null (proxy, "Type");
@@ -436,6 +540,27 @@ interface_removed (GDBusObjectManager *object_manager, GDBusObject *object,
 			id.security = NM_IWD_NETWORK_SECURITY_8021X;
 		else
 			return;
+
+		data = g_hash_table_lookup (priv->known_networks, &id);
+		if (!data)
+			return;
+
+		if (data->mirror_connection) {
+			NMSettingsConnectionIntFlags flags;
+			NMSettingsConnection *mirror_connection = data->mirror_connection;
+
+			flags = nm_settings_connection_get_flags (mirror_connection);
+
+			/* If connection has not been saved since we created it
+			 * in interface_added it too can be removed now. */
+			if (flags & NM_SETTINGS_CONNECTION_INT_FLAGS_NM_GENERATED) {
+				data->mirror_connection = NULL;
+
+				nm_settings_connection_delete (mirror_connection, NULL);
+
+				g_object_unref (mirror_connection);
+			}
+		}
 
 		g_hash_table_remove (priv->known_networks, &id);
 		return;

--- a/src/devices/wifi/nm-iwd-manager.h
+++ b/src/devices/wifi/nm-iwd-manager.h
@@ -59,7 +59,5 @@ NMIwdManager *nm_iwd_manager_get (void);
 
 gboolean nm_iwd_manager_is_known_network (NMIwdManager *self, const char *name,
                                           NMIwdNetworkSecurity security);
-void nm_iwd_manager_network_connected (NMIwdManager *self, const char *name,
-                                       NMIwdNetworkSecurity security);
 
 #endif /* __NETWORKMANAGER_IWD_MANAGER_H__ */

--- a/src/devices/wifi/nm-iwd-manager.h
+++ b/src/devices/wifi/nm-iwd-manager.h
@@ -33,7 +33,7 @@
 #define NM_IWD_AGENT_INTERFACE          "net.connman.iwd.Agent"
 #define NM_IWD_WSC_INTERFACE            \
 	"net.connman.iwd.WiFiSimpleConfiguration"
-#define NM_IWD_KNOWN_NETWORKS_INTERFACE "net.connman.iwd.KnownNetworks"
+#define NM_IWD_KNOWN_NETWORK_INTERFACE  "net.connman.iwd.KnownNetwork"
 #define NM_IWD_SIGNAL_AGENT_INTERFACE   "net.connman.iwd.SignalLevelAgent"
 
 typedef enum {

--- a/src/devices/wifi/nm-iwd-manager.h
+++ b/src/devices/wifi/nm-iwd-manager.h
@@ -22,6 +22,7 @@
 #define __NETWORKMANAGER_IWD_MANAGER_H__
 
 #include "devices/nm-device.h"
+#include "nm-wifi-utils.h"
 
 #define NM_IWD_BUS_TYPE                 G_BUS_TYPE_SYSTEM
 #define NM_IWD_SERVICE                  "net.connman.iwd"
@@ -35,13 +36,6 @@
 	"net.connman.iwd.WiFiSimpleConfiguration"
 #define NM_IWD_KNOWN_NETWORK_INTERFACE  "net.connman.iwd.KnownNetwork"
 #define NM_IWD_SIGNAL_AGENT_INTERFACE   "net.connman.iwd.SignalLevelAgent"
-
-typedef enum {
-	NM_IWD_NETWORK_SECURITY_NONE,
-	NM_IWD_NETWORK_SECURITY_WEP,
-	NM_IWD_NETWORK_SECURITY_PSK,
-	NM_IWD_NETWORK_SECURITY_8021X,
-} NMIwdNetworkSecurity;
 
 #define NM_TYPE_IWD_MANAGER              (nm_iwd_manager_get_type ())
 #define NM_IWD_MANAGER(obj)              (G_TYPE_CHECK_INSTANCE_CAST ((obj), NM_TYPE_IWD_MANAGER, NMIwdManager))

--- a/src/devices/wifi/nm-wifi-utils.c
+++ b/src/devices/wifi/nm-wifi-utils.c
@@ -815,3 +815,39 @@ nm_wifi_utils_is_manf_default_ssid (GBytes *ssid)
 	}
 	return FALSE;
 }
+
+NMIwdNetworkSecurity
+nm_wifi_connection_get_iwd_security (NMConnection *connection,
+                                     gboolean *mapped)
+{
+	NMSettingWirelessSecurity *s_wireless_sec;
+	const char *key_mgmt = NULL;
+
+	if (!nm_connection_get_setting_wireless (connection))
+		goto error;
+
+	if (mapped)
+		*mapped = TRUE;
+
+	s_wireless_sec = nm_connection_get_setting_wireless_security (connection);
+	if (!s_wireless_sec)
+		return NM_IWD_NETWORK_SECURITY_NONE;
+
+	key_mgmt = nm_setting_wireless_security_get_key_mgmt (s_wireless_sec);
+	nm_assert (key_mgmt);
+
+	if (NM_IN_STRSET (key_mgmt, "none", "ieee8021x"))
+		return NM_IWD_NETWORK_SECURITY_WEP;
+
+	if (nm_streq (key_mgmt, "wpa-psk"))
+		return NM_IWD_NETWORK_SECURITY_PSK;
+
+	if (nm_streq (key_mgmt, "wpa-eap"))
+		return NM_IWD_NETWORK_SECURITY_8021X;
+
+error:
+	if (mapped)
+		*mapped = FALSE;
+
+	return NM_IWD_NETWORK_SECURITY_NONE;
+}

--- a/src/devices/wifi/nm-wifi-utils.h
+++ b/src/devices/wifi/nm-wifi-utils.h
@@ -27,6 +27,13 @@
 #include "nm-setting-wireless-security.h"
 #include "nm-setting-8021x.h"
 
+typedef enum {
+	NM_IWD_NETWORK_SECURITY_NONE,
+	NM_IWD_NETWORK_SECURITY_WEP,
+	NM_IWD_NETWORK_SECURITY_PSK,
+	NM_IWD_NETWORK_SECURITY_8021X,
+} NMIwdNetworkSecurity;
+
 gboolean nm_wifi_utils_complete_connection (GBytes *ssid,
                                             const char *bssid,
                                             NM80211Mode mode,
@@ -40,5 +47,8 @@ gboolean nm_wifi_utils_complete_connection (GBytes *ssid,
 guint32 nm_wifi_utils_level_to_quality (int val);
 
 gboolean nm_wifi_utils_is_manf_default_ssid (GBytes *ssid);
+
+NMIwdNetworkSecurity nm_wifi_connection_get_iwd_security (NMConnection *connection,
+                                                          gboolean *mapped);
 
 #endif  /* __NM_WIFI_UTILS_H__ */

--- a/src/supplicant/nm-supplicant-config.c
+++ b/src/supplicant/nm-supplicant-config.c
@@ -1001,6 +1001,7 @@ nm_supplicant_config_add_setting_8021x (NMSupplicantConfig *self,
 	guint32 frag, hdrs;
 	gs_free char *frag_str = NULL;
 	NMSetting8021xAuthFlags phase1_auth_flags;
+	nm_auto_free_gstring GString *eap_str = NULL;
 
 	g_return_val_if_fail (NM_IS_SUPPLICANT_CONFIG (self), FALSE);
 	g_return_val_if_fail (setting != NULL, FALSE);
@@ -1037,19 +1038,39 @@ nm_supplicant_config_add_setting_8021x (NMSupplicantConfig *self,
 		priv->ap_scan = 0;
 	}
 
-	if (!ADD_STRING_LIST_VAL (self, setting, 802_1x, eap_method, eap_methods, "eap", ' ', TRUE, NULL, error))
-		return FALSE;
-
-	/* Check EAP method for special handling: PEAP + GTC, FAST */
+	/* Build the "eap" option string while we check for EAP methods needing
+	 * special handling: PEAP + GTC, FAST, external */
+	eap_str = g_string_new (NULL);
 	num_eap = nm_setting_802_1x_get_num_eap_methods (setting);
 	for (i = 0; i < num_eap; i++) {
 		const char *method = nm_setting_802_1x_get_eap_method (setting, i);
 
-		if (method && (strcasecmp (method, "fast") == 0)) {
+		if (!method)
+			continue;
+
+		if (strcasecmp (method, "fast") == 0) {
 			fast = TRUE;
 			priv->fast_required = TRUE;
 		}
+
+		if (nm_streq (method, "external")) {
+			if (num_eap == 1) {
+				g_set_error (error, NM_SUPPLICANT_ERROR, NM_SUPPLICANT_ERROR_CONFIG,
+				             "Connection settings managed externally to NM, connection"
+					     " cannot be used with wpa_supplicant");
+				return FALSE;
+			}
+			continue;
+		}
+
+		if (eap_str->len)
+			g_string_append_c (eap_str, ' ');
+		g_string_append (eap_str, method);
 	}
+
+	g_string_ascii_up (eap_str);
+	if (eap_str->len && !nm_supplicant_config_add_option (self, "eap", eap_str->str, -1, NULL, error))
+		return FALSE;
 
 	/* Adjust the fragment size according to MTU, but do not set it higher than 1280-14
 	 * for better compatibility */


### PR DESCRIPTION
These commits mostly update the use of the IWD DBus API with the changes seen in this commit: https://git.kernel.org/pub/scm/network/wireless/iwd.git/commit/doc/knownnetworks-api.txt?id=7d3656858ffd105ee5951f934be6ca123956d1b3

The last three commits are unrelated and likely need more discussion, they're a different approach to make EAP networks usable with the IWD backend without manually creating NM profiles for each network we want to connect to (which has to have been configured on the IWD side already), the first approach was described here: https://mail.gnome.org/archives/networkmanager-list/2018-June/msg00023.html