### PR TITLE
docs/test: add check that gtk-doc contains patch to generate proper documentation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1217,7 +1217,7 @@ else
 	if test "$enable_gtk_doc" = "yes"; then
 		# large parts of the documentation require introspection/pygobject to extract
 		# the documentation out of the source files. You cannot enable gtk-doc without alone.
-		AC_MSG_ERROR(["--with-gtk-doc requires --enable-introspection"])
+		AC_MSG_ERROR(["--enable-gtk-doc requires --enable-introspection"])
 	fi
 	have_introspection=no
 fi

--- a/contrib/fedora/rpm/build_clean.sh
+++ b/contrib/fedora/rpm/build_clean.sh
@@ -24,6 +24,7 @@ usage() {
     echo "  -w|--with \$OPTION: pass --with \$OPTION to rpmbuild. For example --with debug"
     echo "  -W|--without \$OPTION: pass --without \$OPTION to rpmbuild. For example --without debug"
     echo "  -s|--snapshot TEXT: use TEXT as the snapshot version for the new package (overwrites \$NM_BUILD_SNAPSHOT environment)"
+    echo "  -r|--release: built a release tarball (this option must be alone)"
 }
 
 
@@ -44,6 +45,8 @@ WITH_LIST=()
 SOURCE_FROM_GIT=0
 SNAPSHOT="$NM_BUILD_SNAPSHOT"
 
+NARGS=$#
+
 while [[ $# -gt 0 ]]; do
     A="$1"
     shift
@@ -54,6 +57,11 @@ while [[ $# -gt 0 ]]; do
             ;;
         -f|--force)
             IGNORE_DIRTY=1
+            ;;
+        -r|--release)
+            [[ $NARGS -eq 1 ]] || die "--release option must be alone"
+            export NMTST_CHECK_GTK_DOC=1
+            BUILDTYPE=SRPM
             ;;
         -c|--clean)
             GIT_CLEAN=1

--- a/docs/libnm/Makefile.am
+++ b/docs/libnm/Makefile.am
@@ -1,6 +1,8 @@
 ## Process this file with automake to produce Makefile.in
 AUTOMAKE_OPTIONS = 1.6
 
+check_local =
+
 # The name of the module
 DOC_MODULE=libnm
 
@@ -94,3 +96,13 @@ CLEANFILES += \
 	tmpl/* \
 	xml/*
 
+if GTK_DOC_BUILD_HTML
+check-local-gtk-doc-patch:
+	if grep -q -F '<a href="libnm-nm-setting-user.html">nm-setting-user</a>' "$(top_builddir)/docs/libnm/html/index.html"; then \
+		echo "The generated documentation has issues. Patch your gtk-doc (see https://gitlab.gnome.org/GNOME/gtk-doc/merge_requests/2). This check fails with NMTST_CHECK_GTK_DOC=1"; \
+		test "$$NMTST_CHECK_GTK_DOC" != 1; \
+	fi
+check_local += check-local-gtk-doc-patch
+endif
+
+check-local: $(check_local)


### PR DESCRIPTION
In libnm, we prefer opaque typedefs. gtk-doc needs to be patched to properly
support that. Add a check for that.

See-also: https://gitlab.gnome.org/GNOME/gtk-doc/merge_requests/2