### PR TITLE
docs: misc. typos

### DIFF
--- a/clients/cli/connections.c
+++ b/clients/cli/connections.c
@@ -1755,7 +1755,7 @@ con_show_get_items (NmCli *nmc, gboolean active_only, gboolean show_active_field
 		 * color (activated or not) based on primary_active. */
 		if (!row_data) {
 			/* this is unexpected. The active connection references a connection that
-			 * seemingly no longer exists. It's a bug in libnm. Add a row nontheless. */
+			 * seemingly no longer exists. It's a bug in libnm. Add a row nonetheless. */
 			row_data = _metagen_con_show_row_data_new_for_connection (c, show_active_fields);
 			g_hash_table_insert (row_hash, c, row_data);
 		}
@@ -3985,7 +3985,7 @@ con_settings (NMConnection *connection, const NMMetaSettingValidPartItem *const*
 
 /*
  * Make sure all required settings are in place (should be called when
- * it's possible that a type is aready set).
+ * it's possible that a type is already set).
  */
 static void
 ensure_settings (NMConnection *connection, const NMMetaSettingValidPartItem *const*item)
@@ -6789,7 +6789,7 @@ property_edit_submenu (NmCli *nmc,
 		gboolean removed;
 		gboolean dirty;
 
-		/* Get the remote connection again, it may have disapeared */
+		/* Get the remote connection again, it may have disappeared */
 		removed = refresh_remote_connection (rem_con_weak, rem_con);
 		if (removed) {
 			g_print (_("The connection profile has been removed from another client. "
@@ -7180,7 +7180,7 @@ editor_menu_main (NmCli *nmc, NMConnection *connection, const char *connection_t
 
 		cmd_user = nmc_readline ("%s", menu_ctx.main_prompt);
 
-		/* Get the remote connection again, it may have disapeared */
+		/* Get the remote connection again, it may have disappeared */
 		removed = refresh_remote_connection (&weak, &rem_con);
 		if (removed) {
 			g_print (_("The connection profile has been removed from another client. "

--- a/clients/cli/general.c
+++ b/clients/cli/general.c
@@ -221,7 +221,7 @@ _metagen_general_status_get_fcn (NMC_META_GENERIC_INFO_GET_FCN_ARGS)
 		goto enabled_out;
 	case NMC_GENERIC_INFO_TYPE_GENERAL_STATUS_WIMAX_HW:
 	case NMC_GENERIC_INFO_TYPE_GENERAL_STATUS_WIMAX:
-		/* deprected fields. Don't return anything. */
+		/* deprecated fields. Don't return anything. */
 		return NULL;
 	default:
 		break;

--- a/clients/cli/settings.c
+++ b/clients/cli/settings.c
@@ -332,7 +332,7 @@ _set_fcn_precheck_connection_secondaries (const char *value,
 				g_print (_("Warning: %s is not an UUID of any existing connection profile\n"),
 				         *iter);
 			} else {
-				/* Currenly NM only supports VPN connections as secondaries */
+				/* Currently NM only supports VPN connections as secondaries */
 				if (!nm_connection_is_type (con, NM_SETTING_VPN_SETTING_NAME)) {
 					g_set_error (error, 1, 0, _("'%s' is not a VPN connection profile"), *iter);
 					return FALSE;
@@ -345,7 +345,7 @@ _set_fcn_precheck_connection_secondaries (const char *value,
 				return FALSE;
 			}
 
-			/* Currenly NM only supports VPN connections as secondaries */
+			/* Currently NM only supports VPN connections as secondaries */
 			if (!nm_connection_is_type (con, NM_SETTING_VPN_SETTING_NAME)) {
 				g_set_error (error, 1, 0, _("'%s' is not a VPN connection profile"), *iter);
 				return FALSE;
@@ -590,11 +590,11 @@ nmc_property_set_default_value (NMSetting *setting, const char *prop)
 }
 
 /*
- * Generic function for reseting (single value) properties.
+ * Generic function for resetting (single value) properties.
  *
  * The function resets the property value to the default one. It respects
  * nmcli restrictions for changing properties. So if 'set_func' is NULL,
- * reseting the value is denied.
+ * resetting the value is denied.
  *
  * Returns: TRUE on success; FALSE on failure and sets error
  */

--- a/clients/cli/utils.c
+++ b/clients/cli/utils.c
@@ -1098,7 +1098,7 @@ _print_fill (const NmcConfig *nmc_config,
 				/* don't mark the entry for display. This is to shorten the output in case
 				 * the property is the default value. But we only do that, if the user
 				 * opts in to this behavior (-overview), or of the property marks itself
-				 * elegible to be hidden.
+				 * eligible to be hidden.
 				 *
 				 * In general, only new API shall mark itself eligible to be hidden.
 				 * Long established properties cannot, because it would be a change
@@ -1273,7 +1273,7 @@ _print_do (const NmcConfig *nmc_config,
 			title = header_cell->title;
 
 			width1 = strlen (title);
-			width2 = nmc_string_screen_width (title, NULL);  /* Width of the string (in screen colums) */
+			width2 = nmc_string_screen_width (title, NULL);  /* Width of the string (in screen columns) */
 			g_string_append_printf (str, "%-*s", (int) (header_cell->width + width1 - width2), title);
 			g_string_append_c (str, ' ');  /* Column separator */
 			table_width += header_cell->width + width1 - width2 + 1;
@@ -1355,7 +1355,7 @@ _print_do (const NmcConfig *nmc_config,
 						const PrintDataHeaderCell *header_cell = &header_row[i_col];
 
 						width1 = strlen (text);
-						width2 = nmc_string_screen_width (text, NULL);  /* Width of the string (in screen colums) */
+						width2 = nmc_string_screen_width (text, NULL);  /* Width of the string (in screen columns) */
 						g_string_append_printf (str, "%-*s", (int) (header_cell->width + width1 - width2), text);
 						g_string_append_c (str, ' ');  /* Column separator */
 						table_width += header_cell->width + width1 - width2 + 1;
@@ -1728,7 +1728,7 @@ print_required_fields (const NmcConfig *nmc_config,
 			g_string_append_c (str, ':');  /* Column separator */
 		} else {
 			width1 = strlen (value);
-			width2 = nmc_string_screen_width (value, NULL);  /* Width of the string (in screen colums) */
+			width2 = nmc_string_screen_width (value, NULL);  /* Width of the string (in screen columns) */
 			g_string_append_printf (str, "%-*s", field_values[idx].width + width1 - width2, strlen (value) > 0 ? value : not_set_str);
 			g_string_append_c (str, ' ');  /* Column separator */
 			table_width += field_values[idx].width + width1 - width2 + 1;

--- a/clients/common/nm-meta-setting-desc.h
+++ b/clients/common/nm-meta-setting-desc.h
@@ -407,7 +407,7 @@ typedef enum {
 
 /* the settings-meta data is supposed to be independent of an actual client
  * implementation. Hence, there is a need for hooks to the meta-data.
- * The meta-data handlers may call back to the enviroment with certain
+ * The meta-data handlers may call back to the environment with certain
  * actions. */
 struct _NMMetaEnvironment {
 

--- a/clients/common/nm-polkit-listener.c
+++ b/clients/common/nm-polkit-listener.c
@@ -198,7 +198,7 @@ choose_identity (GList *identities)
 	GList *elem;
 
 	/* Choose identity. First try current user, then root, and else
-	 * take the firts one */
+	 * take the first one */
 	user = getenv("USER");
 	elem = g_list_find_custom (identities, user, (GCompareFunc) compare_users);
 	if (!elem) {

--- a/clients/common/nm-polkit-listener.h
+++ b/clients/common/nm-polkit-listener.h
@@ -66,7 +66,7 @@ typedef struct {
 	                       gpointer user_data);
 
 	/*
-	 * @gained_authorization: whether the autorization was successful
+	 * @gained_authorization: whether the authorization was successful
 	 *
 	 * Called as a result of completed signal by polkit.
 	 */
@@ -123,7 +123,7 @@ typedef void (*NMPolkitListenerOnShowInfoFunc) (const char *text);
 typedef void (*NMPolkitListenerOnShowErrorFunc) (const char *text);
 /**
  * NMPolkitListenerCompletedFunc:
- * @gained_authorization: whether the autorization was successful
+ * @gained_authorization: whether the authorization was successful
  *
  * Called as a result of completed signal by polkit.
  */

--- a/clients/tests/test-client.py
+++ b/clients/tests/test-client.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 # This test starts NetworkManager stub service in a user D-Bus session,
 # and runs nmcli against it. The output is recorded and compared to a pre-generated
 # expected output (clients/tests/test-client.check-on-disk/*.expected) which
-# is also commited to git.
+# is also committed to git.
 #
 ###############################################################################
 #

--- a/clients/tui/newt/nmt-newt-listbox.c
+++ b/clients/tui/newt/nmt-newt-listbox.c
@@ -227,7 +227,7 @@ nmt_newt_listbox_get_active_key (NmtNewtListbox *listbox)
 /**
  * nmt_newt_listbox_set_height:
  * @listbox: an #NmtNewtListbox
- * @height: the new height, or -1 for no fixed heigh
+ * @height: the new height, or -1 for no fixed height
  *
  * Updates @listbox's height.
  */

--- a/clients/tui/nm-editor-bindings.c
+++ b/clients/tui/nm-editor-bindings.c
@@ -516,7 +516,7 @@ ip_route_transform_from_metric_string (GBinding     *binding,
  * @addr_family: the IP address family
  * @source: the source object
  * @source_property: the source property
- * @dest_target: the target object for the route's destionation
+ * @dest_target: the target object for the route's destination
  * @dest_target_property: the property on @dest_target
  * @next_hop_target: the target object for the route's next hop
  * @next_hop_target_property: the property on @next_hop_target

--- a/clients/tui/nmt-slave-list.c
+++ b/clients/tui/nmt-slave-list.c
@@ -56,7 +56,7 @@ static gboolean nmt_slave_list_connection_filter (NmtEditConnectionList *list,
 /**
  * nmt_slave_list_new:
  * @master: the master #NMConnection whose slaves are being listed
- * @type_filter: (allow-none): a function to limit the availble slave types
+ * @type_filter: (allow-none): a function to limit the available slave types
  * @type_filter_data: (allow-none): data for @type_filter.
  *
  * Creates a new #NmtSlaveList.

--- a/examples/lua/lgi/add-connection.lua
+++ b/examples/lua/lgi/add-connection.lua
@@ -62,7 +62,7 @@ end
 function added_cb(client, result, data)
   local con,err,code = client:add_connection_finish(result)
   if con then
-    print("The connection profile has been succesfully added to NetworkManager:")
+    print("The connection profile has been successfully added to NetworkManager:")
     print(con:get_id(), con:get_uuid())
   else
     print(string.format("Error: (%d) %s", code, err))

--- a/examples/lua/lgi/deactivate-all.lua
+++ b/examples/lua/lgi/deactivate-all.lua
@@ -29,7 +29,7 @@
 local lgi = require 'lgi'
 local NM = lgi.NM
 
--- suported connection types
+-- supported connection types
 connection_types = {
   NM.SETTING_VPN_SETTING_NAME,
   NM.SETTING_WIRELESS_SETTING_NAME,

--- a/examples/nm-conf.d/30-anon.conf
+++ b/examples/nm-conf.d/30-anon.conf
@@ -38,7 +38,7 @@
 #
 #   $ nmcli connection modify "$CON_NAME" connection.stable-id '${CONNECTION}/${BOOT}'
 #
-# ... or keep it stable accross reboots, but still distinct per profile:
+# ... or keep it stable across reboots, but still distinct per profile:
 #
 #   $ nmcli connection modify "$CON_NAME" connection.stable-id '${CONNECTION}'
 #

--- a/examples/python/dbus/create-bond.py
+++ b/examples/python/dbus/create-bond.py
@@ -101,7 +101,7 @@ loop = GObject.MainLoop()
 def properties_changed(props):
     if 'State' in props:
         if props['State'] == 2:
-            print("Succesfully connected")
+            print("Successfully connected")
             loop.quit()
         if props['State'] == 3 or props['State'] == 4:
             print("Bond activation failed")

--- a/examples/python/gi/add_connection.py
+++ b/examples/python/gi/add_connection.py
@@ -69,7 +69,7 @@ def create_profile(name):
 def added_cb(client, result, data):
     try:
         client.add_connection_finish(result)
-        print("The connection profile has been succesfully added to NetworkManager.")
+        print("The connection profile has been successfully added to NetworkManager.")
     except Exception as e:
         sys.stderr.write("Error: %s\n" % e)
     main_loop.quit()

--- a/examples/python/gi/deactivate-all.py
+++ b/examples/python/gi/deactivate-all.py
@@ -35,7 +35,7 @@ import gi
 gi.require_version('NM', '1.0')
 from gi.repository import NM
 
-# suported connection types
+# supported connection types
 connection_types = {
   NM.SETTING_VPN_SETTING_NAME,
   NM.SETTING_WIRELESS_SETTING_NAME,

--- a/examples/python/gi/vpn-import.py
+++ b/examples/python/gi/vpn-import.py
@@ -64,7 +64,7 @@ main_loop = GLib.MainLoop()
 def added_cb(client, result, data):
     try:
         client.add_connection_finish(result)
-        print("The connection profile has been succesfully added to NetworkManager.")
+        print("The connection profile has been successfully added to NetworkManager.")
     except Exception, e:
         print("ERROR: failed to add connection: %s\n" % e)
     main_loop.quit()

--- a/src/devices/nm-device-private.h
+++ b/src/devices/nm-device-private.h
@@ -34,7 +34,7 @@ enum NMActStageReturn {
 	NM_ACT_STAGE_RETURN_IP_DONE,     /* IP config stage is done (state IP_DONE),
 	                                    For the ip-config stage, this is similar to
 	                                    NM_ACT_STAGE_RETURN_SUCCESS, except that no
-	                                    IP config should be commited. */
+	                                    IP config should be committed. */
 	NM_ACT_STAGE_RETURN_IP_FAIL,     /* IP config stage failed (state IP_FAIL), activation may proceed */
 };
 

--- a/src/devices/nm-device.c
+++ b/src/devices/nm-device.c
@@ -2663,7 +2663,7 @@ concheck_periodic_schedule_set (NMDevice *self,
 	/* we are here, because we returned from a connectivity check and adjust the current interval.
 	 *
 	 * But note that we calculate the new timeout based on the time when we scheduled the
-	 * last check, instead of counting from now. The reaons is, that we want that the times
+	 * last check, instead of counting from now. The reasons is, that we want that the times
 	 * when we schedule checks be at precise intervals, without including the time it took for
 	 * the connectivity check. */
 	new_expiry = priv->concheck_p_cur_basetime_ns + (priv->concheck_p_cur_interval * NM_UTILS_NS_PER_SECOND);
@@ -8907,7 +8907,7 @@ _commit_mtu (NMDevice *self, const NMIP4Config *config)
 	{
 		guint32 mtu = 0;
 
-		/* preferably, get the MTU from explict user-configuration.
+		/* preferably, get the MTU from explicit user-configuration.
 		 * Only if that fails, look at the current @config (which contains
 		 * MTUs from DHCP/PPP) or maybe fallback to a device-specific MTU. */
 
@@ -9227,7 +9227,7 @@ addrconf6_start_with_link_ready (NMDevice *self)
 	} else {
 		/* Don't abort the addrconf at this point -- if ndisc needs the iid
 		 * it will notice this itself. */
-		_LOGI (LOGD_IP6, "addrconf6: no interface identifier; IPv6 adddress creation may fail");
+		_LOGI (LOGD_IP6, "addrconf6: no interface identifier; IPv6 address creation may fail");
 	}
 
 	/* Apply any manual configuration before starting RA */
@@ -12967,10 +12967,10 @@ _get_managed_by_flags(NMUnmanagedFlags flags, NMUnmanagedFlags mask, gboolean fo
 
 		/* @for_user_request can make the result only ~more~ managed.
 		 * If the flags already indicate a managed state for a non-user-request,
-		 * then it is also managed for an explict user-request.
+		 * then it is also managed for an explicit user-request.
 		 *
 		 * Effectively, this check is redundant, as the code below already
-		 * already ensures that. Still, express this invariant explictly here. */
+		 * already ensures that. Still, express this invariant explicitly here. */
 		if (_get_managed_by_flags (flags, mask, FALSE))
 			return TRUE;
 
@@ -13026,7 +13026,7 @@ _get_managed_by_flags(NMUnmanagedFlags flags, NMUnmanagedFlags mask, gboolean fo
 /**
  * nm_device_get_managed:
  * @self: the #NMDevice
- * @for_user_request: whether to check the flags for an explict user-request
+ * @for_user_request: whether to check the flags for an explicit user-request
  *
  * Whether the device is unmanaged according to the unmanaged flags.
  *
@@ -13566,7 +13566,7 @@ _nm_device_check_connection_available (NMDevice *self,
 		} else {
 			if (!nm_device_get_managed (self, FALSE)) {
 				nm_utils_error_set_literal (error, NM_UTILS_ERROR_CONNECTION_AVAILABLE_UNMANAGED_DEVICE,
-				                            "device is unmanaged for interal request");
+				                            "device is unmanaged for internal request");
 				return FALSE;
 			}
 		}
@@ -14111,7 +14111,7 @@ _cleanup_generic_post (NMDevice *self, CleanupType cleanup_type)
 		delete_on_deactivate_check_and_schedule (self, nm_device_get_ip_ifindex (self));
 	}
 
-	/* ip_iface should be cleared after flushing all routes and addreses, since
+	/* ip_iface should be cleared after flushing all routes and addresses, since
 	 * those are identified by ip_iface, not by iface (which might be a tty
 	 * or ATM device).
 	 */
@@ -14898,7 +14898,7 @@ nm_device_queue_state (NMDevice *self,
 	}
 
 	/* Add pending action for the new state before clearing the queued states, so
-	 * that we don't accidently pop all pending states and reach 'startup complete'  */
+	 * that we don't accidentally pop all pending states and reach 'startup complete'  */
 	nm_device_add_pending_action (self, queued_state_to_string (state), TRUE);
 
 	/* We should only ever have one delayed state transition at a time */
@@ -15023,7 +15023,7 @@ nm_device_update_hw_address (NMDevice *self)
 	        && priv->state < NM_DEVICE_STATE_PREPARE
 	        && !nm_device_is_activating (self))) {
 		/* when we get a hw_addr the first time or while the device
-		 * is not activated (with no explict hw address set), always
+		 * is not activated (with no explicit hw address set), always
 		 * update our initial hw-address as well. */
 		nm_device_update_initial_hw_address (self);
 	}
@@ -15040,7 +15040,7 @@ nm_device_update_initial_hw_address (NMDevice *self)
 		if (   priv->hw_addr_initial
 		    && priv->hw_addr_type != HW_ADDR_TYPE_UNSET) {
 			/* once we have the initial hw address set, we only allow
-			 * update if the currenty type is "unset". */
+			 * update if the currently type is "unset". */
 			return;
 		}
 		g_free (priv->hw_addr_initial);
@@ -15286,7 +15286,7 @@ _hw_addr_set (NMDevice *self,
 	plerr = nm_platform_link_set_address (nm_device_get_platform (self), nm_device_get_ip_ifindex (self), addr_bytes, addr_len);
 	success = (plerr == NM_PLATFORM_ERROR_SUCCESS);
 	if (success) {
-		/* MAC address succesfully changed; update the current MAC to match */
+		/* MAC address successfully changed; update the current MAC to match */
 		nm_device_update_hw_address (self);
 		if (_hw_addr_matches (self, addr_bytes, addr_len)) {
 			_LOGI (LOGD_DEVICE, "set-hw-addr: %s MAC address to %s (%s)",
@@ -15308,7 +15308,7 @@ _hw_addr_set (NMDevice *self,
 			 * that is rather complicated and it is not expected that this case
 			 * happens for regular drivers.
 			 * Note that brcmfmac can block NetworkManager for 500 msec while
-			 * taking down the device. Let's add annother 100 msec to that.
+			 * taking down the device. Let's add another 100 msec to that.
 			 *
 			 * wait/poll up to 100 msec until it changes. */
 
@@ -15996,7 +15996,7 @@ dispose (GObject *object)
 	G_OBJECT_CLASS (nm_device_parent_class)->dispose (object);
 
 	if (nm_clear_g_source (&priv->queued_state.id)) {
-		/* FIXME: we'd expect the queud_state to be alredy cleared and this statement
+		/* FIXME: we'd expect the queud_state to be already cleared and this statement
 		 * not being necessary. Add this check here to hopefully investigate crash
 		 * rh#1270247. */
 		g_return_if_reached ();

--- a/src/devices/nm-device.h
+++ b/src/devices/nm-device.h
@@ -54,7 +54,7 @@ typedef enum {
 static inline NMDeviceStateReason
 nm_device_state_reason_check (NMDeviceStateReason reason)
 {
-	/* the device-state-reason serves mostly informational purpse during a state
+	/* the device-state-reason serves mostly informational purpose during a state
 	 * change. In some cases however, decisions are made based on the reason.
 	 * I tend to think that interpreting the state reason to derive some behaviors
 	 * is confusing, because the cause and effect are so far apart.
@@ -253,7 +253,7 @@ typedef struct _NMDeviceClass {
 	 * Hook for derived classes to be notfied during realize_start_setup()
 	 * and perform additional setup.
 	 *
-	 * The default implemention of NMDevice calls link_changed().
+	 * The default implementation of NMDevice calls link_changed().
 	 */
 	void        (*realize_start_notify) (NMDevice *self,
 	                                     const NMPlatformLink *pllink);
@@ -592,7 +592,7 @@ void nm_device_copy_ip6_dns_config (NMDevice *self, NMDevice *from_device);
  *   the settings plugin (for example keyfile.unmanaged-devices or ifcfg-rh's
  *   NM_CONTROLLED=no). Although this is user-configuration (provided from
  *   the settings plugins, such as NM_CONTROLLED=no in ifcfg-rh), it cannot
- *   be overruled and is authorative. That is because users may depend on
+ *   be overruled and is authoritative. That is because users may depend on
  *   dropping a ifcfg-rh file to ensure the device is unmanaged.
  * @NM_UNMANAGED_USER_CONF: %TRUE when unmanaged by user decision via
  *   the NetworkManager.conf ("unmanaged" in the [device] section).
@@ -609,7 +609,7 @@ void nm_device_copy_ip6_dns_config (NMDevice *self, NMDevice *from_device);
 typedef enum { /*< skip >*/
 	NM_UNMANAGED_NONE          = 0,
 
-	/* these flags are authorative. If one of them is set,
+	/* these flags are authoritative. If one of them is set,
 	 * the device cannot be managed. */
 	NM_UNMANAGED_SLEEPING      = (1LL <<  0),
 	NM_UNMANAGED_QUITTING      = (1LL <<  1),

--- a/src/devices/ovs/nm-ovsdb.c
+++ b/src/devices/ovs/nm-ovsdb.c
@@ -1126,7 +1126,7 @@ ovsdb_got_msg (NMOvsdb *self, json_t *msg)
 			ovsdb_disconnect (self, FALSE);
 			return;
 		}
-		/* Cool, we found a corresponsing call. Finish it. */
+		/* Cool, we found a corresponding call. Finish it. */
 
 		_call_trace ("response", call, msg);
 

--- a/src/devices/wifi/nm-device-olpc-mesh.c
+++ b/src/devices/wifi/nm-device-olpc-mesh.c
@@ -154,7 +154,7 @@ act_stage1_prepare (NMDevice *device, NMDeviceStateReason *out_failure_reason)
 		       nm_device_get_iface (priv->companion));
 	}
 
-	/* wait with continuing configuration untill the companion device is done scanning */
+	/* wait with continuing configuration until the companion device is done scanning */
 	g_object_get (priv->companion, NM_DEVICE_WIFI_SCANNING, &scanning, NULL);
 	if (scanning) {
 		priv->stage1_waiting = TRUE;

--- a/src/devices/wifi/nm-device-wifi.c
+++ b/src/devices/wifi/nm-device-wifi.c
@@ -731,7 +731,7 @@ check_connection_available (NMDevice *device,
 
 	/* Hidden SSIDs obviously don't always appear in the scan list either.
 	 *
-	 * For an explict user-activation-request, a connection is considered
+	 * For an explicit user-activation-request, a connection is considered
 	 * available because for hidden Wi-Fi, clients didn't consistently
 	 * set the 'hidden' property to indicate hidden SSID networks.  If
 	 * activating but the network isn't available let the device recheck
@@ -1235,7 +1235,7 @@ scanning_prohibited (NMDeviceWifi *self, gboolean periodic)
 		return FALSE;
 	case NM_DEVICE_STATE_ACTIVATED:
 		/* Prohibit periodic scans when connected; we ask the supplicant to
-		 * background scan for us, unless the connection is locked to a specifc
+		 * background scan for us, unless the connection is locked to a specific
 		 * BSSID.
 		 */
 		if (periodic)

--- a/src/devices/wwan/nm-device-modem.c
+++ b/src/devices/wwan/nm-device-modem.c
@@ -448,7 +448,7 @@ check_connection_available (NMDevice *device,
 	state = nm_modem_get_state (priv->modem);
 	if (state <= NM_MODEM_STATE_INITIALIZING) {
 		nm_utils_error_set_literal (error, NM_UTILS_ERROR_CONNECTION_AVAILABLE_TEMPORARY,
-		                            "modem not initalized");
+		                            "modem not initialized");
 		return FALSE;
 	}
 

--- a/src/platform/nm-fake-platform.c
+++ b/src/platform/nm-fake-platform.c
@@ -194,7 +194,7 @@ link_add_prepare (NMPlatform *platform,
 {
 	gboolean connected;
 
-	/* we must clear the driver, because platform cache want's to set it */
+	/* we must clear the driver, because platform cache wants to set it */
 	g_assert (obj_tmp->link.driver == g_intern_string (obj_tmp->link.driver));
 	obj_tmp->link.driver = NULL;
 

--- a/src/platform/nm-linux-platform.c
+++ b/src/platform/nm-linux-platform.c
@@ -447,7 +447,7 @@ G_DEFINE_TYPE (NMLinuxPlatform, nm_linux_platform, NM_TYPE_PLATFORM)
         if (nm_logging_enabled (__level, __domain)) { \
             int __errsv = (errsv); \
             \
-            /* The %m format specifier (GNU extension) would alread allow you to specify the error
+            /* The %m format specifier (GNU extension) would already allow you to specify the error
              * message conveniently (and nm_log would get that right too). But we don't want to depend
              * on that, so instead append the message at the end.
              * Currently users are expected not to use %m in the format string. */ \
@@ -2227,7 +2227,7 @@ _wireguard_read_info (NMPlatform *platform /* used only as logging context */,
 	 * there. The realloc/resize of the GArray is fine there. However,
 	 * while we build the GArray, we don't yet have the final pointers.
 	 * Hence, while constructing, we track the indexes with peer->_construct_idx_*
-	 * fields. These indexes must be convered to actual pointers blow.
+	 * fields. These indexes must be converted to actual pointers blow.
 	 *
 	 * This is all done during parsing. In the final NMPObjectLnkWireGuard we
 	 * don't want the CList anymore and repackage the NMPObject tightly. The

--- a/src/platform/nm-netlink.c
+++ b/src/platform/nm-netlink.c
@@ -539,7 +539,7 @@ _nest_end (struct nl_msg *msg, struct nlattr *start, int keep_empty)
 	pad = NLMSG_ALIGN (msg->nm_nlh->nlmsg_len) - msg->nm_nlh->nlmsg_len;
 	if (pad > 0) {
 		/*
-		 * Data inside attribute does not end at a alignment boundry.
+		 * Data inside attribute does not end at a alignment boundary.
 		 * Pad accordingly and accoun for the additional space in
 		 * the message. nlmsg_reserve() may never fail in this situation,
 		 * the allocate message buffer must be a multiple of NLMSG_ALIGNTO.

--- a/src/platform/nm-platform-utils.c
+++ b/src/platform/nm-platform-utils.c
@@ -664,7 +664,7 @@ nmp_utils_ethtool_set_features (int ifindex,
 	              "set-features",
 	              success
 	                ? "successfully setting features"
-	                : "at least some of the features were not successfuly set");
+	                : "at least some of the features were not successfully set");
 	return success;
 }
 
@@ -1247,7 +1247,7 @@ nmp_utils_ip_config_source_to_string (NMIPConfigSource source, char *buf, gsize 
  * @ifindex: the ifindex for which to open "/sys/class/net/%s"
  * @ifname_guess: (allow-none): optional argument, if present used as initial
  *   guess as the current name for @ifindex. If guessed right,
- *   it saves an addtional if_indextoname() call.
+ *   it saves an additional if_indextoname() call.
  * @out_ifname: (allow-none): if present, must be at least IFNAMSIZ
  *   characters. On success, this will contain the actual ifname
  *   found while opening the directory.

--- a/src/platform/nm-platform.c
+++ b/src/platform/nm-platform.c
@@ -996,7 +996,7 @@ nm_platform_link_set_netns (NMPlatform *self, int ifindex, int netns_fd)
  * @name: Interface name
  *
  * Returns: The interface index corresponding to the given interface name
- * or 0. Inteface name is owned by #NMPlatform, don't free it.
+ * or 0. Interface name is owned by #NMPlatform, don't free it.
  */
 int
 nm_platform_link_get_ifindex (NMPlatform *self, const char *name)
@@ -1084,7 +1084,7 @@ nm_platform_link_get_type_name (NMPlatform *self, int ifindex)
 
 	if (obj->link.type != NM_LINK_TYPE_UNKNOWN) {
 		/* We could detect the @link_type. In this case the function returns
-		 * our internel module names, which differs from rtnl_link_get_type():
+		 * our internal module names, which differs from rtnl_link_get_type():
 		 *   - NM_LINK_TYPE_INFINIBAND (gives "infiniband", instead of "ipoib")
 		 *   - NM_LINK_TYPE_TAP (gives "tap", instead of "tun").
 		 * Note that this functions is only used by NMDeviceGeneric to
@@ -1845,7 +1845,7 @@ nm_platform_link_can_assume (NMPlatform *self, int ifindex)
  * Returns: the internal link lnk object. The returned object
  * is owned by the platform cache and must not be modified. Note
  * however, that the object is guaranteed to be immutable, so
- * you can savely take a reference and keep it for yourself
+ * you can safely take a reference and keep it for yourself
  * (but don't modify it).
  */
 const NMPObject *
@@ -3691,7 +3691,7 @@ ip4_addr_subnets_is_secondary (const NMPObject *address,
  *   That means, expired addresses and addresses that could not be added
  *   will be dropped.
  *   Hence, the input argument @known_addresses is also an output argument
- *   telling which addresses were succesfully added.
+ *   telling which addresses were successfully added.
  *   Addresses are removed by unrefing the instance via nmp_object_unref()
  *   and leaving a NULL tombstone.
  *
@@ -3865,7 +3865,7 @@ ip6_address_scope_cmp (gconstpointer a, gconstpointer b)
  *   That means, expired addresses and addresses that could not be added
  *   will be dropped.
  *   Hence, the input argument @known_addresses is also an output argument
- *   telling which addresses were succesfully added.
+ *   telling which addresses were successfully added.
  *   Addresses are removed by unrefing the instance via nmp_object_unref()
  *   and leaving a NULL tombstone.
  * @full_sync: Also remove link-local and temporary addresses.
@@ -4225,7 +4225,7 @@ nm_platform_ip_route_sync (NMPlatform *self,
 				                   NM_PLATFORM_IP_ROUTE_CMP_TYPE_SEMANTICALLY) == 0)
 					continue;
 
-				/* we need to replace the existing route with a (slightly) differnt
+				/* we need to replace the existing route with a (slightly) different
 				 * one. Delete it first. */
 				if (!nm_platform_object_delete (self, plat_o)) {
 					/* ignore error. */
@@ -4787,7 +4787,7 @@ _ip4_dev_route_blacklist_schedule (NMPlatform *self)
  * route, however it has a wrong metric of zero. We add our own device route (with
  * proper metric), but need to delete the route that kernel adds.
  *
- * The problem is, that kernel does not immidiately add the route, when adding
+ * The problem is, that kernel does not immediately add the route, when adding
  * the address. It only shows up some time later. So, we register here a list
  * of blacklisted routes, and when they show up within a time out, we assume it's
  * the kernel generated one, and we delete it.

--- a/src/platform/nm-platform.h
+++ b/src/platform/nm-platform.h
@@ -299,10 +299,10 @@ struct _NMPlatformObject {
 	 *   are permanent. This rule is so that unset addresses (calloc) are permanent by default.
 	 * 2 @lifetime==@preferred==NM_PLATFORM_LIFETIME_PERMANENT: @timestamp is irrelevant (but mostly
 	 *   set to 0). Such addresses are permanent.
-	 * 3 Non permanent addreses should (almost) always have @timestamp > 0. 0 is not a valid timestamp
+	 * 3 Non permanent addresses should (almost) always have @timestamp > 0. 0 is not a valid timestamp
 	 *   and never returned by nm_utils_get_monotonic_timestamp_s(). In this case @valid/@preferred
 	 *   is anchored at @timestamp.
-	 * 4 Non permanent addresses with @timestamp == 0 are implicitely anchored at *now*, thus the time
+	 * 4 Non permanent addresses with @timestamp == 0 are implicitly anchored at *now*, thus the time
 	 *   moves as time goes by. This is usually not useful, except e.g. nm_platform_ip[46]_address_add().
 	 *
 	 * Non permanent addresses from DHCP/RA might have the @timestamp set to the moment of when the
@@ -417,7 +417,7 @@ typedef union {
 	 * On the other hand, for IPv6 you cannot add two IPv6 routes that only differ
 	 * by an RTA_METRICS property.
 	 *
-	 * When deleting a route, kernel seems to ignore the RTA_METRICS propeties.
+	 * When deleting a route, kernel seems to ignore the RTA_METRICS properties.
 	 * That is a problem/bug for IPv4 because you cannot explicitly select which
 	 * route to delete. Kernel just picks the first. See rh#1475642. */ \
 	\
@@ -1160,7 +1160,7 @@ GPtrArray *nm_platform_lookup_clone (NMPlatform *platform,
                                      NMPObjectPredicateFunc predicate,
                                      gpointer user_data);
 
-/* convienience methods to lookup the link and access fields of NMPlatformLink. */
+/* convenience methods to lookup the link and access fields of NMPlatformLink. */
 int nm_platform_link_get_ifindex (NMPlatform *self, const char *name);
 const char *nm_platform_link_get_name (NMPlatform *self, int ifindex);
 NMLinkType nm_platform_link_get_type (NMPlatform *self, int ifindex);

--- a/src/platform/nmp-object.c
+++ b/src/platform/nmp-object.c
@@ -1636,7 +1636,7 @@ nmp_cache_link_connected_needs_toggle (const NMPCache *cache, const NMPObject *m
  * The flag obj->link.connected depends on the state of other links in the
  * @cache. See also nmp_cache_link_connected_needs_toggle(). Given an ifindex
  * of a master, check if the cache contains such a master link that needs
- * toogling of the connected flag.
+ * toggling of the connected flag.
  *
  * Returns: NULL if there is no master link with ifindex @master_ifindex that should be toggled.
  *   Otherwise, return the link object from inside the cache with the given ifindex.
@@ -2338,7 +2338,7 @@ nmp_cache_remove_netlink (NMPCache *cache,
  *
  * Returns: how the cache changed.
  *
- * Even if there was no change in the cace (NMP_CACHE_OPS_UNCHANGED), @out_obj_old
+ * Even if there was no change in the cache (NMP_CACHE_OPS_UNCHANGED), @out_obj_old
  * and @out_obj_new will be set accordingly.
  **/
 NMPCacheOpsType
@@ -2609,7 +2609,7 @@ update_done:
 		nm_dedup_multi_entry_reorder (entry_cur, NULL, FALSE);
 		break;
 	default:
-		/* this is an unexecpted case, probably a bug that we need to handle better. */
+		/* this is an unexpected case, probably a bug that we need to handle better. */
 		resync_required = TRUE;
 		break;
 	}

--- a/src/platform/nmp-object.h
+++ b/src/platform/nmp-object.h
@@ -100,14 +100,14 @@ typedef enum { /*< skip >*/
 	 *
 	 * Also, note that links may be considered invisible. This index type
 	 * expose all links, even invisible ones. For addresses/routes, this
-	 * distiction doesn't exist, as all addresses/routes that are alive
+	 * distinction doesn't exist, as all addresses/routes that are alive
 	 * are visible as well. */
 	NMP_CACHE_ID_TYPE_OBJECT_TYPE,
 
 	/* index for the link objects by ifname. */
 	NMP_CACHE_ID_TYPE_LINK_BY_IFNAME,
 
-	/* indeces for the visible default-routes, ignoring ifindex.
+	/* indices for the visible default-routes, ignoring ifindex.
 	 * This index only contains two partitions: all visible default-routes,
 	 * separate for IPv4 and IPv6. */
 	NMP_CACHE_ID_TYPE_DEFAULT_ROUTES,
@@ -504,7 +504,7 @@ nmp_object_ref (const NMPObject *obj)
 	}
 
 	/* ref and unref accept const pointers. NMPObject is supposed to be shared
-	 * and kept immutable. Disallowing to take/retrun a reference to a const
+	 * and kept immutable. Disallowing to take/return a reference to a const
 	 * NMPObject is cumbersome, because callers are precisely expected to
 	 * keep a ref on the otherwise immutable object. */
 	g_return_val_if_fail (NMP_OBJECT_IS_VALID (obj), NULL);

--- a/src/platform/tests/test-address.c
+++ b/src/platform/tests/test-address.c
@@ -189,7 +189,7 @@ test_ip4_address_general_2 (void)
 	inet_pton (AF_INET, IP4_ADDRESS, &addr);
 	g_assert (ifindex > 0);
 
-	/* Looks like addresses are not announced by kerenl when the interface
+	/* Looks like addresses are not announced by kernel when the interface
 	 * is down. Link-local IPv6 address is automatically added.
 	 */
 	g_assert (nm_platform_link_set_up (NM_PLATFORM_GET, DEVICE_IFINDEX, NULL));

--- a/src/platform/tests/test-link.c
+++ b/src/platform/tests/test-link.c
@@ -1217,7 +1217,7 @@ test_software_detect (gconstpointer user_data)
 				g_assert_cmpint (plnk->dst_port, ==, 4789);
 				if (   plnk->src_port_min != 0
 				    || plnk->src_port_max != 0) {
-					/* on some kernels, omiting the port range results in setting
+					/* on some kernels, omitting the port range results in setting
 					 * following default port range. */
 					g_assert_cmpint (plnk->src_port_min, ==, 32768);
 					g_assert_cmpint (plnk->src_port_max, ==, 61000);

--- a/src/platform/wifi/nm-wifi-utils-wext.c
+++ b/src/platform/wifi/nm-wifi-utils-wext.c
@@ -771,7 +771,7 @@ nm_wifi_utils_wext_is_wifi (const char *iface)
 	/* performing an ioctl on a non-existing name may cause the automatic
 	 * loading of kernel modules, which should be avoided.
 	 *
-	 * Usually, we should thus make sure that an inteface with this name
+	 * Usually, we should thus make sure that an interface with this name
 	 * exists.
 	 *
 	 * Note that wifi_wext_is_wifi() has only one caller which just verified

--- a/src/platform/wifi/nm-wifi-utils.h
+++ b/src/platform/wifi/nm-wifi-utils.h
@@ -62,7 +62,7 @@ gboolean nm_wifi_utils_get_bssid (NMWifiUtils *data, guint8 *out_bssid);
 /* Returns current bitrate in Kbps */
 guint32 nm_wifi_utils_get_rate (NMWifiUtils *data);
 
-/* Returns quality 0 - 100% on succes, or -1 on error */
+/* Returns quality 0 - 100% on success, or -1 on error */
 int nm_wifi_utils_get_qual (NMWifiUtils *data);
 
 /* Tells the driver DHCP or SLAAC is running */

--- a/src/settings/nm-settings-connection.c
+++ b/src/settings/nm-settings-connection.c
@@ -770,7 +770,7 @@ out:
 		else if (new_connection)
 			_LOGI ("write: successfully updated (%s)", logmsg_change);
 		else
-			_LOGI ("write: successfully commited (%s)", logmsg_change);
+			_LOGI ("write: successfully committed (%s)", logmsg_change);
 	}
 	return TRUE;
 }
@@ -1318,7 +1318,7 @@ nm_settings_connection_get_secrets (NMSettingsConnection *self,
 	/* we remember the current version-id of the secret-agents. The version-id is strictly increasing,
 	 * as new agents register the number. We know hence, that this request was made against a certain
 	 * set of secret-agents.
-	 * If after making this request a new secret-agent registeres, the version-id increases.
+	 * If after making this request a new secret-agent registers, the version-id increases.
 	 * Then we know that the this request probably did not yet include the latest secret-agent. */
 	priv->last_secret_agent_version_id = nm_agent_manager_get_agent_version_id (priv->agent_mgr);
 

--- a/src/settings/plugins/ifcfg-rh/nms-ifcfg-rh-plugin.c
+++ b/src/settings/plugins/ifcfg-rh/nms-ifcfg-rh-plugin.c
@@ -539,7 +539,7 @@ read_connections (SettingsPluginIfcfg *plugin)
 	 * iterating over the files.
 	 *
 	 * To have sensible, reproducible behavior, sort the paths by last modification
-	 * time prefering older files.
+	 * time preferring older files.
 	 */
 	paths = _paths_from_connections (priv->connections);
 	g_ptr_array_sort_with_data (filenames, (GCompareDataFunc) _sort_paths, paths);
@@ -987,7 +987,7 @@ config_changed_cb (NMConfig *config,
 	 * won't be offered.
 	 *
 	 * On SIGHUP and SIGUSR1 try to re-connect to D-Bus. So in the unlikely
-	 * event that the D-Bus conneciton is broken, that allows for recovery
+	 * event that the D-Bus connection is broken, that allows for recovery
 	 * without need for restarting NetworkManager. */
 	if (!NM_FLAGS_ANY (changes,   NM_CONFIG_CHANGE_CAUSE_SIGHUP
 	                            | NM_CONFIG_CHANGE_CAUSE_SIGUSR1))

--- a/src/settings/plugins/ifcfg-rh/nms-ifcfg-rh-reader.c
+++ b/src/settings/plugins/ifcfg-rh/nms-ifcfg-rh-reader.c
@@ -810,7 +810,7 @@ enum {
  * setting, and one for initscript's handle_ip_file(), which takes the lines
  * and passes them to `ip route add`. The modes are similar, but certain properties
  * are not allowed for OPTIONS.
- * The mode is differenciated by having an @options_route argument.
+ * The mode is differentiated by having an @options_route argument.
  *
  * Returns: returns a negative errno on failure. On success, it returns 0
  *   and @out_route.
@@ -1150,7 +1150,7 @@ next:
 			                                                    : ""));
 			break;
 		case PARSE_LINE_TYPE_FLAG:
-			/* NOTE: the flag (for "onlink") only allows to explictly set "TRUE".
+			/* NOTE: the flag (for "onlink") only allows to explicitly set "TRUE".
 			 * There is no way to express an explicit "FALSE" setting
 			 * of this attribute, hence, the file format cannot encode
 			 * that configuration. */
@@ -3151,7 +3151,7 @@ eap_tls_reader (const char *eap_method,
 	/* FIXME: writer does not actually write IEEE_8021X_CLIENT_CERT_PASSWORD and other
 	 * certificate related passwords. It should, because otherwise persisting such profiles
 	 * to ifcfg looses information. As this currently only matters for PKCS11 URIs, it seems
-	 * a seldomly used feature so that it is not fixed yet. */
+	 * a seldom used feature so that it is not fixed yet. */
 	_secret_set_from_ifcfg (s_8021x,
 	                        ifcfg,
 	                        keys_ifcfg,

--- a/src/settings/plugins/ifcfg-rh/shvar.c
+++ b/src/settings/plugins/ifcfg-rh/shvar.c
@@ -330,7 +330,7 @@ _gstr_init (GString **str, const char *value, gsize i)
 		 * Unescaping usually does not extend the length of a string,
 		 * so we might be tempted to allocate a fixed buffer of length
 		 * (strlen(value)+CONST).
-		 * However, due to $'\Ux' escapes, the maxium length is some
+		 * However, due to $'\Ux' escapes, the maximum length is some
 		 * (FACTOR*strlen(value) + CONST), which is non trivial to get
 		 * right in all cases. Also, we would have to provision for the
 		 * very unlikely extreme case.
@@ -453,7 +453,7 @@ svUnescape (const char *value, char **to_free)
 					if (NM_IN_SET (value[i], '$', '`', '"', '\\')) {
 						/* Drop the backslash. */
 					} else if (NM_IN_SET (value[i], '\'', '~')) {
-						/* '\'' and '~' in double qoutes are not handled special by shell.
+						/* '\'' and '~' in double quotes are not handled special by shell.
 						 * However, old versions of svEscape() would wrongly use double-quoting
 						 * with backslash escaping for these characters (expecting svUnescape()
 						 * to remove the backslash).
@@ -649,7 +649,7 @@ void
 _nmtst_svFileSetName (shvarFile *s, const char *fileName)
 {
 	/* changing the file name is not supported for regular
-	 * operation. Only allowed to use in tests, othewise,
+	 * operation. Only allowed to use in tests, otherwise,
 	 * the filename is immutable. */
 	g_free (s->fileName);
 	s->fileName = g_strdup (fileName);

--- a/src/settings/plugins/ifcfg-rh/tests/network-scripts/ifcfg-test-write-unknown-4
+++ b/src/settings/plugins/ifcfg-rh/tests/network-scripts/ifcfg-test-write-unknown-4
@@ -6,7 +6,7 @@
 # expected.
 #
 # Also note that setting NAME will replace the last
-# occurance, and delete all previous once.
+# occurrence, and delete all previous once.
 
 #L1
 NAME=l2

--- a/src/settings/plugins/ifcfg-rh/tests/network-scripts/ifcfg-test-write-unknown-4.expected
+++ b/src/settings/plugins/ifcfg-rh/tests/network-scripts/ifcfg-test-write-unknown-4.expected
@@ -6,7 +6,7 @@
 # expected.
 #
 # Also note that setting NAME will replace the last
-# occurance, and delete all previous once.
+# occurrence, and delete all previous once.
 
 #L1
 

--- a/src/settings/plugins/ifcfg-rh/tests/network-scripts/network-test-wired-never-default
+++ b/src/settings/plugins/ifcfg-rh/tests/network-scripts/network-test-wired-never-default
@@ -1,4 +1,4 @@
 GATEWAYDEV=eth0
-# when devices in IPV6_DEFAULTDEV and IPV6_DEFAULTGW don't match the one in IPV6_DEFAULTGW is prefered
+# when devices in IPV6_DEFAULTDEV and IPV6_DEFAULTGW don't match the one in IPV6_DEFAULTGW is preferred
 IPV6_DEFAULTDEV=eth4
 IPV6_DEFAULTGW=2001::1234%eth0

--- a/src/settings/plugins/keyfile/nms-keyfile-plugin.c
+++ b/src/settings/plugins/keyfile/nms-keyfile-plugin.c
@@ -449,7 +449,7 @@ read_connections (NMSettingsPlugin *config)
 	 * iterating over the files.
 	 *
 	 * To have sensible, reproducible behavior, sort the paths by last modification
-	 * time prefering older files.
+	 * time preferring older files.
 	 */
 	paths = _paths_from_connections (priv->connections);
 	g_ptr_array_sort_with_data (filenames, (GCompareDataFunc) _sort_paths, paths);

--- a/src/tests/test-general.c
+++ b/src/tests/test-general.c
@@ -1296,7 +1296,7 @@ _do_test_match_spec_config (const char *file, int line, const char *spec_str, gu
 	match_result = nm_match_spec_config (specs, version, NULL);
 
 	if (expected != match_result)
-		g_error ("%s:%d: faild comparing \"%s\" with %u.%u.%u. Expected %d, but got %d", file, line, spec_str, v_maj, v_min, v_mic, (int) expected, (int) match_result);
+		g_error ("%s:%d: failed comparing \"%s\" with %u.%u.%u. Expected %d, but got %d", file, line, spec_str, v_maj, v_min, v_mic, (int) expected, (int) match_result);
 
 	if (g_slist_length (specs) == 1 && match_result != NM_MATCH_SPEC_NEG_MATCH) {
 		/* there is only one spec in the list... test that we match except: */

--- a/src/tests/test-ip6-config.c
+++ b/src/tests/test-ip6-config.c
@@ -251,7 +251,7 @@ test_nm_ip6_config_addresses_sort_check (NMIP6Config *config, NMSettingIP6Config
 	copy2 = nm_ip6_config_clone (config);
 	g_assert (copy2);
 
-	/* initialize the array of indeces, and keep shuffling them for every @repeat iteration. */
+	/* initialize the array of indices, and keep shuffling them for every @repeat iteration. */
 	for (i = 0; i < addr_count; i++)
 		idx[i] = i;
 


### PR DESCRIPTION
Found via `codespell -q 3 --skip="*.po"`