### PR TITLE
acd: make NMAcdManager no GObject

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1668,12 +1668,12 @@ src_libNetworkManager_la_SOURCES = \
 	src/nm-checkpoint-manager.c \
 	src/nm-checkpoint-manager.h \
 	\
-	src/devices/nm-device.c \
-	src/devices/nm-device.h \
-	src/devices/nm-lldp-listener.c \
-	src/devices/nm-lldp-listener.h \
 	src/devices/nm-acd-manager.c \
 	src/devices/nm-acd-manager.h \
+	src/devices/nm-lldp-listener.c \
+	src/devices/nm-lldp-listener.h \
+	src/devices/nm-device.c \
+	src/devices/nm-device.h \
 	src/devices/nm-device-ethernet-utils.c \
 	src/devices/nm-device-ethernet-utils.h \
 	src/devices/nm-device-factory.c \

--- a/src/devices/nm-acd-manager.h
+++ b/src/devices/nm-acd-manager.h
@@ -19,25 +19,25 @@
 
 #include <netinet/in.h>
 
-#define NM_TYPE_ACD_MANAGER            (nm_acd_manager_get_type ())
-#define NM_ACD_MANAGER(obj)            (G_TYPE_CHECK_INSTANCE_CAST ((obj), NM_TYPE_ACD_MANAGER, NMAcdManager))
-#define NM_ACD_MANAGER_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST ((klass),  NM_TYPE_ACD_MANAGER, NMAcdManagerClass))
-#define NM_IS_ACD_MANAGER(obj)         (G_TYPE_CHECK_INSTANCE_TYPE ((obj), NM_TYPE_ACD_MANAGER))
-#define NM_IS_ACD_MANAGER_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass),  NM_TYPE_ACD_MANAGER))
-#define NM_ACD_MANAGER_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS ((obj),  NM_TYPE_ACD_MANAGER, NMAcdManagerClass))
+typedef struct _NMAcdManager NMAcdManager;
 
-#define NM_ACD_MANAGER_PROBE_TERMINATED  "probe-terminated"
+typedef struct {
+	void (*probe_terminated_callback) (NMAcdManager *self,
+	                                   gpointer user_data);
+	GDestroyNotify user_data_destroy;
+} NMAcdCallbacks;
 
-typedef struct _NMAcdManagerClass NMAcdManagerClass;
+NMAcdManager *nm_acd_manager_new (int ifindex,
+                                  const guint8 *hwaddr,
+                                  guint hwaddr_len,
+                                  const NMAcdCallbacks *callbacks,
+                                  gpointer user_data);
 
-GType nm_acd_manager_get_type (void);
+void nm_acd_manager_free (NMAcdManager *self);
 
-NMAcdManager *nm_acd_manager_new (int ifindex, const guint8 *hwaddr, guint hwaddr_len);
-void nm_acd_manager_destroy (NMAcdManager *self);
 gboolean nm_acd_manager_add_address (NMAcdManager *self, in_addr_t address);
 gboolean nm_acd_manager_start_probe (NMAcdManager *self, guint timeout);
 gboolean nm_acd_manager_check_address (NMAcdManager *self, in_addr_t address);
 void nm_acd_manager_announce_addresses (NMAcdManager *self);
-void nm_acd_manager_reset (NMAcdManager *self);
 
 #endif /* __NM_ACD_MANAGER__ */

--- a/src/nm-types.h
+++ b/src/nm-types.h
@@ -37,7 +37,6 @@ typedef struct _NMAuthSubject        NMAuthSubject;
 typedef struct _NMDBusManager        NMDBusManager;
 typedef struct _NMConfig             NMConfig;
 typedef struct _NMConfigData         NMConfigData;
-typedef struct _NMAcdManager         NMAcdManager;
 typedef struct _NMConnectivity       NMConnectivity;
 typedef struct _NMDevice             NMDevice;
 typedef struct _NMDhcp4Config        NMDhcp4Config;


### PR DESCRIPTION
NMAcdManager is a rather simple instance.

It does not need (thread-safe) ref-counting, in fact, having
it ref-counted makes it slighly ugly that we connect a signal,
but never bother to disconnect it (while the ref-counted instance
could outlife the signal subscriber).

We also don't need GObject signals. They have more overhead
and are less type-safe than a regular function pointers. Signals
would make sense, if there could be multiple independent listeners,
but that just doesn't make sense.

Implementing it as a plain struct is less lines of code, and less
runtime over head.

Also drop the possiblitiy to reset the NMAcdManager instance.
It wasn't needed and I think it was buggy because it wouldn't
reset the n-acd instance.