### PR TITLE
bg/preserve-routes-down-rh1626004

### DIFF
--- a/src/devices/nm-device.c
+++ b/src/devices/nm-device.c
@@ -3618,6 +3618,7 @@ device_link_changed (NMDevice *self)
 	gboolean ip_ifname_changed = FALSE;
 	nm_auto_nmpobj const NMPObject *pllink_keep_alive = NULL;
 	const NMPlatformLink *pllink;
+	const char *str;
 	int ifindex;
 	gboolean was_up;
 	gboolean update_unmanaged_specs = FALSE;
@@ -3632,7 +3633,23 @@ device_link_changed (NMDevice *self)
 
 	pllink_keep_alive = nmp_object_ref (NMP_OBJECT_UP_CAST (pllink));
 
-	nm_device_update_from_platform_link (self, pllink);
+	str = nm_platform_link_get_udi (nm_device_get_platform (self), pllink->ifindex);
+	if (!nm_streq0 (str, priv->udi)) {
+		g_free (priv->udi);
+		priv->udi = g_strdup (str);
+		_notify (self, PROP_UDI);
+	}
+
+	if (!nm_streq0 (pllink->driver, priv->driver)) {
+		g_free (priv->driver);
+		priv->driver = g_strdup (pllink->driver);
+		_notify (self, PROP_DRIVER);
+	}
+
+	_set_mtu (self, pllink->mtu);
+
+	if (ifindex == nm_device_get_ip_ifindex (self))
+		_stats_update_counters_from_pllink (self, pllink);
 
 	had_hw_addr = (priv->hw_addr != NULL);
 	nm_device_update_hw_address (self);

--- a/src/devices/nm-device.c
+++ b/src/devices/nm-device.c
@@ -12636,12 +12636,15 @@ update_ext_ip_config (NMDevice *self, int addr_family, gboolean intersect_config
 	NMDevicePrivate *priv = NM_DEVICE_GET_PRIVATE (self);
 	int ifindex;
 	GSList *iter;
+	gboolean is_up;
 
 	nm_assert_addr_family (addr_family);
 
 	ifindex = nm_device_get_ip_ifindex (self);
 	if (!ifindex)
 		return FALSE;
+
+	is_up = nm_platform_link_is_up (nm_device_get_platform (self), ifindex);
 
 	if (addr_family == AF_INET) {
 
@@ -12657,15 +12660,15 @@ update_ext_ip_config (NMDevice *self, int addr_family, gboolean intersect_config
 				 * by the user. */
 				if (priv->con_ip_config_4) {
 					nm_ip4_config_intersect (priv->con_ip_config_4, priv->ext_ip_config_4,
-					                         TRUE,
+					                         is_up,
 					                         default_route_metric_penalty_get (self, AF_INET));
 				}
 
-				intersect_ext_config (self, &priv->dev_ip4_config, TRUE);
-				intersect_ext_config (self, &priv->wwan_ip_config_4, TRUE);
+				intersect_ext_config (self, &priv->dev_ip4_config, is_up);
+				intersect_ext_config (self, &priv->wwan_ip_config_4, is_up);
 
 				for (iter = priv->vpn_configs_4; iter; iter = iter->next)
-					nm_ip4_config_intersect (iter->data, priv->ext_ip_config_4, TRUE, 0);
+					nm_ip4_config_intersect (iter->data, priv->ext_ip_config_4, is_up, 0);
 			}
 
 			/* Remove parts from ext_ip_config_4 to only contain the information that
@@ -12709,16 +12712,16 @@ update_ext_ip_config (NMDevice *self, int addr_family, gboolean intersect_config
 				 * by the user. */
 				if (priv->con_ip_config_6) {
 					nm_ip6_config_intersect (priv->con_ip_config_6, priv->ext_ip_config_6,
-					                         TRUE,
+					                         is_up,
 					                         default_route_metric_penalty_get (self, AF_INET6));
 				}
 
-				intersect_ext_config (self, &priv->ac_ip6_config, TRUE);
-				intersect_ext_config (self, &priv->dhcp6.ip6_config, TRUE);
-				intersect_ext_config (self, &priv->wwan_ip_config_6, TRUE);
+				intersect_ext_config (self, &priv->ac_ip6_config, is_up);
+				intersect_ext_config (self, &priv->dhcp6.ip6_config, is_up);
+				intersect_ext_config (self, &priv->wwan_ip_config_6, is_up);
 
 				for (iter = priv->vpn_configs_6; iter; iter = iter->next)
-					nm_ip6_config_intersect (iter->data, priv->ext_ip_config_6, TRUE, 0);
+					nm_ip6_config_intersect (iter->data, priv->ext_ip_config_6, is_up, 0);
 
 				if (   priv->ipv6ll_has
 				    && !nm_ip6_config_lookup_address (priv->ext_ip_config_6, &priv->ipv6ll_addr))

--- a/src/devices/nm-device.c
+++ b/src/devices/nm-device.c
@@ -12602,7 +12602,9 @@ nm_device_get_firmware_missing (NMDevice *self)
 }
 
 static void
-intersect_ext_config (NMDevice *self, AppliedConfig *config)
+intersect_ext_config (NMDevice *self,
+                      AppliedConfig *config,
+                      gboolean intersect_routes)
 {
 	NMDevicePrivate *priv = NM_DEVICE_GET_PRIVATE (self);
 	NMIPConfig *ext;
@@ -12619,10 +12621,11 @@ intersect_ext_config (NMDevice *self, AppliedConfig *config)
 	      : (NMIPConfig *) priv->ext_ip_config_6;
 
 	if (config->current)
-		nm_ip_config_intersect (config->current, ext, penalty);
+		nm_ip_config_intersect (config->current, ext, intersect_routes, penalty);
 	else {
 		config->current = nm_ip_config_intersect_alloc (config->orig,
 		                                                ext,
+		                                                intersect_routes,
 		                                                penalty);
 	}
 }
@@ -12654,14 +12657,15 @@ update_ext_ip_config (NMDevice *self, int addr_family, gboolean intersect_config
 				 * by the user. */
 				if (priv->con_ip_config_4) {
 					nm_ip4_config_intersect (priv->con_ip_config_4, priv->ext_ip_config_4,
+					                         TRUE,
 					                         default_route_metric_penalty_get (self, AF_INET));
 				}
 
-				intersect_ext_config (self, &priv->dev_ip4_config);
-				intersect_ext_config (self, &priv->wwan_ip_config_4);
+				intersect_ext_config (self, &priv->dev_ip4_config, TRUE);
+				intersect_ext_config (self, &priv->wwan_ip_config_4, TRUE);
 
 				for (iter = priv->vpn_configs_4; iter; iter = iter->next)
-					nm_ip4_config_intersect (iter->data, priv->ext_ip_config_4, 0);
+					nm_ip4_config_intersect (iter->data, priv->ext_ip_config_4, TRUE, 0);
 			}
 
 			/* Remove parts from ext_ip_config_4 to only contain the information that
@@ -12705,15 +12709,16 @@ update_ext_ip_config (NMDevice *self, int addr_family, gboolean intersect_config
 				 * by the user. */
 				if (priv->con_ip_config_6) {
 					nm_ip6_config_intersect (priv->con_ip_config_6, priv->ext_ip_config_6,
+					                         TRUE,
 					                         default_route_metric_penalty_get (self, AF_INET6));
 				}
 
-				intersect_ext_config (self, &priv->ac_ip6_config);
-				intersect_ext_config (self, &priv->dhcp6.ip6_config);
-				intersect_ext_config (self, &priv->wwan_ip_config_6);
+				intersect_ext_config (self, &priv->ac_ip6_config, TRUE);
+				intersect_ext_config (self, &priv->dhcp6.ip6_config, TRUE);
+				intersect_ext_config (self, &priv->wwan_ip_config_6, TRUE);
 
 				for (iter = priv->vpn_configs_6; iter; iter = iter->next)
-					nm_ip6_config_intersect (iter->data, priv->ext_ip_config_6, 0);
+					nm_ip6_config_intersect (iter->data, priv->ext_ip_config_6, TRUE, 0);
 
 				if (   priv->ipv6ll_has
 				    && !nm_ip6_config_lookup_address (priv->ext_ip_config_6, &priv->ipv6ll_addr))

--- a/src/nm-ip4-config.c
+++ b/src/nm-ip4-config.c
@@ -1971,71 +1971,90 @@ nm_ip4_config_replace (NMIP4Config *dst, const NMIP4Config *src, gboolean *relev
 }
 
 void
-nm_ip4_config_dump (const NMIP4Config *self, const char *detail)
+nm_ip_config_dump (const NMIPConfig *self,
+                   const char *detail,
+                   NMLogLevel level,
+                   NMLogDomain domain)
 {
-	guint32 tmp;
-	guint i;
-	const char *str;
 	NMDedupMultiIter ipconf_iter;
-	const NMPlatformIP4Address *address;
-	const NMPlatformIP4Route *route;
+	const NMPlatformIP4Address *addr4;
+	const NMPlatformIP6Address *addr6;
+	const NMPlatformIP4Route *route4;
+	const NMPlatformIP6Route *route6;
+	const NMIP4Config *ip4;
+	const NMIP6Config *ip6;
+	int addr_family = AF_UNSPEC;
+	char addr_family_char = '?';
+	const char *path;
+	gconstpointer ptr;
+	guint i;
 
-	g_message ("--------- NMIP4Config %p (%s)", self, detail);
+	if (self) {
+		addr_family = nm_ip_config_get_addr_family (self);
+		addr_family_char = nm_utils_addr_family_to_char (addr_family);
+	}
 
-	if (self == NULL) {
-		g_message (" (null)");
+	nm_log (level, domain, NULL, NULL,
+	        "---- NMIP%cConfig %p (%s)",
+	        addr_family_char,
+	        self,
+	        detail);
+
+	if (!self)
 		return;
+
+	path = nm_dbus_object_get_path (NM_DBUS_OBJECT (self));
+	if (path)
+		nm_log (level, domain, NULL, NULL, " path     : %s", path);
+
+	if (addr_family == AF_INET) {
+		ip4 = NM_IP4_CONFIG (self);
+		nm_ip_config_iter_ip4_address_for_each (&ipconf_iter, ip4, &addr4) {
+			nm_log (level, domain, NULL, NULL, " address  : %s",
+			        nm_platform_ip4_address_to_string (addr4, NULL, 0));
+		}
+		nm_ip_config_iter_ip4_route_for_each (&ipconf_iter, ip4, &route4) {
+			nm_log (level, domain, NULL, NULL, " route    : %s",
+			        nm_platform_ip4_route_to_string (route4, NULL, 0));
+		}
+	} else {
+		ip6 = NM_IP6_CONFIG (self);
+		nm_ip_config_iter_ip6_address_for_each (&ipconf_iter, ip6, &addr6) {
+			nm_log (level, domain, NULL, NULL, " address  : %s",
+			        nm_platform_ip6_address_to_string (addr6, NULL, 0));
+		}
+		nm_ip_config_iter_ip6_route_for_each (&ipconf_iter, ip6, &route6) {
+			nm_log (level, domain, NULL, NULL, " route    : %s",
+			        nm_platform_ip6_route_to_string (route6, NULL, 0));
+		}
 	}
 
-	str = nm_dbus_object_get_path (NM_DBUS_OBJECT (self));
-	if (str)
-		g_message ("   path: %s", str);
-
-	/* addresses */
-	nm_ip_config_iter_ip4_address_for_each (&ipconf_iter, self, &address)
-		g_message ("      a: %s", nm_platform_ip4_address_to_string (address, NULL, 0));
-
-	/* nameservers */
-	for (i = 0; i < nm_ip4_config_get_num_nameservers (self); i++) {
-		tmp = nm_ip4_config_get_nameserver (self, i);
-		g_message ("     ns: %s", nm_utils_inet4_ntop (tmp, NULL));
+	for (i = 0; i < nm_ip_config_get_num_nameservers (self); i++) {
+		ptr = nm_ip_config_get_nameserver (self, i);
+		nm_log (level, domain, NULL, NULL, " dns      : %s",
+		        nm_utils_inet_ntop (addr_family, ptr, NULL));
 	}
 
-	/* routes */
-	nm_ip_config_iter_ip4_route_for_each (&ipconf_iter, self, &route)
-		g_message ("     rt: %s", nm_platform_ip4_route_to_string (route, NULL, 0));
+	for (i = 0; i < nm_ip_config_get_num_domains (self); i++)
+		nm_log (level, domain, NULL, NULL, " domain   : %s", nm_ip_config_get_domain (self, i));
 
-	/* domains */
-	for (i = 0; i < nm_ip4_config_get_num_domains (self); i++)
-		g_message (" domain: %s", nm_ip4_config_get_domain (self, i));
+	for (i = 0; i < nm_ip_config_get_num_searches (self); i++)
+		nm_log (level, domain, NULL, NULL, " search   : %s", nm_ip_config_get_search (self, i));
 
-	/* dns searches */
-	for (i = 0; i < nm_ip4_config_get_num_searches (self); i++)
-		g_message (" search: %s", nm_ip4_config_get_search (self, i));
+	for (i = 0; i < nm_ip_config_get_num_dns_options (self); i++)
+		nm_log (level, domain, NULL, NULL, "dns-option: %s", nm_ip_config_get_dns_option (self, i));
 
-	/* dns options */
-	for (i = 0; i < nm_ip4_config_get_num_dns_options (self); i++)
-		g_message (" dnsopt: %s", nm_ip4_config_get_dns_option (self, i));
+	nm_log (level, domain, NULL, NULL, " dns-prio : %d", nm_ip_config_get_dns_priority (self));
 
-	g_message (" dnspri: %d", nm_ip4_config_get_dns_priority (self));
-
-	g_message ("    mtu: %"G_GUINT32_FORMAT" (source: %d)", nm_ip4_config_get_mtu (self), (int) nm_ip4_config_get_mtu_source (self));
-
-	/* NIS */
-	for (i = 0; i < nm_ip4_config_get_num_nis_servers (self); i++) {
-		tmp = nm_ip4_config_get_nis_server (self, i);
-		g_message ("    nis: %s", nm_utils_inet4_ntop (tmp, NULL));
+	if (addr_family == AF_INET) {
+		ip4 = NM_IP4_CONFIG (self);
+		nm_log (level, domain, NULL, NULL,
+		        " mtu      : %"G_GUINT32_FORMAT" (source: %d)",
+		        nm_ip4_config_get_mtu (ip4),
+		        (int) nm_ip4_config_get_mtu_source (ip4));
+		nm_log (level, domain, NULL, NULL, " metered  : %d",
+		        (int) nm_ip4_config_get_metered (ip4));
 	}
-
-	g_message (" nisdmn: %s", nm_ip4_config_get_nis_domain (self) ?: "(none)");
-
-	/* WINS */
-	for (i = 0; i < nm_ip4_config_get_num_wins (self); i++) {
-		tmp = nm_ip4_config_get_wins (self, i);
-		g_message ("   wins: %s", nm_utils_inet4_ntop (tmp, NULL));
-	}
-
-	g_message (" mtrd:   %d", (int) nm_ip4_config_get_metered (self));
 }
 
 /*****************************************************************************/

--- a/src/nm-ip4-config.h
+++ b/src/nm-ip4-config.h
@@ -194,7 +194,6 @@ NMIP4Config *nm_ip4_config_intersect_alloc (const NMIP4Config *a,
                                             const NMIP4Config *b,
                                             guint32 default_route_metric_penalty);
 gboolean nm_ip4_config_replace (NMIP4Config *dst, const NMIP4Config *src, gboolean *relevant_changes);
-void nm_ip4_config_dump (const NMIP4Config *self, const char *detail);
 
 const NMPObject *nm_ip4_config_best_default_route_get (const NMIP4Config *self);
 const NMPObject *_nm_ip4_config_best_default_route_find (const NMIP4Config *self);
@@ -296,6 +295,11 @@ void nm_ip4_config_hash (const NMIP4Config *self, GChecksum *sum, gboolean dns_o
 gboolean nm_ip4_config_equal (const NMIP4Config *a, const NMIP4Config *b);
 
 gboolean _nm_ip_config_check_and_add_domain (GPtrArray *array, const char *domain);
+
+void nm_ip_config_dump (const NMIPConfig *self,
+                        const char *detail,
+                        NMLogLevel level,
+                        NMLogDomain domain);
 
 /*****************************************************************************/
 

--- a/src/nm-ip4-config.h
+++ b/src/nm-ip4-config.h
@@ -189,9 +189,11 @@ void nm_ip4_config_subtract (NMIP4Config *dst,
                              guint32 default_route_metric_penalty);
 void nm_ip4_config_intersect (NMIP4Config *dst,
                               const NMIP4Config *src,
+                              gboolean intersect_routes,
                               guint32 default_route_metric_penalty);
 NMIP4Config *nm_ip4_config_intersect_alloc (const NMIP4Config *a,
                                             const NMIP4Config *b,
+                                            gboolean intersect_routes,
                                             guint32 default_route_metric_penalty);
 gboolean nm_ip4_config_replace (NMIP4Config *dst, const NMIP4Config *src, gboolean *relevant_changes);
 
@@ -541,11 +543,13 @@ nm_ip_config_best_default_route_get (const NMIPConfig *self)
 static inline void
 nm_ip_config_intersect (NMIPConfig *dst,
                         const NMIPConfig *src,
+                        gboolean intersect_routes,
                         guint32 default_route_metric_penalty)
 {
 	_NM_IP_CONFIG_DISPATCH_SET_OP (, dst, src,
 	                               nm_ip4_config_intersect,
 	                               nm_ip6_config_intersect,
+	                               intersect_routes,
 	                               default_route_metric_penalty);
 }
 
@@ -587,18 +591,21 @@ nm_ip_config_replace (NMIPConfig *dst,
 static inline NMIPConfig *
 nm_ip_config_intersect_alloc (const NMIPConfig *a,
                               const NMIPConfig *b,
+                              gboolean intersect_routes,
                               guint32 default_route_metric_penalty)
 {
 	if (NM_IS_IP4_CONFIG (a)) {
 		nm_assert (NM_IS_IP4_CONFIG (b));
 		return (NMIPConfig *) nm_ip4_config_intersect_alloc ((const NMIP4Config *) a,
 		                                                     (const NMIP4Config *) b,
+		                                                     intersect_routes,
 		                                                     default_route_metric_penalty);
 	} else {
 		nm_assert (NM_IS_IP6_CONFIG (a));
 		nm_assert (NM_IS_IP6_CONFIG (b));
 		return (NMIPConfig *) nm_ip6_config_intersect_alloc ((const NMIP6Config *) a,
 		                                                     (const NMIP6Config *) b,
+		                                                     intersect_routes,
 		                                                     default_route_metric_penalty);
 	}
 }

--- a/src/nm-ip6-config.c
+++ b/src/nm-ip6-config.c
@@ -1084,6 +1084,7 @@ nm_ip6_config_subtract (NMIP6Config *dst,
 static gboolean
 _nm_ip6_config_intersect_helper (NMIP6Config *dst,
                                  const NMIP6Config *src,
+                                 gboolean intersect_routes,
                                  guint32 default_route_metric_penalty,
                                  gboolean update_dst)
 {
@@ -1128,6 +1129,9 @@ _nm_ip6_config_intersect_helper (NMIP6Config *dst,
 	/* ignore nameservers */
 
 	/* routes */
+	if (!intersect_routes)
+		goto skip_routes;
+
 	changed = FALSE;
 	new_best_default_route = NULL;
 	nm_ip_config_iter_ip6_route_for_each (&ipconf_iter, dst, &r) {
@@ -1172,6 +1176,7 @@ _nm_ip6_config_intersect_helper (NMIP6Config *dst,
 		result = TRUE;
 	}
 
+skip_routes:
 	/* ignore domains */
 	/* ignore dns searches */
 	/* ignore dns options */
@@ -1194,9 +1199,10 @@ _nm_ip6_config_intersect_helper (NMIP6Config *dst,
 void
 nm_ip6_config_intersect (NMIP6Config *dst,
                          const NMIP6Config *src,
+                         gboolean intersect_routes,
                          guint32 default_route_metric_penalty)
 {
-	_nm_ip6_config_intersect_helper (dst, src, default_route_metric_penalty, TRUE);
+	_nm_ip6_config_intersect_helper (dst, src, intersect_routes, default_route_metric_penalty, TRUE);
 }
 
 /**
@@ -1217,14 +1223,17 @@ nm_ip6_config_intersect (NMIP6Config *dst,
 NMIP6Config *
 nm_ip6_config_intersect_alloc (const NMIP6Config *a,
                                const NMIP6Config *b,
+                               gboolean intersect_routes,
                                guint32 default_route_metric_penalty)
 {
 	NMIP6Config *a_copy;
 
 	if (_nm_ip6_config_intersect_helper ((NMIP6Config *) a, b,
+	                                     intersect_routes,
 	                                     default_route_metric_penalty, FALSE)) {
 		a_copy = nm_ip6_config_clone (a);
-		_nm_ip6_config_intersect_helper (a_copy, b, default_route_metric_penalty, TRUE);
+		_nm_ip6_config_intersect_helper (a_copy, b, intersect_routes,
+		                                 default_route_metric_penalty, TRUE);
 		return a_copy;
 	} else
 		return NULL;

--- a/src/nm-ip6-config.c
+++ b/src/nm-ip6-config.c
@@ -1483,53 +1483,6 @@ nm_ip6_config_replace (NMIP6Config *dst, const NMIP6Config *src, gboolean *relev
 	return has_relevant_changes || has_minor_changes;
 }
 
-void
-nm_ip6_config_dump (const NMIP6Config *self, const char *detail)
-{
-	const struct in6_addr *tmp;
-	guint32 i;
-	const char *str;
-	NMDedupMultiIter ipconf_iter;
-	const NMPlatformIP6Address *address;
-	const NMPlatformIP6Route *route;
-
-	g_return_if_fail (self != NULL);
-
-	g_message ("--------- NMIP6Config %p (%s)", self, detail);
-
-	str = nm_dbus_object_get_path (NM_DBUS_OBJECT (self));
-	if (str)
-		g_message ("   path: %s", str);
-
-	/* addresses */
-	nm_ip_config_iter_ip6_address_for_each (&ipconf_iter, self, &address)
-		g_message ("      a: %s", nm_platform_ip6_address_to_string (address, NULL, 0));
-
-	/* nameservers */
-	for (i = 0; i < nm_ip6_config_get_num_nameservers (self); i++) {
-		tmp = nm_ip6_config_get_nameserver (self, i);
-		g_message ("     ns: %s", nm_utils_inet6_ntop (tmp, NULL));
-	}
-
-	/* routes */
-	nm_ip_config_iter_ip6_route_for_each (&ipconf_iter, self, &route)
-		g_message ("     rt: %s", nm_platform_ip6_route_to_string (route, NULL, 0));
-
-	/* domains */
-	for (i = 0; i < nm_ip6_config_get_num_domains (self); i++)
-		g_message (" domain: %s", nm_ip6_config_get_domain (self, i));
-
-	/* dns searches */
-	for (i = 0; i < nm_ip6_config_get_num_searches (self); i++)
-		g_message (" search: %s", nm_ip6_config_get_search (self, i));
-
-	/* dns options */
-	for (i = 0; i < nm_ip6_config_get_num_dns_options (self); i++)
-		g_message (" dnsopt: %s", nm_ip6_config_get_dns_option (self, i));
-
-	g_message (" dnspri: %d", nm_ip6_config_get_dns_priority (self));
-}
-
 /*****************************************************************************/
 
 void

--- a/src/nm-ip6-config.h
+++ b/src/nm-ip6-config.h
@@ -130,9 +130,11 @@ void nm_ip6_config_subtract (NMIP6Config *dst,
                              guint32 default_route_metric_penalty);
 void nm_ip6_config_intersect (NMIP6Config *dst,
                               const NMIP6Config *src,
+                              gboolean intersect_routes,
                               guint32 default_route_metric_penalty);
 NMIP6Config *nm_ip6_config_intersect_alloc (const NMIP6Config *a,
                                             const NMIP6Config *b,
+                                            gboolean intersect_routes,
                                             guint32 default_route_metric_penalty);
 gboolean nm_ip6_config_replace (NMIP6Config *dst, const NMIP6Config *src, gboolean *relevant_changes);
 

--- a/src/nm-ip6-config.h
+++ b/src/nm-ip6-config.h
@@ -135,7 +135,6 @@ NMIP6Config *nm_ip6_config_intersect_alloc (const NMIP6Config *a,
                                             const NMIP6Config *b,
                                             guint32 default_route_metric_penalty);
 gboolean nm_ip6_config_replace (NMIP6Config *dst, const NMIP6Config *src, gboolean *relevant_changes);
-void nm_ip6_config_dump (const NMIP6Config *self, const char *detail);
 
 const NMPObject *nm_ip6_config_best_default_route_get (const NMIP6Config *self);
 const NMPObject *_nm_ip6_config_best_default_route_find (const NMIP6Config *self);


### PR DESCRIPTION
Preserve the device route when the interface is brought down and up again.