### PR TITLE
th/no-gasyncresult

### DIFF
--- a/libnm-core/nm-core-internal.h
+++ b/libnm-core/nm-core-internal.h
@@ -305,6 +305,10 @@ void _nm_dbus_errors_init (void);
 
 extern gboolean _nm_utils_is_manager_process;
 
+gboolean _nm_dbus_typecheck_response (GVariant *response,
+                                      const GVariantType *reply_type,
+                                      GError **error);
+
 gulong _nm_dbus_signal_connect_data (GDBusProxy *proxy,
                                      const char *signal_name,
                                      const GVariantType *signature,
@@ -328,6 +332,11 @@ GVariant *_nm_dbus_proxy_call_sync   (GDBusProxy           *proxy,
                                       int                   timeout_msec,
                                       GCancellable         *cancellable,
                                       GError              **error);
+
+GVariant * _nm_dbus_connection_call_finish (GDBusConnection *dbus_connection,
+                                            GAsyncResult *result,
+                                            const GVariantType *reply_type,
+                                            GError **error);
 
 gboolean _nm_dbus_error_has_name (GError     *error,
                                   const char *dbus_error_name);

--- a/libnm-core/nm-dbus-utils.c
+++ b/libnm-core/nm-dbus-utils.c
@@ -174,23 +174,35 @@ _nm_dbus_signal_connect_data (GDBusProxy *proxy,
  * Returns: the signal handler ID, as with _nm_signal_connect_data().
  */
 
-static void
-typecheck_response (GVariant **response,
-                    const GVariantType *reply_type,
-                    GError **error)
+/**
+ * _nm_dbus_typecheck_response:
+ * @response: the #GVariant response to check.
+ * @reply_type: the expected reply type. It may be %NULL to perform no
+ *   checking.
+ * @error: (allow-none): the error in case the @reply_type does not match.
+ *
+ * Returns: %TRUE, if @response is of the expected @reply_type.
+ */
+gboolean
+_nm_dbus_typecheck_response (GVariant *response,
+                             const GVariantType *reply_type,
+                             GError **error)
 {
-	if (   *response
-	    && reply_type
-	    && !g_variant_is_of_type (*response, reply_type)) {
-		/* This is the same error code that g_dbus_connection_call() returns if
-		 * @reply_type doesn't match.
-		 */
-		g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
-		             _("Method returned type '%s', but expected '%s'"),
-		             g_variant_get_type_string (*response),
-		             g_variant_type_peek_string (reply_type));
-		g_clear_pointer (response, g_variant_unref);
-	}
+	g_return_val_if_fail (response, FALSE);
+
+	if (!reply_type)
+		return TRUE;
+	if (g_variant_is_of_type (response, reply_type))
+		return TRUE;
+
+	/* This is the same error code that g_dbus_connection_call() returns if
+	 * @reply_type doesn't match.
+	 */
+	g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+	             _("Method returned type '%s', but expected '%s'"),
+	             g_variant_get_type_string (response),
+	             g_variant_type_peek_string (reply_type));
+	return FALSE;
 }
 
 /**
@@ -215,11 +227,15 @@ _nm_dbus_proxy_call_finish (GDBusProxy          *proxy,
                             const GVariantType  *reply_type,
                             GError             **error)
 {
-	GVariant *ret;
+	GVariant *variant;
 
-	ret = g_dbus_proxy_call_finish (proxy, res, error);
-	typecheck_response (&ret, reply_type, error);
-	return ret;
+	variant = g_dbus_proxy_call_finish (proxy,
+	                                    res,
+	                                    error);
+	if (   variant
+	    && !_nm_dbus_typecheck_response (variant, reply_type, error))
+		nm_clear_pointer (&variant, g_variant_unref);
+	return variant;
 }
 
 /**
@@ -253,13 +269,34 @@ _nm_dbus_proxy_call_sync (GDBusProxy          *proxy,
                           GCancellable        *cancellable,
                           GError             **error)
 {
-	GVariant *ret;
+	GVariant *variant;
 
-	ret = g_dbus_proxy_call_sync (proxy, method_name, parameters,
-	                              flags, timeout_msec,
-	                              cancellable, error);
-	typecheck_response (&ret, reply_type, error);
-	return ret;
+	variant = g_dbus_proxy_call_sync (proxy,
+	                                  method_name,
+	                                  parameters,
+	                                  flags,
+	                                  timeout_msec,
+	                                  cancellable,
+	                                  error);
+	if (   variant
+	    && !_nm_dbus_typecheck_response (variant, reply_type, error))
+		nm_clear_pointer (&variant, g_variant_unref);
+	return variant;
+}
+
+GVariant *
+_nm_dbus_connection_call_finish (GDBusConnection *dbus_connection,
+                                 GAsyncResult *result,
+                                 const GVariantType *reply_type,
+                                 GError **error)
+{
+	GVariant *variant;
+
+	variant = g_dbus_connection_call_finish (dbus_connection, result, error);
+	if (   variant
+	    && !_nm_dbus_typecheck_response (variant, reply_type, error))
+		nm_clear_pointer (&variant, g_variant_unref);
+	return variant;
 }
 
 /**

--- a/shared/nm-utils/nm-shared-utils.h
+++ b/shared/nm-utils/nm-shared-utils.h
@@ -909,4 +909,13 @@ void _nm_utils_user_data_unpack (gpointer user_data, int nargs, ...);
 const char *_nm_utils_escape_spaces (const char *str, char **to_free);
 char *_nm_utils_unescape_spaces (char *str);
 
+/*****************************************************************************/
+
+typedef void (*NMUtilsInvokeOnIdleCallback) (gpointer callback_user_data,
+                                             GCancellable *cancellable);
+
+void nm_utils_invoke_on_idle (NMUtilsInvokeOnIdleCallback callback,
+                              gpointer callback_user_data,
+                              GCancellable *cancellable);
+
 #endif /* __NM_SHARED_UTILS_H__ */

--- a/src/devices/adsl/nm-device-adsl.c
+++ b/src/devices/adsl/nm-device-adsl.c
@@ -523,7 +523,7 @@ adsl_cleanup (NMDeviceAdsl *self)
 	if (priv->ppp_manager) {
 		g_signal_handlers_disconnect_by_func (priv->ppp_manager, G_CALLBACK (ppp_state_changed), self);
 		g_signal_handlers_disconnect_by_func (priv->ppp_manager, G_CALLBACK (ppp_ip4_config), self);
-		nm_ppp_manager_stop (priv->ppp_manager, NULL, NULL);
+		nm_ppp_manager_stop (priv->ppp_manager, NULL, NULL, NULL);
 		g_clear_object (&priv->ppp_manager);
 	}
 

--- a/src/devices/bluetooth/nm-bluez-device.h
+++ b/src/devices/bluetooth/nm-bluez-device.h
@@ -66,16 +66,17 @@ guint32 nm_bluez_device_get_capabilities (NMBluezDevice *self);
 
 gboolean nm_bluez_device_get_connected (NMBluezDevice *self);
 
+typedef void (*NMBluezDeviceConnectCallback) (NMBluezDevice *self,
+                                              const char *device,
+                                              GError *error,
+                                              gpointer user_data);
+
 void
 nm_bluez_device_connect_async (NMBluezDevice *self,
                                NMBluetoothCapabilities connection_bt_type,
-                               GAsyncReadyCallback callback,
-                               gpointer user_data);
-
-const char *
-nm_bluez_device_connect_finish (NMBluezDevice *self,
-                                GAsyncResult *result,
-                                GError **error);
+                               GCancellable *cancellable,
+                               NMBluezDeviceConnectCallback callback,
+                               gpointer callback_user_data);
 
 void
 nm_bluez_device_disconnect (NMBluezDevice *self);

--- a/src/devices/bluetooth/nm-bluez5-dun.c
+++ b/src/devices/bluetooth/nm-bluez5-dun.c
@@ -342,13 +342,14 @@ nm_bluez5_dun_connect (NMBluez5DunContext *context,
 
 	if (context->rfcomm_channel != -1) {
 		nm_log_dbg (LOGD_BT, "(%s): channel number on device %s cached: %d",
-			    context->src_str, context->dst_str, context->rfcomm_channel);
+		            context->src_str, context->dst_str, context->rfcomm_channel);
+		/* FIXME: don't invoke the callback synchronously. */
 		dun_connect (context);
 		return;
 	}
 
 	nm_log_dbg (LOGD_BT, "(%s): starting channel number discovery for device %s",
-		    context->src_str, context->dst_str);
+	            context->src_str, context->dst_str);
 
 	context->sdp_session = sdp_connect (&context->src, &context->dst, SDP_NON_BLOCKING);
 	if (!context->sdp_session) {
@@ -358,10 +359,12 @@ nm_bluez5_dun_connect (NMBluez5DunContext *context,
 		error = g_error_new (NM_BT_ERROR, NM_BT_ERROR_DUN_CONNECT_FAILED,
 		                     "Failed to connect to the SDP server: (%d) %s",
 		                      err, strerror (err));
+		/* FIXME: don't invoke the callback synchronously. */
 		context->callback (context, NULL, error, context->user_data);
 		return;
 	}
 
+	/* FIXME(shutdown): make connect cancellable. */
 	channel = g_io_channel_unix_new (sdp_get_socket (context->sdp_session));
 	context->sdp_watch_id = g_io_add_watch (channel,
 	                                        G_IO_OUT | G_IO_HUP | G_IO_ERR | G_IO_NVAL,

--- a/src/devices/bluetooth/nm-bluez5-dun.h
+++ b/src/devices/bluetooth/nm-bluez5-dun.h
@@ -32,7 +32,8 @@ NMBluez5DunContext *nm_bluez5_dun_new (const char *adapter,
                                        const char *remote);
 
 void nm_bluez5_dun_connect (NMBluez5DunContext *context,
-                            NMBluez5DunFunc callback, gpointer user_data);
+                            NMBluez5DunFunc callback,
+                            gpointer user_data);
 
 /* Clean up connection resources */
 void nm_bluez5_dun_cleanup (NMBluez5DunContext *context);

--- a/src/devices/nm-device-ethernet.c
+++ b/src/devices/nm-device-ethernet.c
@@ -1347,7 +1347,7 @@ deactivate (NMDevice *device)
 	nm_clear_g_source (&priv->pppoe_wait_id);
 
 	if (priv->ppp_manager) {
-		nm_ppp_manager_stop (priv->ppp_manager, NULL, NULL);
+		nm_ppp_manager_stop (priv->ppp_manager, NULL, NULL, NULL);
 		g_clear_object (&priv->ppp_manager);
 	}
 

--- a/src/devices/nm-device-ppp.c
+++ b/src/devices/nm-device-ppp.c
@@ -221,7 +221,7 @@ deactivate (NMDevice *device)
 	NMDevicePppPrivate *priv = NM_DEVICE_PPP_GET_PRIVATE (self);
 
 	if (priv->ppp_manager) {
-		nm_ppp_manager_stop (priv->ppp_manager, NULL, NULL);
+		nm_ppp_manager_stop (priv->ppp_manager, NULL, NULL, NULL);
 		g_clear_object (&priv->ppp_manager);
 	}
 }

--- a/src/devices/nm-device.h
+++ b/src/devices/nm-device.h
@@ -197,6 +197,10 @@ typedef enum { /*< skip >*/
 	NM_DEVICE_CHECK_DEV_AVAILABLE_ALL                                   = (1L << 1) - 1,
 } NMDeviceCheckDevAvailableFlags;
 
+typedef void (*NMDeviceDeactivateCallback) (NMDevice *self,
+                                            GError *error,
+                                            gpointer user_data);
+
 typedef struct _NMDeviceClass {
 	NMDBusObjectClass parent;
 
@@ -354,11 +358,8 @@ typedef struct _NMDeviceClass {
 	/* Async deactivating (in the DEACTIVATING phase) */
 	void            (* deactivate_async)        (NMDevice *self,
 	                                             GCancellable *cancellable,
-	                                             GAsyncReadyCallback callback,
+	                                             NMDeviceDeactivateCallback callback,
 	                                             gpointer user_data);
-	gboolean        (* deactivate_async_finish) (NMDevice *self,
-	                                             GAsyncResult *res,
-	                                             GError **error);
 
 	void            (* deactivate_reset_hw_addr) (NMDevice *self);
 

--- a/src/devices/wwan/libnm-wwan.ver
+++ b/src/devices/wwan/libnm-wwan.ver
@@ -6,7 +6,6 @@ global:
 	nm_modem_complete_connection;
 	nm_modem_deactivate;
 	nm_modem_deactivate_async;
-	nm_modem_deactivate_async_finish;
 	nm_modem_device_state_changed;
 	nm_modem_get_capabilities;
 	nm_modem_get_configured_mtu;

--- a/src/devices/wwan/nm-modem-broadband.c
+++ b/src/devices/wwan/nm-modem-broadband.c
@@ -1188,9 +1188,11 @@ disconnect (NMModem *modem,
 /*****************************************************************************/
 
 static void
-deactivate_cleanup (NMModem *_self, NMDevice *device)
+deactivate_cleanup (NMModem *modem,
+                    NMDevice *device,
+                    gboolean stop_ppp_manager)
 {
-	NMModemBroadband *self = NM_MODEM_BROADBAND (_self);
+	NMModemBroadband *self = NM_MODEM_BROADBAND (modem);
 
 	/* TODO: cancel SimpleConnect() if any */
 
@@ -1201,8 +1203,9 @@ deactivate_cleanup (NMModem *_self, NMDevice *device)
 
 	self->_priv.pin_tries = 0;
 
-	/* Chain up parent's */
-	NM_MODEM_CLASS (nm_modem_broadband_parent_class)->deactivate_cleanup (_self, device);
+	NM_MODEM_CLASS (nm_modem_broadband_parent_class)->deactivate_cleanup (modem,
+	                                                                      device,
+	                                                                      stop_ppp_manager);
 }
 
 /*****************************************************************************/

--- a/src/devices/wwan/nm-modem-ofono.c
+++ b/src/devices/wwan/nm-modem-ofono.c
@@ -252,7 +252,9 @@ disconnect (NMModem *modem,
 }
 
 static void
-deactivate_cleanup (NMModem *modem, NMDevice *device)
+deactivate_cleanup (NMModem *modem,
+                    NMDevice *device,
+                    gboolean stop_ppp_manager)
 {
 	NMModemOfono *self = NM_MODEM_OFONO (modem);
 	NMModemOfonoPrivate *priv = NM_MODEM_OFONO_GET_PRIVATE (self);
@@ -261,7 +263,9 @@ deactivate_cleanup (NMModem *modem, NMDevice *device)
 
 	g_clear_object (&priv->ip4_config);
 
-	NM_MODEM_CLASS (nm_modem_ofono_parent_class)->deactivate_cleanup (modem, device);
+	NM_MODEM_CLASS (nm_modem_ofono_parent_class)->deactivate_cleanup (modem,
+	                                                                  device,
+	                                                                  stop_ppp_manager);
 }
 
 static gboolean

--- a/src/devices/wwan/nm-modem.h
+++ b/src/devices/wwan/nm-modem.h
@@ -109,6 +109,10 @@ struct _NMModem {
 
 typedef struct _NMModem NMModem;
 
+typedef void (*_NMModemDisconnectCallback) (NMModem *modem,
+                                            GError *error,
+                                            gpointer user_data);
+
 typedef struct {
 	GObjectClass parent;
 
@@ -149,11 +153,8 @@ typedef struct {
 	void     (*disconnect)                     (NMModem *self,
 	                                            gboolean warn,
 	                                            GCancellable *cancellable,
-	                                            GAsyncReadyCallback callback,
+	                                            _NMModemDisconnectCallback callback,
 	                                            gpointer user_data);
-	gboolean (*disconnect_finish)              (NMModem *self,
-	                                            GAsyncResult *res,
-	                                            GError **error);
 
 	void     (*deactivate_cleanup)             (NMModem *self, NMDevice *device);
 
@@ -236,14 +237,15 @@ void nm_modem_get_secrets (NMModem *modem,
 
 void nm_modem_deactivate (NMModem *modem, NMDevice *device);
 
+typedef void (*NMModemDeactivateCallback) (NMModem *self,
+                                           GError *error,
+                                           gpointer user_data);
+
 void     nm_modem_deactivate_async        (NMModem *self,
                                            NMDevice *device,
                                            GCancellable *cancellable,
-                                           GAsyncReadyCallback callback,
+                                           NMModemDeactivateCallback callback,
                                            gpointer user_data);
-gboolean nm_modem_deactivate_async_finish (NMModem *self,
-                                           GAsyncResult *res,
-                                           GError **error);
 
 void nm_modem_device_state_changed (NMModem *modem,
                                     NMDeviceState new_state,

--- a/src/devices/wwan/nm-modem.h
+++ b/src/devices/wwan/nm-modem.h
@@ -156,7 +156,9 @@ typedef struct {
 	                                            _NMModemDisconnectCallback callback,
 	                                            gpointer user_data);
 
-	void     (*deactivate_cleanup)             (NMModem *self, NMDevice *device);
+	void     (*deactivate_cleanup)             (NMModem *self,
+	                                            NMDevice *device,
+	                                            gboolean stop_ppp_manager);
 
 	gboolean (*owns_port)                      (NMModem *self, const char *iface);
 } NMModemClass;

--- a/src/ppp/nm-ppp-manager-call.c
+++ b/src/ppp/nm-ppp-manager-call.c
@@ -126,12 +126,13 @@ nm_ppp_manager_start (NMPPPManager *self,
 
 NMPPPManagerStopHandle *
 nm_ppp_manager_stop (NMPPPManager *self,
+                     GCancellable *cancellable,
                      NMPPPManagerStopCallback callback,
                      gpointer user_data)
 {
 	g_return_val_if_fail (ppp_ops, NULL);
 
-	return ppp_ops->stop (self, callback, user_data);
+	return ppp_ops->stop (self, cancellable, callback, user_data);
 }
 
 void

--- a/src/ppp/nm-ppp-manager-call.h
+++ b/src/ppp/nm-ppp-manager-call.h
@@ -40,6 +40,7 @@ gboolean            nm_ppp_manager_start       (NMPPPManager *self,
                                                 GError **error);
 
 NMPPPManagerStopHandle *nm_ppp_manager_stop (NMPPPManager *self,
+                                             GCancellable *cancellable,
                                              NMPPPManagerStopCallback callback,
                                              gpointer user_data);
 

--- a/src/ppp/nm-ppp-plugin-api.h
+++ b/src/ppp/nm-ppp-plugin-api.h
@@ -40,6 +40,7 @@ typedef const struct {
 	                        GError **err);
 
 	NMPPPManagerStopHandle *(*stop) (NMPPPManager *manager,
+	                                 GCancellable *cancellable,
 	                                 NMPPPManagerStopCallback callback,
 	                                 gpointer user_data);
 


### PR DESCRIPTION
I think the `GAsyncResult` pattern is less than optimal.

Maybe it serves a purpose in public glib API, where it better works for language bindings/introspection. For NetworkManager core, it's just a nuisance.

It results in
 - more lines of code (look at the patch)
 - more indirection of calling layers of code
 - less control of what actually happens because of the additional layers of code
 - less type-safety (instead of directly having a callback with suitable arguments, there is a `GAsyncReadyCallback`. Also, `g_simple_async_result_set_op_res_gpointer()` etc. looses type information).
 - more resource overhead (`GAsyncResult` is itself a `GObject`, ref-counted and unnecessary "features". In most cases, we need a simple heap allocation to package the user-data and relevant state. `nm_utils_user_data_pack()` is enough).