### PR TITLE
all: remove \n endings from log calls

### DIFF
--- a/src/dhcp/nm-dhcp-helper.c
+++ b/src/dhcp/nm-dhcp-helper.c
@@ -118,7 +118,7 @@ kill_pid (void)
 	if (pid_str)
 		pid = strtol (pid_str, NULL, 10);
 	if (pid) {
-		_LOGI ("a fatal error occurred, kill dhclient instance with pid %d\n", pid);
+		_LOGI ("a fatal error occurred, kill dhclient instance with pid %d", pid);
 		kill (pid, SIGTERM);
 	}
 }

--- a/src/dhcp/nm-dhcp-systemd.c
+++ b/src/dhcp/nm-dhcp-systemd.c
@@ -926,7 +926,7 @@ ip6_start (NMDhcpClient *client,
 	}
 
 	if (needed_prefixes > 0) {
-		_LOGW ("dhcp-client6: prefix delegation not yet supported, won't supply %d prefixes\n",
+		_LOGW ("dhcp-client6: prefix delegation not yet supported, won't supply %d prefixes",
 		       needed_prefixes);
 	}
 

--- a/src/dns/nm-dns-systemd-resolved.c
+++ b/src/dns/nm-dns-systemd-resolved.c
@@ -129,7 +129,7 @@ call_done (GObject *source, GAsyncResult *r, gpointer user_data)
 	if (!v) {
 		if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
 			return;
-		_LOGW ("Failed: %s\n", error->message);
+		_LOGW ("Failed: %s", error->message);
 		g_error_free (error);
 	}
 }

--- a/src/initrd/nm-initrd-generator.c
+++ b/src/initrd/nm-initrd-generator.c
@@ -109,7 +109,7 @@ main (int argc, char *argv[])
 	g_option_context_add_main_entries (option_context, option_entries, GETTEXT_PACKAGE);
 
 	if (!g_option_context_parse (option_context, &argc, &argv, &error)) {
-		_LOGW (LOGD_CORE, "%s\n", error->message);
+		_LOGW (LOGD_CORE, "%s", error->message);
 		return 1;
 	}
 
@@ -126,7 +126,7 @@ main (int argc, char *argv[])
 		g_clear_pointer (&connections_dir, g_free);
 
 	if (connections_dir && g_mkdir_with_parents (connections_dir, 0755) != 0) {
-		_LOGW (LOGD_CORE, "%s: %s\n", connections_dir, strerror (errno));
+		_LOGW (LOGD_CORE, "%s: %s", connections_dir, strerror (errno));
 		return 1;
 	}
 

--- a/src/initrd/nmi-cmdline-reader.c
+++ b/src/initrd/nmi-cmdline-reader.c
@@ -132,7 +132,7 @@ _base_setting_set (NMConnection *connection, const char *property, const char *v
 	GParamSpec *spec = g_object_class_find_property (object_class, property);
 
 	if (!spec) {
-		_LOGW (LOGD_CORE, "'%s' does not support setting %s\n", type_name, property);
+		_LOGW (LOGD_CORE, "'%s' does not support setting %s", type_name, property);
 		return;
 	}
 
@@ -143,7 +143,7 @@ _base_setting_set (NMConnection *connection, const char *property, const char *v
 	else if (G_IS_PARAM_SPEC_STRING (spec))
 		g_object_set (setting, property, value, NULL);
 	else
-		_LOGW (LOGD_CORE, "Don't know how to set '%s' of %s\n", property, type_name);
+		_LOGW (LOGD_CORE, "Don't know how to set '%s' of %s", property, type_name);
 
 	g_type_class_unref (object_class);
 }
@@ -203,7 +203,7 @@ parse_ip (GHashTable *connections, const char *sysfs_dir, char *argument)
 			dns[1] = get_word (&argument, ':');
 			dns_addr_family[1] = guess_ip_address_family (dns[1]);
 			if (argument && *argument)
-				_LOGW (LOGD_CORE, "Ignoring extra: '%s'.\n", argument);
+				_LOGW (LOGD_CORE, "Ignoring extra: '%s'.", argument);
 		} else {
 			mtu = tmp;
 			macaddr = argument;
@@ -228,12 +228,12 @@ parse_ip (GHashTable *connections, const char *sysfs_dir, char *argument)
 
 			index = g_hash_table_lookup (nic, "index");
 			if (!index) {
-				_LOGW (LOGD_CORE, "Ignoring an iBFT entry without an index\n");
+				_LOGW (LOGD_CORE, "Ignoring an iBFT entry without an index");
 				continue;
 			}
 
 			if (!nmi_ibft_update_connection_from_nic (connection, nic, &error)) {
-				_LOGW (LOGD_CORE, "Unable to merge iBFT configuration: %s\n", error->message);
+				_LOGW (LOGD_CORE, "Unable to merge iBFT configuration: %s", error->message);
 				g_error_free (error);
 			}
 
@@ -256,7 +256,7 @@ parse_ip (GHashTable *connections, const char *sysfs_dir, char *argument)
 		if (nm_utils_parse_inaddr_bin (AF_INET, netmask, NULL, &addr)) {
 			client_ip_prefix = nm_utils_ip4_netmask_to_prefix (addr.addr4);
 		} else {
-			_LOGW (LOGD_CORE, "Unrecognized address: %s\n", client_ip);
+			_LOGW (LOGD_CORE, "Unrecognized address: %s", client_ip);
 		}
 	}
 
@@ -280,11 +280,11 @@ parse_ip (GHashTable *connections, const char *sysfs_dir, char *argument)
 
 			address = nm_ip_address_new_binary (client_ip_family, &addr.addr_ptr, client_ip_prefix, &error);
 			if (!address) {
-				_LOGW (LOGD_CORE, "Invalid address '%s': %s\n", client_ip, error->message);
+				_LOGW (LOGD_CORE, "Invalid address '%s': %s", client_ip, error->message);
 				g_clear_error (&error);
 			}
 		} else {
-			_LOGW (LOGD_CORE, "Unrecognized address: %s\n", client_ip);
+			_LOGW (LOGD_CORE, "Unrecognized address: %s", client_ip);
 		}
 
 		if (address) {
@@ -304,7 +304,7 @@ parse_ip (GHashTable *connections, const char *sysfs_dir, char *argument)
 				nm_setting_ip_config_add_address (s_ip6, address);
 				break;
 			default:
-				_LOGW (LOGD_CORE, "Unknown address family: %s\n", client_ip);
+				_LOGW (LOGD_CORE, "Unknown address family: %s", client_ip);
 				break;
 			}
 			nm_ip_address_unref (address);
@@ -369,12 +369,12 @@ parse_ip (GHashTable *connections, const char *sysfs_dir, char *argument)
 				ibft = nmi_ibft_read (sysfs_dir);
 			nic = g_hash_table_lookup (ibft, mac_up);
 			if (!nic)
-				_LOGW (LOGD_CORE, "No iBFT NIC for %s (%s)\n", ifname, mac_up);
+				_LOGW (LOGD_CORE, "No iBFT NIC for %s (%s)", ifname, mac_up);
 		}
 
 		if (nic) {
 			if (!nmi_ibft_update_connection_from_nic (connection, nic, &error)) {
-				_LOGW (LOGD_CORE, "Unable to merge iBFT configuration: %s\n", error->message);
+				_LOGW (LOGD_CORE, "Unable to merge iBFT configuration: %s", error->message);
 				g_clear_error (&error);
 			}
 		}
@@ -395,11 +395,11 @@ parse_ip (GHashTable *connections, const char *sysfs_dir, char *argument)
 				g_object_set (s_ip6, NM_SETTING_IP_CONFIG_GATEWAY, gateway_ip, NULL);
 				break;
 			default:
-				_LOGW (LOGD_CORE, "Unknown address family: %s\n", gateway_ip);
+				_LOGW (LOGD_CORE, "Unknown address family: %s", gateway_ip);
 				break;
 			}
 		} else {
-			_LOGW (LOGD_CORE, "Invalid gateway: %s\n", gateway_ip);
+			_LOGW (LOGD_CORE, "Invalid gateway: %s", gateway_ip);
 		}
 	}
 
@@ -420,11 +420,11 @@ parse_ip (GHashTable *connections, const char *sysfs_dir, char *argument)
 				nm_setting_ip_config_add_dns (s_ip6, dns[i]);
 				break;
 			default:
-				_LOGW (LOGD_CORE, "Unknown address family: %s\n", dns[i]);
+				_LOGW (LOGD_CORE, "Unknown address family: %s", dns[i]);
 				break;
 			}
 		} else {
-			_LOGW (LOGD_CORE, "Invalid name server: %s\n", dns[i]);
+			_LOGW (LOGD_CORE, "Invalid name server: %s", dns[i]);
 		}
 	}
 
@@ -488,7 +488,7 @@ parse_master (GHashTable *connections, char *argument, const char *type_name)
 	} while (slaves && *slaves != '\0');
 
 	if (argument && *argument)
-		_LOGW (LOGD_CORE, "Ignoring extra: '%s'.\n", argument);
+		_LOGW (LOGD_CORE, "Ignoring extra: '%s'.", argument);
 }
 
 static void
@@ -514,14 +514,14 @@ parse_rd_route (GHashTable *connections, char *argument)
 
 	if (net && *net) {
 		if (!nm_utils_parse_inaddr_prefix_bin (family, net, &family, &net_addr, &net_prefix)) {
-			_LOGW (LOGD_CORE, "Unrecognized address: %s\n", net);
+			_LOGW (LOGD_CORE, "Unrecognized address: %s", net);
 			return;
 		}
 	}
 
 	if (gateway && *gateway) {
 		if (!nm_utils_parse_inaddr_bin (family, gateway, &family, &gateway_addr)) {
-			_LOGW (LOGD_CORE, "Unrecognized address: %s\n", gateway);
+			_LOGW (LOGD_CORE, "Unrecognized address: %s", gateway);
 			return;
 		}
 	}
@@ -538,7 +538,7 @@ parse_rd_route (GHashTable *connections, char *argument)
 			net_prefix = 128;
 		break;
 	default:
-		_LOGW (LOGD_CORE, "Unknown address family: %s\n", net);
+		_LOGW (LOGD_CORE, "Unknown address family: %s", net);
 		return;
 	}
 
@@ -579,7 +579,7 @@ parse_vlan (GHashTable *connections, char *argument)
 	              NULL);
 
 	if (argument && *argument)
-		_LOGW (LOGD_CORE, "Ignoring extra: '%s'.\n", argument);
+		_LOGW (LOGD_CORE, "Ignoring extra: '%s'.", argument);
 }
 
 static void
@@ -615,14 +615,14 @@ parse_nameserver (GHashTable *connections, char *argument)
 		s_ip = nm_connection_get_setting_ip6_config (connection);
 		break;
 	default:
-		_LOGW (LOGD_CORE, "Unknown address family: %s\n", dns);
+		_LOGW (LOGD_CORE, "Unknown address family: %s", dns);
 		break;
 	}
 
 	nm_setting_ip_config_add_dns (s_ip, dns);
 
 	if (argument && *argument)
-		_LOGW (LOGD_CORE, "xIgnoring extra: '%s'.\n", argument);
+		_LOGW (LOGD_CORE, "Ignoring extra: '%s'.", argument);
 }
 
 static void

--- a/src/nm-config.c
+++ b/src/nm-config.c
@@ -938,7 +938,7 @@ read_base_config (GKeyFile *keyfile,
 	}
 
 	if (!g_error_matches (my_error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_NOT_FOUND)) {
-		_LOGW ("Old default config file invalid: %s\n",
+		_LOGW ("Old default config file invalid: %s",
 		       my_error->message);
 	}
 	g_clear_error (&my_error);
@@ -950,7 +950,7 @@ read_base_config (GKeyFile *keyfile,
 	}
 
 	if (!g_error_matches (my_error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_NOT_FOUND)) {
-		_LOGW ("Default config file invalid: %s\n",
+		_LOGW ("Default config file invalid: %s",
 		       my_error->message);
 		g_propagate_error (error, my_error);
 		return FALSE;
@@ -961,7 +961,7 @@ read_base_config (GKeyFile *keyfile,
 	 * config file path.
 	 */
 	*out_config_main_file = g_strdup (DEFAULT_CONFIG_MAIN_FILE);
-	_LOGI ("No config file found or given; using %s\n",
+	_LOGI ("No config file found or given; using %s",
 	       DEFAULT_CONFIG_MAIN_FILE);
 	return TRUE;
 }

--- a/src/settings/plugins/ifupdown/nms-ifupdown-interface-parser.c
+++ b/src/settings/plugins/ifupdown/nms-ifupdown-interface-parser.c
@@ -126,17 +126,17 @@ _recursive_ifparser (if_parser *parser, const char *eni_file, int quiet)
 	/* Check if interfaces file exists and open it */
 	if (!g_file_test (eni_file, G_FILE_TEST_EXISTS)) {
 		if (!quiet)
-			_LOGW ("interfaces file %s doesn't exist\n", eni_file);
+			_LOGW ("interfaces file %s doesn't exist", eni_file);
 		return;
 	}
 	inp = fopen (eni_file, "re");
 	if (inp == NULL) {
 		if (!quiet)
-			_LOGW ("Can't open %s\n", eni_file);
+			_LOGW ("Can't open %s", eni_file);
 		return;
 	}
 	if (!quiet)
-		_LOGI ("      interface-parser: parsing file %s\n", eni_file);
+		_LOGI ("      interface-parser: parsing file %s", eni_file);
 
 	while (!feof (inp)) {
 		char *token[128]; /* 255 chars can only be split into 127 tokens */
@@ -154,7 +154,7 @@ _recursive_ifparser (if_parser *parser, const char *eni_file, int quiet)
 		if (!feof (inp) && len > 0 &&  line[len-1] != '\n') {
 			if (!skip_long_line) {
 				if (!quiet)
-					_LOGW ("Skipping over-long-line '%s...'\n", line);
+					_LOGW ("Skipping over-long-line '%s...'", line);
 			}
 			skip_long_line = 1;
 			continue;
@@ -192,7 +192,7 @@ _recursive_ifparser (if_parser *parser, const char *eni_file, int quiet)
 
 		if (toknum < 2) {
 			if (!quiet) {
-				_LOGW ("Can't parse interface line '%s'\n",
+				_LOGW ("Can't parse interface line '%s'",
 				       join_values_with_spaces (value, token));
 			}
 			skip_to_block = 1;
@@ -207,7 +207,7 @@ _recursive_ifparser (if_parser *parser, const char *eni_file, int quiet)
 		if (nm_streq (token[0], "iface")) {
 			if (toknum < 4) {
 				if (!quiet) {
-					_LOGW ("Can't parse iface line '%s'\n",
+					_LOGW ("Can't parse iface line '%s'",
 					       join_values_with_spaces (value, token));
 				}
 				continue;
@@ -254,7 +254,7 @@ _recursive_ifparser (if_parser *parser, const char *eni_file, int quiet)
 		else {
 			if (skip_to_block) {
 				if (!quiet) {
-					_LOGW ("ignoring out-of-block data '%s'\n",
+					_LOGW ("ignoring out-of-block data '%s'",
 					       join_values_with_spaces (value, token));
 				}
 			} else
@@ -264,7 +264,7 @@ _recursive_ifparser (if_parser *parser, const char *eni_file, int quiet)
 	fclose (inp);
 
 	if (!quiet)
-		_LOGI ("      interface-parser: finished parsing file %s\n", eni_file);
+		_LOGI ("      interface-parser: finished parsing file %s", eni_file);
 }
 
 static void
@@ -283,12 +283,12 @@ _ifparser_source (if_parser *parser, const char *path, const char *en_dir, int q
 		abs_path = g_build_filename (en_dir, path, NULL);
 
 	if (!quiet)
-		_LOGI ("      interface-parser: source line includes interfaces file(s) %s\n", abs_path);
+		_LOGI ("      interface-parser: source line includes interfaces file(s) %s", abs_path);
 
 	/* ifupdown uses WRDE_NOCMD for wordexp. */
 	if (wordexp (abs_path, &we, WRDE_NOCMD)) {
 		if (!quiet)
-			_LOGW ("word expansion for %s failed\n", abs_path);
+			_LOGW ("word expansion for %s failed", abs_path);
 	} else {
 		for (i = 0; i < we.we_wordc; i++) {
 			if (dir) {


### PR DESCRIPTION
The extra newlines look bad when logging to the console.