### PR TITLE
th/nm-1-14-keyfile-changes

### DIFF
--- a/libnm-core/nm-keyfile-internal.h
+++ b/libnm-core/nm-keyfile-internal.h
@@ -95,7 +95,6 @@ typedef struct {
 } NMKeyfileReadTypeDataWarn;
 
 NMConnection *nm_keyfile_read (GKeyFile *keyfile,
-                               const char *keyfile_name,
                                const char *base_dir,
                                NMKeyfileReadHandler handler,
                                void *user_data,

--- a/libnm-core/nm-keyfile-internal.h
+++ b/libnm-core/nm-keyfile-internal.h
@@ -101,6 +101,12 @@ NMConnection *nm_keyfile_read (GKeyFile *keyfile,
                                void *user_data,
                                GError **error);
 
+gboolean nm_keyfile_read_ensure_id (NMConnection *connection,
+                                    const char *fallback_id);
+
+gboolean nm_keyfile_read_ensure_uuid (NMConnection *connection,
+                                      const char *fallback_uuid_seed);
+
 /*****************************************************************************/
 
 typedef enum {

--- a/libnm-core/nm-keyfile.c
+++ b/libnm-core/nm-keyfile.c
@@ -2812,6 +2812,46 @@ read_vpn_secrets (KeyfileReaderInfo *info, NMSettingVpn *s_vpn)
 	}
 }
 
+gboolean
+nm_keyfile_read_ensure_id (NMConnection *connection,
+                           const char *fallback_id)
+{
+	NMSettingConnection *s_con;
+
+	g_return_val_if_fail (NM_IS_CONNECTION (connection), FALSE);
+	g_return_val_if_fail (fallback_id, FALSE);
+
+	s_con = nm_connection_get_setting_connection (connection);
+	g_return_val_if_fail (NM_IS_SETTING_CONNECTION (s_con), FALSE);
+
+	if (nm_setting_connection_get_id (s_con))
+		return FALSE;
+
+	g_object_set (s_con, NM_SETTING_CONNECTION_ID, fallback_id, NULL);
+	return TRUE;
+}
+
+gboolean
+nm_keyfile_read_ensure_uuid (NMConnection *connection,
+                             const char *fallback_uuid_seed)
+{
+	NMSettingConnection *s_con;
+	gs_free char *hashed_uuid = NULL;
+
+	g_return_val_if_fail (NM_IS_CONNECTION (connection), FALSE);
+	g_return_val_if_fail (fallback_uuid_seed, FALSE);
+
+	s_con = nm_connection_get_setting_connection (connection);
+	g_return_val_if_fail (NM_IS_SETTING_CONNECTION (s_con), FALSE);
+
+	if (nm_setting_connection_get_uuid (s_con))
+		return FALSE;
+
+	hashed_uuid = _nm_utils_uuid_generate_from_strings ("keyfile", fallback_uuid_seed, NULL);
+	g_object_set (s_con, NM_SETTING_CONNECTION_UUID, hashed_uuid, NULL);
+	return TRUE;
+}
+
 /**
  * nm_keyfile_read:
  * @keyfile: the keyfile from which to create the connection
@@ -2902,23 +2942,14 @@ nm_keyfile_read (GKeyFile *keyfile,
 		nm_connection_add_setting (connection, NM_SETTING (s_con));
 	}
 
-	/* Make sure that we have 'id' even if not explictly specified in the keyfile */
-	if (   keyfile_name
-	    && !nm_setting_connection_get_id (s_con)) {
-		gs_free char *base_name = NULL;
+	if (keyfile_name) {
+		gs_free char *basename = g_path_get_basename (keyfile_name);
 
-		base_name = g_path_get_basename (keyfile_name);
-		g_object_set (s_con, NM_SETTING_CONNECTION_ID, base_name, NULL);
+		nm_keyfile_read_ensure_id (connection, basename);
 	}
 
-	/* Make sure that we have 'uuid' even if not explictly specified in the keyfile */
-	if (   keyfile_name
-	    && !nm_setting_connection_get_uuid (s_con)) {
-		gs_free char *hashed_uuid = NULL;
-
-		hashed_uuid = _nm_utils_uuid_generate_from_strings ("keyfile", keyfile_name, NULL);
-		g_object_set (s_con, NM_SETTING_CONNECTION_UUID, hashed_uuid, NULL);
-	}
+	if (keyfile_name)
+		nm_keyfile_read_ensure_uuid (connection, keyfile_name);
 
 	/* Make sure that we have 'interface-name' even if it was specified in the
 	 * "wrong" (ie, deprecated) group.

--- a/libnm-core/tests/test-keyfile.c
+++ b/libnm-core/tests/test-keyfile.c
@@ -167,19 +167,28 @@ _nm_keyfile_write (NMConnection *connection,
 static NMConnection *
 _nm_keyfile_read (GKeyFile *keyfile,
                   const char *keyfile_name,
-                  const char *base_dir,
                   NMKeyfileReadHandler read_handler,
                   void *read_data,
                   gboolean needs_normalization)
 {
 	GError *error = NULL;
 	NMConnection *con;
+	gs_free char *filename = NULL;
+	gs_free char *base_dir = NULL;
 
 	g_assert (keyfile);
+	g_assert (!keyfile_name || (keyfile_name[0] == '/'));
 
-	con = nm_keyfile_read (keyfile, keyfile_name, base_dir, read_handler, read_data, &error);
+	base_dir = g_path_get_dirname (keyfile_name);
+	filename = g_path_get_basename (keyfile_name);
+
+	con = nm_keyfile_read (keyfile, base_dir, read_handler, read_data, &error);
 	g_assert_no_error (error);
 	g_assert (NM_IS_CONNECTION (con));
+
+	nm_keyfile_read_ensure_id (con, filename);
+	nm_keyfile_read_ensure_uuid (con, keyfile_name);
+
 	if (needs_normalization) {
 		nmtst_assert_connection_verifies_after_normalization (con, 0, 0);
 		nmtst_connection_normalize (con);
@@ -205,7 +214,6 @@ static void
 _keyfile_convert (NMConnection **con,
                   GKeyFile **keyfile,
                   const char *keyfile_name,
-                  const char *base_dir,
                   NMKeyfileReadHandler read_handler,
                   void *read_data,
                   NMKeyfileWriteHandler write_handler,
@@ -229,7 +237,7 @@ _keyfile_convert (NMConnection **con,
 
 	if (c0) {
 		c0_k1 = _nm_keyfile_write (c0, write_handler, write_data);
-		c0_k1_c2 = _nm_keyfile_read (c0_k1, keyfile_name, base_dir, read_handler, read_data, FALSE);
+		c0_k1_c2 = _nm_keyfile_read (c0_k1, keyfile_name, read_handler, read_data, FALSE);
 		c0_k1_c2_k3 = _nm_keyfile_write (c0_k1_c2, write_handler, write_data);
 
 		g_assert (_nm_keyfile_equals (c0_k1, c0_k1_c2_k3, TRUE));
@@ -237,9 +245,9 @@ _keyfile_convert (NMConnection **con,
 	if (k0) {
 		NMSetting8021x *s1, *s2;
 
-		k0_c1 = _nm_keyfile_read (k0, keyfile_name, base_dir, read_handler, read_data, needs_normalization);
+		k0_c1 = _nm_keyfile_read (k0, keyfile_name, read_handler, read_data, needs_normalization);
 		k0_c1_k2 = _nm_keyfile_write (k0_c1, write_handler, write_data);
-		k0_c1_k2_c3 = _nm_keyfile_read (k0_c1_k2, keyfile_name, base_dir, read_handler, read_data, FALSE);
+		k0_c1_k2_c3 = _nm_keyfile_read (k0_c1_k2, keyfile_name, read_handler, read_data, FALSE);
 
 		/* It is a expeced behavior, that if @k0 contains a relative path ca-cert, @k0_c1 will
 		 * contain that path as relative. But @k0_c1_k2 and @k0_c1_k2_c3 will have absolute paths.
@@ -312,7 +320,7 @@ _test_8021x_cert_check (NMConnection *con,
 	NMSetting8021x *s_8021x;
 	gs_free char *kval = NULL;
 
-	_keyfile_convert (&con, &keyfile, NULL, NULL, NULL, NULL, NULL, NULL, FALSE);
+	_keyfile_convert (&con, &keyfile, "/_test_8021x_cert_check/foo", NULL, NULL, NULL, NULL, FALSE);
 
 	s_8021x = nm_connection_get_setting_802_1x (con);
 
@@ -449,14 +457,14 @@ test_8021x_cert_read (void)
 	con = nmtst_create_connection_from_keyfile (
 	      "[connection]\n"
 	      "type=ethernet",
-	      "/test_8021x_cert_read/test0", NULL);
+	      "/test_8021x_cert_read/test0");
 	CLEAR (&con, &keyfile);
 
 	keyfile = _keyfile_load_from_data (
 	          "[connection]\n"
 	          "type=ethernet"
 	          );
-	_keyfile_convert (&con, &keyfile, "/test_8021x_cert_read/test1", NULL, NULL, NULL, NULL, NULL, TRUE);
+	_keyfile_convert (&con, &keyfile, "/test_8021x_cert_read/test1", NULL, NULL, NULL, NULL, TRUE);
 	CLEAR (&con, &keyfile);
 
 	keyfile = _keyfile_load_from_data (
@@ -471,7 +479,7 @@ test_8021x_cert_read (void)
 	          "private-key=102;105;108;101;58;47;47;47;104;111;109;101;47;100;99;98;119;47;68;101;115;107;116;111;112;47;99;101;114;116;105;110;102;114;97;47;99;108;105;101;110;116;46;112;101;109;0;\n"
 	          "private-key-password=12345testing\n"
 	          );
-	_keyfile_convert (&con, &keyfile, "/test_8021x_cert_read/test2", NULL, NULL, NULL, NULL, NULL, TRUE);
+	_keyfile_convert (&con, &keyfile, "/test_8021x_cert_read/test2", NULL, NULL, NULL, NULL, TRUE);
 	CLEAR (&con, &keyfile);
 
 	keyfile = _keyfile_load_from_data (
@@ -500,7 +508,7 @@ test_8021x_cert_read (void)
 	                      "/33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333111111\n"
 	          "private-key-password=12345testing\n"
 	          );
-	_keyfile_convert (&con, &keyfile, "/test_8021x_cert_read/test2", NULL, NULL, NULL, NULL, NULL, TRUE);
+	_keyfile_convert (&con, &keyfile, "/test_8021x_cert_read/test2", NULL, NULL, NULL, NULL, TRUE);
 	s_8021x = nm_connection_get_setting_802_1x (con);
 
 	g_assert (nm_setting_802_1x_get_ca_cert_scheme (s_8021x) == NM_SETTING_802_1X_CK_SCHEME_PATH);
@@ -528,7 +536,7 @@ test_8021x_cert_read (void)
 	          "private-key=data:;base64,aGFsbG8=\n" // hallo
 	          "private-key-password=12345testing\n"
 	          );
-	_keyfile_convert (&con, &keyfile, "/test_8021x_cert_read/test2", NULL, NULL, NULL, NULL, NULL, TRUE);
+	_keyfile_convert (&con, &keyfile, "/test_8021x_cert_read/test2", NULL, NULL, NULL, NULL, TRUE);
 	s_8021x = nm_connection_get_setting_802_1x (con);
 
 	g_assert (nm_setting_802_1x_get_ca_cert_scheme (s_8021x) == NM_SETTING_802_1X_CK_SCHEME_PATH);
@@ -553,7 +561,7 @@ test_8021x_cert_read (void)
 	          "private-key=abc.deR\n"
 	          "private-key-password=12345testing\n"
 	          );
-	_keyfile_convert (&con, &keyfile, "/test_8021x_cert_read/test2", NULL, NULL, NULL, NULL, NULL, TRUE);
+	_keyfile_convert (&con, &keyfile, "/test_8021x_cert_read/test2", NULL, NULL, NULL, NULL, TRUE);
 	s_8021x = nm_connection_get_setting_802_1x (con);
 
 	g_assert (nm_setting_802_1x_get_ca_cert_scheme (s_8021x) == NM_SETTING_802_1X_CK_SCHEME_PATH);
@@ -578,7 +586,7 @@ test_8021x_cert_read (void)
 	          "private-key=hallo\n"
 	          "private-key-password=12345testing\n"
 	          );
-	_keyfile_convert (&con, &keyfile, "/test_8021x_cert_read/test2", NULL, NULL, NULL, NULL, NULL, TRUE);
+	_keyfile_convert (&con, &keyfile, "/test_8021x_cert_read/test2", NULL, NULL, NULL, NULL, TRUE);
 	s_8021x = nm_connection_get_setting_802_1x (con);
 
 	g_assert (nm_setting_802_1x_get_ca_cert_scheme (s_8021x) == NM_SETTING_802_1X_CK_SCHEME_BLOB);
@@ -605,7 +613,7 @@ test_team_conf_read_valid (void)
 	      "interface-name=nm-team1\n"
 	      "[team]\n"
 	      "config={\"foo\":\"bar\"}",
-	      "/test_team_conf_read/valid", NULL);
+	      "/test_team_conf_read/valid");
 
 	g_assert (con);
 	s_team = nm_connection_get_setting_team (con);
@@ -629,7 +637,7 @@ test_team_conf_read_invalid (void)
 	      "interface-name=nm-team1\n"
 	      "[team]\n"
 	      "config={foobar}",
-	      "/test_team_conf_read/invalid", NULL);
+	      "/test_team_conf_read/invalid");
 
 	g_assert (con);
 	s_team = nm_connection_get_setting_team (con);
@@ -657,7 +665,7 @@ test_user_1 (void)
 	      "[user]\n"
 	      "my-value.x=value1\n"
 	      "",
-	      "/test_user_1/invalid", NULL);
+	      "/test_user_1/invalid");
 	g_assert (con);
 	s_user = NM_SETTING_USER (nm_connection_get_setting (con, NM_TYPE_SETTING_USER));
 	g_assert (s_user);
@@ -704,7 +712,7 @@ test_user_1 (void)
 	nm_connection_add_setting (con, NM_SETTING (s_user));
 	nmtst_connection_normalize (con);
 
-	_keyfile_convert (&con, &keyfile, NULL, NULL, NULL, NULL, NULL, NULL, FALSE);
+	_keyfile_convert (&con, &keyfile, "/test_user_1/foo", NULL, NULL, NULL, NULL, FALSE);
 }
 
 /*****************************************************************************/
@@ -725,7 +733,7 @@ test_vpn_1 (void)
 	      "service-type=a.b.c\n"
 	      "vpn-key-1=value1\n"
 	      "",
-	      "/test_vpn_1/invalid", NULL);
+	      "/test_vpn_1/invalid");
 	g_assert (con);
 	s_vpn = NM_SETTING_VPN (nm_connection_get_setting (con, NM_TYPE_SETTING_VPN));
 	g_assert (s_vpn);

--- a/libnm-core/tests/test-setting.c
+++ b/libnm-core/tests/test-setting.c
@@ -1319,12 +1319,14 @@ test_ethtool_1 (void)
 	nmtst_assert_success (keyfile, error);
 
 	con3 = nm_keyfile_read (keyfile,
-	                        "ethtool-keyfile-name",
-	                        NULL,
+	                        "/ignored/current/working/directory/for/loading/relative/paths",
 	                        NULL,
 	                        NULL,
 	                        &error);
 	nmtst_assert_success (con3, error);
+
+	nm_keyfile_read_ensure_id (con3, "unused-because-already-has-id");
+	nm_keyfile_read_ensure_uuid (con3, "unused-because-already-has-uuid");
 
 	nmtst_connection_normalize (con3);
 

--- a/src/settings/plugins/ifcfg-rh/tests/test-ifcfg-rh.c
+++ b/src/settings/plugins/ifcfg-rh/tests/test-ifcfg-rh.c
@@ -9054,7 +9054,7 @@ test_team_reread_slave (void)
 	        "id=142\n"
 	        "ingress-priority-map=\n"
 	        "parent=enp31s0f1\n"
-	        , "/test_team_reread_slave", NULL);
+	        , "/test_team_reread_slave");
 
 	/* to double-check keyfile syntax, re-create the connection by hand. */
 	connection_2 = nmtst_create_minimal_connection ("team-slave-enp31s0f1-142", "74f435bb-ede4-415a-9d48-f580b60eba04", NM_SETTING_VLAN_SETTING_NAME, &s_con);

--- a/src/settings/plugins/keyfile/nms-keyfile-connection.c
+++ b/src/settings/plugins/keyfile/nms-keyfile-connection.c
@@ -124,6 +124,7 @@ nms_keyfile_connection_init (NMSKeyfileConnection *connection)
 NMSKeyfileConnection *
 nms_keyfile_connection_new (NMConnection *source,
                             const char *full_path,
+                            const char *profile_dir,
                             GError **error)
 {
 	GObject *object;
@@ -131,13 +132,15 @@ nms_keyfile_connection_new (NMConnection *source,
 	const char *uuid;
 	gboolean update_unsaved = TRUE;
 
-	g_assert (source || full_path);
+	nm_assert (source || full_path);
+	nm_assert (!full_path || full_path[0] == '/');
+	nm_assert (!profile_dir || profile_dir[0] == '/');
 
 	/* If we're given a connection already, prefer that instead of re-reading */
 	if (source)
 		tmp = g_object_ref (source);
 	else {
-		tmp = nms_keyfile_reader_from_file (full_path, error);
+		tmp = nms_keyfile_reader_from_file (full_path, profile_dir, error);
 		if (!tmp)
 			return NULL;
 

--- a/src/settings/plugins/keyfile/nms-keyfile-connection.h
+++ b/src/settings/plugins/keyfile/nms-keyfile-connection.h
@@ -37,7 +37,8 @@ typedef struct _NMSKeyfileConnectionClass NMSKeyfileConnectionClass;
 GType nms_keyfile_connection_get_type (void);
 
 NMSKeyfileConnection *nms_keyfile_connection_new (NMConnection *source,
-                                                  const char *filename,
+                                                  const char *full_path,
+                                                  const char *profile_dir,
                                                   GError **error);
 
 #endif /* __NMS_KEYFILE_CONNECTION_H__ */

--- a/src/settings/plugins/keyfile/nms-keyfile-plugin.c
+++ b/src/settings/plugins/keyfile/nms-keyfile-plugin.c
@@ -195,7 +195,7 @@ update_connection (NMSKeyfilePlugin *self,
 		return FALSE;
 	}
 
-	connection_new = nms_keyfile_connection_new (source, full_path, &local);
+	connection_new = nms_keyfile_connection_new (source, full_path, nms_keyfile_utils_get_path (), &local);
 	if (!connection_new) {
 		/* Error; remove the connection */
 		if (source)

--- a/src/settings/plugins/keyfile/nms-keyfile-reader.c
+++ b/src/settings/plugins/keyfile/nms-keyfile-reader.c
@@ -114,6 +114,7 @@ nms_keyfile_reader_from_keyfile (GKeyFile *key_file,
 	};
 	gs_free char *base_dir_free = NULL;
 	gs_free char *profile_filename_free = NULL;
+	gs_free char *filename_id = NULL;
 	const char *profile_filename = NULL;
 
 	nm_assert (filename && filename[0]);
@@ -141,7 +142,14 @@ nms_keyfile_reader_from_keyfile (GKeyFile *key_file,
 	if (!connection)
 		return NULL;
 
-	nm_keyfile_read_ensure_id (connection, filename);
+	if (g_str_has_suffix (filename, NMS_KEYFILE_PATH_SUFFIX_NMCONNECTION)) {
+		gsize l = strlen (filename);
+
+		if (l > NM_STRLEN (NMS_KEYFILE_PATH_SUFFIX_NMCONNECTION))
+			filename_id = g_strndup (filename, l - NM_STRLEN (NMS_KEYFILE_PATH_SUFFIX_NMCONNECTION));
+	}
+
+	nm_keyfile_read_ensure_id (connection, filename_id ?: filename);
 
 	if (!profile_filename) {
 		profile_filename_free = g_build_filename (profile_dir ?: base_dir, filename, NULL);

--- a/src/settings/plugins/keyfile/nms-keyfile-reader.c
+++ b/src/settings/plugins/keyfile/nms-keyfile-reader.c
@@ -103,33 +103,77 @@ _handler_read (GKeyFile *keyfile,
 NMConnection *
 nms_keyfile_reader_from_keyfile (GKeyFile *key_file,
                                  const char *filename,
+                                 const char *base_dir,
+                                 const char *profile_dir,
                                  gboolean verbose,
                                  GError **error)
 {
+	NMConnection *connection;
 	HandlerReadData data = {
 		.verbose = verbose,
 	};
+	gs_free char *base_dir_free = NULL;
+	gs_free char *profile_filename_free = NULL;
+	const char *profile_filename = NULL;
 
-	return nm_keyfile_read (key_file, filename, NULL, _handler_read, &data, error);
+	nm_assert (filename && filename[0]);
+	nm_assert (!base_dir || base_dir[0] == '/');
+	nm_assert (!profile_dir || profile_dir[0] == '/');
+
+	if (base_dir)
+		nm_assert (!strchr (filename, '/'));
+	else {
+		const char *s;
+
+		nm_assert (filename[0] == '/');
+
+		/* @base_dir may be NULL, in which case @filename must be an absolute path,
+		 * and the directory is taken as the @base_dir. */
+		s = strrchr (filename, '/');
+		base_dir = nm_strndup_a (255, filename, s - filename, &base_dir_free);
+		if (   !profile_dir
+		    || nm_streq (base_dir, profile_dir))
+			profile_filename = filename;
+		filename = &s[1];
+	}
+
+	connection = nm_keyfile_read (key_file, base_dir, _handler_read, &data, error);
+	if (!connection)
+		return NULL;
+
+	nm_keyfile_read_ensure_id (connection, filename);
+
+	if (!profile_filename) {
+		profile_filename_free = g_build_filename (profile_dir ?: base_dir, filename, NULL);
+		profile_filename = profile_filename_free;
+	}
+	nm_keyfile_read_ensure_uuid (connection, profile_filename);
+
+	return connection;
 }
 
 NMConnection *
-nms_keyfile_reader_from_file (const char *filename, GError **error)
+nms_keyfile_reader_from_file (const char *full_filename,
+                              const char *profile_dir,
+                              GError **error)
 {
 	gs_unref_keyfile GKeyFile *key_file = NULL;
 	NMConnection *connection = NULL;
 	GError *verify_error = NULL;
 
-	if (!nms_keyfile_utils_check_file_permissions (filename,
+	nm_assert (full_filename && full_filename[0] == '/');
+	nm_assert (!profile_dir || profile_dir[0] == '/');
+
+	if (!nms_keyfile_utils_check_file_permissions (full_filename,
 	                                               NULL,
 	                                               error))
 		return NULL;
 
 	key_file = g_key_file_new ();
-	if (!g_key_file_load_from_file (key_file, filename, G_KEY_FILE_NONE, error))
+	if (!g_key_file_load_from_file (key_file, full_filename, G_KEY_FILE_NONE, error))
 		return NULL;
 
-	connection = nms_keyfile_reader_from_keyfile (key_file, filename, TRUE, error);
+	connection = nms_keyfile_reader_from_keyfile (key_file, full_filename, NULL, profile_dir, TRUE, error);
 	if (!connection)
 		return NULL;
 

--- a/src/settings/plugins/keyfile/nms-keyfile-reader.h
+++ b/src/settings/plugins/keyfile/nms-keyfile-reader.h
@@ -26,9 +26,13 @@
 
 NMConnection *nms_keyfile_reader_from_keyfile (GKeyFile *key_file,
                                                const char *filename,
+                                               const char *base_dir,
+                                               const char *profile_dir,
                                                gboolean verbose,
                                                GError **error);
 
-NMConnection *nms_keyfile_reader_from_file (const char *filename, GError **error);
+NMConnection *nms_keyfile_reader_from_file (const char *full_filename,
+                                            const char *profile_dir,
+                                            GError **error);
 
 #endif /* __NMS_KEYFILE_READER_H__ */

--- a/src/settings/plugins/keyfile/nms-keyfile-utils.c
+++ b/src/settings/plugins/keyfile/nms-keyfile-utils.c
@@ -56,18 +56,11 @@ check_mkstemp_suffix (const char *path)
 }
 
 static gboolean
-check_prefix (const char *base, const char *tag)
+check_prefix_dot (const char *base)
 {
-	int len, tag_len;
+	nm_assert (base && base[0]);
 
-	g_return_val_if_fail (base != NULL, TRUE);
-	g_return_val_if_fail (tag != NULL, TRUE);
-
-	len = strlen (base);
-	tag_len = strlen (tag);
-	if ((len > tag_len) && !g_ascii_strncasecmp (base, tag, tag_len))
-		return TRUE;
-	return FALSE;
+	return base[0] == '.';
 }
 
 static gboolean
@@ -102,7 +95,7 @@ nms_keyfile_utils_should_ignore_file (const char *filename)
 
 	/* Ignore hidden and backup files */
 	/* should_ignore_file() must mirror escape_filename() */
-	if (check_prefix (base, ".") || check_suffix (base, "~"))
+	if (check_prefix_dot (base) || check_suffix (base, "~"))
 		return TRUE;
 	/* Ignore temporary files */
 	if (check_mkstemp_suffix (base))
@@ -198,7 +191,7 @@ nms_keyfile_utils_escape_filename (const char *filename)
 
 	/* escape_filename() must avoid anything that should_ignore_file() would reject.
 	 * We can escape here more aggressivly then what we would read back. */
-	if (check_prefix (str->str, "."))
+	if (check_prefix_dot (str->str))
 		str->str[0] = ESCAPE_CHAR2;
 	if (check_suffix (str->str, "~"))
 		str->str[str->len - 1] = ESCAPE_CHAR2;

--- a/src/settings/plugins/keyfile/nms-keyfile-utils.c
+++ b/src/settings/plugins/keyfile/nms-keyfile-utils.c
@@ -24,6 +24,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 
 #include "nm-setting-wired.h"
 #include "nm-setting-wireless.h"
@@ -112,6 +113,65 @@ nms_keyfile_utils_should_ignore_file (const char *filename)
 
 	return FALSE;
 }
+
+/*****************************************************************************/
+
+gboolean
+nms_keyfile_utils_check_file_permissions_stat (const struct stat *st,
+                                               GError **error)
+{
+	g_return_val_if_fail (st, FALSE);
+
+	if (!S_ISREG (st->st_mode)) {
+		g_set_error_literal (error, NM_SETTINGS_ERROR, NM_SETTINGS_ERROR_INVALID_CONNECTION,
+		                     "file is not a regular file");
+		return FALSE;
+	}
+
+	if (!NM_FLAGS_HAS (nm_utils_get_testing (), NM_UTILS_TEST_NO_KEYFILE_OWNER_CHECK)) {
+		if (st->st_uid != 0) {
+			g_set_error (error, NM_SETTINGS_ERROR, NM_SETTINGS_ERROR_INVALID_CONNECTION,
+			             "File owner (%lld) is insecure",
+			             (long long) st->st_uid);
+			return FALSE;
+		}
+
+		if (st->st_mode & 0077) {
+			g_set_error (error, NM_SETTINGS_ERROR, NM_SETTINGS_ERROR_INVALID_CONNECTION,
+			             "File permissions (%03o) are insecure",
+			             st->st_mode);
+			return FALSE;
+		}
+	}
+
+	return TRUE;
+}
+
+gboolean
+nms_keyfile_utils_check_file_permissions (const char *filename,
+                                          struct stat *out_st,
+                                          GError **error)
+{
+	struct stat st;
+	int errsv;
+
+	g_return_val_if_fail (filename && filename[0] == '/', FALSE);
+
+	if (stat (filename, &st) != 0) {
+		errsv = errno;
+		g_set_error (error, NM_SETTINGS_ERROR, NM_SETTINGS_ERROR_INVALID_CONNECTION,
+		             "cannot access file: %s", g_strerror (errsv));
+		return FALSE;
+	}
+
+	if (!nms_keyfile_utils_check_file_permissions_stat (&st, error))
+		return FALSE;
+
+	NM_SET_OUT (out_st, st);
+	return TRUE;
+}
+
+/*****************************************************************************/
 
 char *
 nms_keyfile_utils_escape_filename (const char *filename)

--- a/src/settings/plugins/keyfile/nms-keyfile-utils.h
+++ b/src/settings/plugins/keyfile/nms-keyfile-utils.h
@@ -37,4 +37,12 @@ char *nms_keyfile_utils_escape_filename (const char *filename);
 
 const char *nms_keyfile_utils_get_path (void);
 
+struct stat;
+gboolean nms_keyfile_utils_check_file_permissions_stat (const struct stat *st,
+                                                        GError **error);
+
+gboolean nms_keyfile_utils_check_file_permissions (const char *filename,
+                                                   struct stat *out_st,
+                                                   GError **error);
+
 #endif /* __NMS_KEYFILE_UTILS_H__ */

--- a/src/settings/plugins/keyfile/nms-keyfile-utils.h
+++ b/src/settings/plugins/keyfile/nms-keyfile-utils.h
@@ -25,15 +25,17 @@
 
 #define NM_CONFIG_KEYFILE_PATH_IN_MEMORY NMRUNDIR "/system-connections"
 
+#define NMS_KEYFILE_PATH_SUFFIX_NMCONNECTION      ".nmconnection"
+
 #define NMS_KEYFILE_CONNECTION_LOG_PATH(path)  ((path) ?: "in-memory")
 #define NMS_KEYFILE_CONNECTION_LOG_FMT         "%s (%s,\"%s\")"
 #define NMS_KEYFILE_CONNECTION_LOG_ARG(con)    NMS_KEYFILE_CONNECTION_LOG_PATH (nm_settings_connection_get_filename ((NMSettingsConnection *) (con))), nm_settings_connection_get_uuid ((NMSettingsConnection *) (con)), nm_settings_connection_get_id ((NMSettingsConnection *) (con))
 #define NMS_KEYFILE_CONNECTION_LOG_FMTD        "%s (%s,\"%s\",%p)"
 #define NMS_KEYFILE_CONNECTION_LOG_ARGD(con)   NMS_KEYFILE_CONNECTION_LOG_PATH (nm_settings_connection_get_filename ((NMSettingsConnection *) (con))), nm_settings_connection_get_uuid ((NMSettingsConnection *) (con)), nm_settings_connection_get_id ((NMSettingsConnection *) (con)), (con)
 
-gboolean nms_keyfile_utils_should_ignore_file (const char *filename);
+gboolean nms_keyfile_utils_should_ignore_file (const char *filename, gboolean require_extension);
 
-char *nms_keyfile_utils_escape_filename (const char *filename);
+char *nms_keyfile_utils_escape_filename (const char *filename, gboolean with_extension);
 
 const char *nms_keyfile_utils_get_path (void);
 

--- a/src/settings/plugins/keyfile/nms-keyfile-writer.c
+++ b/src/settings/plugins/keyfile/nms-keyfile-writer.c
@@ -173,6 +173,7 @@ static gboolean
 _internal_write_connection (NMConnection *connection,
                             const char *keyfile_dir,
                             const char *profile_dir,
+                            gboolean with_extension,
                             uid_t owner_uid,
                             pid_t owner_grp,
                             const char *existing_path,
@@ -229,7 +230,7 @@ _internal_write_connection (NMConnection *connection,
 	if (existing_path != NULL && !rename) {
 		path = g_strdup (existing_path);
 	} else {
-		char *filename_escaped = nms_keyfile_utils_escape_filename (id);
+		char *filename_escaped = nms_keyfile_utils_escape_filename (id, with_extension);
 
 		path = g_build_filename (keyfile_dir, filename_escaped, NULL);
 		g_free (filename_escaped);
@@ -255,7 +256,7 @@ _internal_write_connection (NMConnection *connection,
 			else
 				filename = g_strdup_printf ("%s-%s-%u", id, nm_connection_get_uuid (connection), i);
 
-			filename_escaped = nms_keyfile_utils_escape_filename (filename);
+			filename_escaped = nms_keyfile_utils_escape_filename (filename, with_extension);
 
 			g_free (path);
 			path = g_strdup_printf ("%s/%s", keyfile_dir, filename_escaped);
@@ -351,16 +352,21 @@ nms_keyfile_writer_connection (NMConnection *connection,
                                GError **error)
 {
 	const char *keyfile_dir;
+	gboolean with_extension = FALSE;
 
 	if (save_to_disk)
 		keyfile_dir = nms_keyfile_utils_get_path ();
-	else
+	else {
 		keyfile_dir = NM_CONFIG_KEYFILE_PATH_IN_MEMORY;
+		with_extension = TRUE;
+	}
 
 	return _internal_write_connection (connection,
 	                                   keyfile_dir,
 	                                   nms_keyfile_utils_get_path (),
-	                                   0, 0,
+	                                   with_extension,
+	                                   0,
+	                                   0,
 	                                   existing_path,
 	                                   force_rename,
 	                                   out_path,
@@ -382,7 +388,9 @@ nms_keyfile_writer_test_connection (NMConnection *connection,
 	return _internal_write_connection (connection,
 	                                   keyfile_dir,
 	                                   keyfile_dir,
-	                                   owner_uid, owner_grp,
+	                                   FALSE,
+	                                   owner_uid,
+	                                   owner_grp,
 	                                   NULL,
 	                                   FALSE,
 	                                   out_path,

--- a/src/settings/plugins/keyfile/nms-keyfile-writer.c
+++ b/src/settings/plugins/keyfile/nms-keyfile-writer.c
@@ -172,6 +172,7 @@ _handler_write (NMConnection *connection,
 static gboolean
 _internal_write_connection (NMConnection *connection,
                             const char *keyfile_dir,
+                            const char *profile_dir,
                             uid_t owner_uid,
                             pid_t owner_grp,
                             const char *existing_path,
@@ -308,7 +309,7 @@ _internal_write_connection (NMConnection *connection,
 		gs_unref_object NMConnection *reread = NULL;
 		gboolean reread_same = FALSE;
 
-		reread = nms_keyfile_reader_from_keyfile (key_file, path, FALSE, NULL);
+		reread = nms_keyfile_reader_from_keyfile (key_file, path, NULL, profile_dir, FALSE, NULL);
 
 		nm_assert (NM_IS_CONNECTION (reread));
 
@@ -358,6 +359,7 @@ nms_keyfile_writer_connection (NMConnection *connection,
 
 	return _internal_write_connection (connection,
 	                                   keyfile_dir,
+	                                   nms_keyfile_utils_get_path (),
 	                                   0, 0,
 	                                   existing_path,
 	                                   force_rename,
@@ -378,6 +380,7 @@ nms_keyfile_writer_test_connection (NMConnection *connection,
                                     GError **error)
 {
 	return _internal_write_connection (connection,
+	                                   keyfile_dir,
 	                                   keyfile_dir,
 	                                   owner_uid, owner_grp,
 	                                   NULL,

--- a/src/settings/plugins/keyfile/tests/test-keyfile.c
+++ b/src/settings/plugins/keyfile/tests/test-keyfile.c
@@ -73,6 +73,7 @@ check_ip_route (NMSettingIPConfig *config, int idx, const char *destination, int
 	g_assert (full_filename && full_filename[0] == '/'); \
 	\
 	_connection = nms_keyfile_reader_from_file (full_filename, \
+	                                            NULL, \
 	                                            (nmtst_get_rand_int () % 2) ? &_error : NULL); \
 	nmtst_assert_success (_connection, _error); \
 	nmtst_assert_connection_verifies_without_normalization (_connection); \

--- a/src/settings/plugins/keyfile/tests/test-keyfile.c
+++ b/src/settings/plugins/keyfile/tests/test-keyfile.c
@@ -2150,12 +2150,15 @@ static void
 test_read_missing_id_uuid (void)
 {
 	gs_unref_object NMConnection *connection = NULL;
+	gs_free char *expected_uuid = NULL;
+	const char *FILENAME = TEST_KEYFILES_DIR"/Test_Missing_ID_UUID";
 
-	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR"/Test_Missing_ID_UUID");
+	expected_uuid = _nm_utils_uuid_generate_from_strings ("keyfile", FILENAME, NULL);
 
-	/* Ensure the ID and UUID properties are there */
+	connection = keyfile_read_connection_from_file (FILENAME);
+
 	g_assert_cmpstr (nm_connection_get_id (connection), ==, "Test_Missing_ID_UUID");
-	g_assert (nm_connection_get_uuid (connection));
+	g_assert_cmpstr (nm_connection_get_uuid (connection), ==, expected_uuid);
 }
 
 static void

--- a/src/settings/plugins/keyfile/tests/test-keyfile.c
+++ b/src/settings/plugins/keyfile/tests/test-keyfile.c
@@ -2460,49 +2460,51 @@ test_write_tc_config (void)
 /*****************************************************************************/
 
 static void
-_escape_filename (const char *filename, gboolean would_be_ignored)
+_escape_filename (gboolean with_extension, const char *filename, gboolean would_be_ignored)
 {
 	gs_free char *esc = NULL;
 
 	g_assert (filename && filename[0]);
 
-	if (!!would_be_ignored != !!nms_keyfile_utils_should_ignore_file (filename)) {
+	if (!!would_be_ignored != !!nms_keyfile_utils_should_ignore_file (filename, with_extension)) {
 		if (would_be_ignored)
 			g_error ("We expect filename \"%s\" to be ignored, but it isn't", filename);
 		else
 			g_error ("We expect filename \"%s\" not to be ignored, but it is", filename);
 	}
 
-	esc = nms_keyfile_utils_escape_filename (filename);
+	esc = nms_keyfile_utils_escape_filename (filename, with_extension);
 	g_assert (esc && esc[0]);
 	g_assert (!strchr (esc, '/'));
 
-	if (nms_keyfile_utils_should_ignore_file (esc))
+	if (nms_keyfile_utils_should_ignore_file (esc, with_extension))
 		g_error ("Escaping filename \"%s\" yielded \"%s\", but this is ignored", filename, esc);
 }
 
 static void
 test_nm_keyfile_plugin_utils_escape_filename (void)
 {
-	_escape_filename ("ab", FALSE);
-	_escape_filename (".vim-file.swp", TRUE);
-	_escape_filename (".vim-file.Swp", TRUE);
-	_escape_filename (".vim-file.SWP", TRUE);
-	_escape_filename (".vim-file.swpx", TRUE);
-	_escape_filename (".vim-file.Swpx", TRUE);
-	_escape_filename (".vim-file.SWPX", TRUE);
-	_escape_filename (".pem-file.pem", TRUE);
-	_escape_filename (".pem-file.Pem", TRUE);
-	_escape_filename (".pem-file.PEM", TRUE);
-	_escape_filename (".pem-file.der", TRUE);
-	_escape_filename (".pem-file.Der", TRUE);
-	_escape_filename (".mkstemp.ABCEDF", TRUE);
-	_escape_filename (".mkstemp.abcdef", TRUE);
-	_escape_filename (".mkstemp.123456", TRUE);
-	_escape_filename (".mkstemp.A23456", TRUE);
-	_escape_filename (".#emacs-locking", TRUE);
-	_escape_filename ("file-with-tilde~", TRUE);
-	_escape_filename (".file-with-dot", TRUE);
+	_escape_filename (FALSE, "ab", FALSE);
+	_escape_filename (FALSE, ".vim-file.swp", TRUE);
+	_escape_filename (FALSE, ".vim-file.Swp", TRUE);
+	_escape_filename (FALSE, ".vim-file.SWP", TRUE);
+	_escape_filename (FALSE, ".vim-file.swpx", TRUE);
+	_escape_filename (FALSE, ".vim-file.Swpx", TRUE);
+	_escape_filename (FALSE, ".vim-file.SWPX", TRUE);
+	_escape_filename (FALSE, ".pem-file.pem", TRUE);
+	_escape_filename (FALSE, ".pem-file.Pem", TRUE);
+	_escape_filename (FALSE, ".pem-file.PEM", TRUE);
+	_escape_filename (FALSE, ".pem-file.der", TRUE);
+	_escape_filename (FALSE, ".pem-file.Der", TRUE);
+	_escape_filename (FALSE, ".mkstemp.ABCEDF", TRUE);
+	_escape_filename (FALSE, ".mkstemp.abcdef", TRUE);
+	_escape_filename (FALSE, ".mkstemp.123456", TRUE);
+	_escape_filename (FALSE, ".mkstemp.A23456", TRUE);
+	_escape_filename (FALSE, ".#emacs-locking", TRUE);
+	_escape_filename (FALSE, "file-with-tilde~", TRUE);
+	_escape_filename (FALSE, ".file-with-dot", TRUE);
+
+	_escape_filename (TRUE, "lala", TRUE);
 }
 
 /*****************************************************************************/

--- a/src/settings/plugins/keyfile/tests/test-keyfile.c
+++ b/src/settings/plugins/keyfile/tests/test-keyfile.c
@@ -65,37 +65,31 @@ check_ip_route (NMSettingIPConfig *config, int idx, const char *destination, int
 	g_assert_cmpint (nm_ip_route_get_metric (route), ==, metric);
 }
 
-static NMConnection *
-keyfile_read_connection_from_file (const char *filename)
-{
-	gs_free_error GError *error = NULL;
-	NMConnection *connection;
-
-	g_assert (filename);
-
-	connection = nms_keyfile_reader_from_file (filename, &error);
-	g_assert_no_error (error);
-
-	nmtst_assert_connection_verifies_without_normalization (connection);
-
-	return connection;
-}
+#define keyfile_read_connection_from_file(full_filename) \
+({ \
+	gs_free_error GError *_error = NULL; \
+	NMConnection *_connection; \
+	\
+	g_assert (full_filename && full_filename[0] == '/'); \
+	\
+	_connection = nms_keyfile_reader_from_file (full_filename, \
+	                                            (nmtst_get_rand_int () % 2) ? &_error : NULL); \
+	nmtst_assert_success (_connection, _error); \
+	nmtst_assert_connection_verifies_without_normalization (_connection); \
+	\
+	_connection; \
+})
 
 static void
 assert_reread (NMConnection *connection, gboolean normalize_connection, const char *testfile)
 {
 	gs_unref_object NMConnection *reread = NULL;
 	gs_unref_object NMConnection *connection_clone = NULL;
-	GError *error = NULL;
-	GError **p_error = (nmtst_get_rand_int () % 2) ? &error : NULL;
 	NMSettingConnection *s_con;
 
 	g_assert (NM_IS_CONNECTION (connection));
-	g_assert (testfile && testfile[0]);
 
-	reread = nms_keyfile_reader_from_file (testfile, p_error);
-	g_assert_no_error (error);
-	g_assert (NM_IS_CONNECTION (reread));
+	reread = keyfile_read_connection_from_file (testfile);
 
 	if (   !normalize_connection
 	    && (s_con = nm_connection_get_setting_connection (connection))
@@ -229,10 +223,8 @@ test_read_valid_wired_connection (void)
 	NMSettingIPConfig *s_ip4;
 	NMSettingIPConfig *s_ip6;
 	NMIPRoute *route;
-	gs_free_error GError *error = NULL;
 	const char *mac;
 	char expected_mac_address[ETH_ALEN] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55 };
-	gboolean success;
 
 	NMTST_EXPECT_NM_INFO ("*ipv4.addresses:*semicolon at the end*addresses1*");
 	NMTST_EXPECT_NM_INFO ("*ipv4.addresses:*semicolon at the end*addresses2*");
@@ -249,16 +241,9 @@ test_read_valid_wired_connection (void)
 	NMTST_EXPECT_NM_INFO ("*ipv6.address*semicolon at the end*address7*");
 	NMTST_EXPECT_NM_INFO ("*ipv6.routes*semicolon at the end*routes1*");
 	NMTST_EXPECT_NM_INFO ("*ipv6.route*semicolon at the end*route6*");
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR "/Test_Wired_Connection", &error);
-	g_assert_no_error (error);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR "/Test_Wired_Connection");
 	g_test_assert_expected_messages ();
-	g_assert (connection);
 
-	success = nm_connection_verify (connection, &error);
-	g_assert_no_error (error);
-	g_assert (success);
-
-	/* ===== CONNECTION SETTING ===== */
 	s_con = nm_connection_get_setting_connection (connection);
 	g_assert (s_con);
 	g_assert_cmpstr (nm_setting_connection_get_id (s_con), ==, "Test Wired Connection");
@@ -266,7 +251,6 @@ test_read_valid_wired_connection (void)
 	g_assert_cmpuint (nm_setting_connection_get_timestamp (s_con), ==, 6654332);
 	g_assert (nm_setting_connection_get_autoconnect (s_con));
 
-	/* ===== WIRED SETTING ===== */
 	s_wired = nm_connection_get_setting_wired (connection);
 	g_assert (s_wired);
 
@@ -275,7 +259,6 @@ test_read_valid_wired_connection (void)
 	g_assert (nm_utils_hwaddr_matches (mac, -1, expected_mac_address, sizeof (expected_mac_address)));
 	g_assert_cmpint (nm_setting_wired_get_mtu (s_wired), ==, 1400);
 
-	/* ===== IPv4 SETTING ===== */
 	s_ip4 = nm_connection_get_setting_ip4_config (connection);
 	g_assert (s_ip4);
 	g_assert_cmpstr (nm_setting_ip_config_get_method (s_ip4), ==, NM_SETTING_IP4_CONFIG_METHOD_MANUAL);
@@ -324,7 +307,6 @@ test_read_valid_wired_connection (void)
 	nmtst_assert_route_attribute_boolean (route, NM_IP_ROUTE_ATTRIBUTE_LOCK_CWND, TRUE);
 	nmtst_assert_route_attribute_string  (route, NM_IP_ROUTE_ATTRIBUTE_SRC, "7.7.7.7");
 
-	/* ===== IPv6 SETTING ===== */
 	s_ip6 = nm_connection_get_setting_ip6_config (connection);
 	g_assert (s_ip6);
 
@@ -535,32 +517,22 @@ test_read_ip6_wired_connection (void)
 	NMSettingWired *s_wired;
 	NMSettingIPConfig *s_ip4;
 	NMSettingIPConfig *s_ip6;
-	gs_free_error GError *error = NULL;
-	gboolean success;
 
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR "/Test_Wired_Connection_IP6", NULL);
-	g_assert (connection);
-	success = nm_connection_verify (connection, &error);
-	g_assert_no_error (error);
-	g_assert (success);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR "/Test_Wired_Connection_IP6");
 
-	/* ===== CONNECTION SETTING ===== */
 	s_con = nm_connection_get_setting_connection (connection);
 	g_assert (s_con);
 	g_assert_cmpstr (nm_setting_connection_get_id (s_con), ==, "Test Wired Connection IP6");
 	g_assert_cmpstr (nm_setting_connection_get_uuid (s_con), ==, "4e80a56d-c99f-4aad-a6dd-b449bc398c57");
 
-	/* ===== WIRED SETTING ===== */
 	s_wired = nm_connection_get_setting_wired (connection);
 	g_assert (s_wired);
 
-	/* ===== IPv4 SETTING ===== */
 	s_ip4 = nm_connection_get_setting_ip4_config (connection);
 	g_assert (s_ip4);
 	g_assert_cmpstr (nm_setting_ip_config_get_method (s_ip4), ==, NM_SETTING_IP4_CONFIG_METHOD_DISABLED);
 	g_assert_cmpint (nm_setting_ip_config_get_num_addresses (s_ip4), ==, 0);
 
-	/* ===== IPv6 SETTING ===== */
 	s_ip6 = nm_connection_get_setting_ip6_config (connection);
 	g_assert (s_ip6);
 	g_assert_cmpstr (nm_setting_ip_config_get_method (s_ip6), ==, NM_SETTING_IP6_CONFIG_METHOD_MANUAL);
@@ -638,28 +610,20 @@ test_read_wired_mac_case (void)
 	gs_unref_object NMConnection *connection = NULL;
 	NMSettingConnection *s_con;
 	NMSettingWired *s_wired;
-	gs_free_error GError *error = NULL;
 	const char *mac;
 	char expected_mac_address[ETH_ALEN] = { 0x00, 0x11, 0xaa, 0xbb, 0xcc, 0x55 };
-	gboolean success;
 
 	NMTST_EXPECT_NM_INFO ("*ipv4.addresses*semicolon at the end*addresses1*");
 	NMTST_EXPECT_NM_INFO ("*ipv4.addresses*semicolon at the end*addresses2*");
 	NMTST_EXPECT_NM_INFO ("*ipv6.routes*semicolon at the end*routes1*");
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR "/Test_Wired_Connection_MAC_Case", NULL);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR "/Test_Wired_Connection_MAC_Case");
 	g_test_assert_expected_messages ();
-	g_assert (connection);
-	success = nm_connection_verify (connection, &error);
-	g_assert_no_error (error);
-	g_assert (success);
 
-	/* ===== CONNECTION SETTING ===== */
 	s_con = nm_connection_get_setting_connection (connection);
 	g_assert (s_con);
 	g_assert_cmpstr (nm_setting_connection_get_id (s_con), ==, "Test Wired Connection MAC Case");
 	g_assert_cmpstr (nm_setting_connection_get_uuid (s_con), ==, "4e80a56d-c99f-4aad-a6dd-b449bc398c57");
 
-	/* ===== WIRED SETTING ===== */
 	s_wired = nm_connection_get_setting_wired (connection);
 	g_assert (s_wired);
 	mac = nm_setting_wired_get_mac_address (s_wired);
@@ -672,29 +636,19 @@ test_read_mac_old_format (void)
 {
 	gs_unref_object NMConnection *connection = NULL;
 	NMSettingWired *s_wired;
-	gs_free_error GError *error = NULL;
-	gboolean success;
 	const char *mac;
 	char expected_mac[ETH_ALEN] = { 0x00, 0x11, 0xaa, 0xbb, 0xcc, 0x55 };
 	char expected_cloned_mac[ETH_ALEN] = { 0x00, 0x16, 0xaa, 0xbb, 0xcc, 0xfe };
 
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR "/Test_MAC_Old_Format", &error);
-	g_assert_no_error (error);
-	g_assert (connection);
-
-	success = nm_connection_verify (connection, &error);
-	g_assert_no_error (error);
-	g_assert (success);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR "/Test_MAC_Old_Format");
 
 	s_wired = nm_connection_get_setting_wired (connection);
 	g_assert (s_wired);
 
-	/* MAC address */
 	mac = nm_setting_wired_get_mac_address (s_wired);
 	g_assert (mac);
 	g_assert (nm_utils_hwaddr_matches (mac, -1, expected_mac, ETH_ALEN));
 
-	/* Cloned MAC address */
 	mac = nm_setting_wired_get_cloned_mac_address (s_wired);
 	g_assert (mac);
 	g_assert (nm_utils_hwaddr_matches (mac, -1, expected_cloned_mac, ETH_ALEN));
@@ -705,20 +659,12 @@ test_read_mac_ib_old_format (void)
 {
 	gs_unref_object NMConnection *connection = NULL;
 	NMSettingInfiniband *s_ib;
-	gs_free_error GError *error = NULL;
-	gboolean success;
 	const char *mac;
 	guint8 expected_mac[INFINIBAND_ALEN] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66,
-		0x77, 0x88, 0x99, 0x01, 0x12, 0x23, 0x34, 0x45, 0x56, 0x67, 0x78, 0x89,
-		0x90 };
+	    0x77, 0x88, 0x99, 0x01, 0x12, 0x23, 0x34, 0x45, 0x56, 0x67, 0x78, 0x89,
+	    0x90 };
 
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR "/Test_MAC_IB_Old_Format", &error);
-	g_assert_no_error (error);
-	g_assert (connection);
-
-	success = nm_connection_verify (connection, &error);
-	g_assert_no_error (error);
-	g_assert (success);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR "/Test_MAC_IB_Old_Format");
 
 	s_ib = nm_connection_get_setting_infiniband (connection);
 	g_assert (s_ib);
@@ -736,18 +682,11 @@ test_read_valid_wireless_connection (void)
 	NMSettingConnection *s_con;
 	NMSettingWireless *s_wireless;
 	NMSettingIPConfig *s_ip4;
-	gs_free_error GError *error = NULL;
 	const char *bssid;
 	const guint8 expected_bssid[ETH_ALEN] = { 0x00, 0x1a, 0x33, 0x44, 0x99, 0x82 };
-	gboolean success;
 
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR "/Test_Wireless_Connection", NULL);
-	g_assert (connection);
-	success = nm_connection_verify (connection, &error);
-	g_assert_no_error (error);
-	g_assert (success);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR "/Test_Wireless_Connection");
 
-	/* ===== CONNECTION SETTING ===== */
 	s_con = nm_connection_get_setting_connection (connection);
 	g_assert (s_con);
 	g_assert_cmpstr (nm_setting_connection_get_id (s_con), ==, "Test Wireless Connection");
@@ -755,14 +694,12 @@ test_read_valid_wireless_connection (void)
 	g_assert_cmpuint (nm_setting_connection_get_timestamp (s_con), ==, 1226604314);
 	g_assert (nm_setting_connection_get_autoconnect (s_con) == FALSE);
 
-	/* ===== WIRELESS SETTING ===== */
 	s_wireless = nm_connection_get_setting_wireless (connection);
 	g_assert (s_wireless);
 	bssid = nm_setting_wireless_get_bssid (s_wireless);
 	g_assert (bssid);
 	g_assert (nm_utils_hwaddr_matches (bssid, -1, expected_bssid, sizeof (expected_bssid)));
 
-	/* ===== IPv4 SETTING ===== */
 	s_ip4 = nm_connection_get_setting_ip4_config (connection);
 	g_assert (s_ip4);
 	g_assert_cmpstr (nm_setting_ip_config_get_method (s_ip4), ==, NM_SETTING_IP4_CONFIG_METHOD_AUTO);
@@ -838,24 +775,19 @@ test_read_string_ssid (void)
 {
 	gs_unref_object NMConnection *connection = NULL;
 	NMSettingWireless *s_wireless;
-	gs_free_error GError *error = NULL;
 	GBytes *ssid;
 	const guint8 *ssid_data;
 	gsize ssid_len;
 	const char *expected_ssid = "blah blah ssid 1234";
-	gboolean success;
 
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR "/Test_String_SSID", NULL);
-	g_assert (connection);
-	success = nm_connection_verify (connection, &error);
-	g_assert_no_error (error);
-	g_assert (success);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR "/Test_String_SSID");
 
-	/* ===== WIRELESS SETTING ===== */
 	s_wireless = nm_connection_get_setting_wireless (connection);
 	g_assert (s_wireless);
+
 	ssid = nm_setting_wireless_get_ssid (s_wireless);
 	g_assert (ssid);
+
 	ssid_data = g_bytes_get_data (ssid, &ssid_len);
 	g_assert_cmpmem (ssid_data, ssid_len, expected_ssid, strlen (expected_ssid));
 }
@@ -922,22 +854,13 @@ test_read_intlist_ssid (void)
 {
 	gs_unref_object NMConnection *connection = NULL;
 	NMSettingWireless *s_wifi;
-	gs_free_error GError *error = NULL;
-	gboolean success;
 	GBytes *ssid;
 	const guint8 *ssid_data;
 	gsize ssid_len;
 	const char *expected_ssid = "blah1234";
 
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR "/Test_Intlist_SSID", &error);
-	g_assert_no_error (error);
-	g_assert (connection);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR "/Test_Intlist_SSID");
 
-	success = nm_connection_verify (connection, &error);
-	g_assert_no_error (error);
-	g_assert (success);
-
-	/* SSID */
 	s_wifi = nm_connection_get_setting_wireless (connection);
 	g_assert (s_wifi);
 
@@ -1015,16 +938,10 @@ test_read_intlike_ssid (void)
 {
 	gs_unref_object NMConnection *connection = NULL;
 	NMSettingWireless *s_wifi;
-	gs_free_error GError *error = NULL;
-	gboolean success;
 	GBytes *ssid;
 	const char *expected_ssid = "101";
 
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR "/Test_Intlike_SSID", &error);
-	nmtst_assert_success (connection, error);
-
-	success = nm_connection_verify (connection, &error);
-	nmtst_assert_success (success, error);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR "/Test_Intlike_SSID");
 
 	s_wifi = nm_connection_get_setting_wireless (connection);
 	g_assert (s_wifi);
@@ -1039,16 +956,10 @@ test_read_intlike_ssid_2 (void)
 {
 	gs_unref_object NMConnection *connection = NULL;
 	NMSettingWireless *s_wifi;
-	gs_free_error GError *error = NULL;
-	gboolean success;
 	GBytes *ssid;
 	const char *expected_ssid = "11;12;13;";
 
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR "/Test_Intlike_SSID_2", &error);
-	nmtst_assert_success (connection, error);
-
-	success = nm_connection_verify (connection, &error);
-	nmtst_assert_success (success, error);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR "/Test_Intlike_SSID_2");
 
 	s_wifi = nm_connection_get_setting_wireless (connection);
 	g_assert (s_wifi);
@@ -1183,24 +1094,16 @@ test_read_bt_dun_connection (void)
 	NMSettingBluetooth *s_bluetooth;
 	NMSettingSerial *s_serial;
 	NMSettingGsm *s_gsm;
-	gs_free_error GError *error = NULL;
 	const char *bdaddr;
 	const guint8 expected_bdaddr[ETH_ALEN] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55 };
-	gboolean success;
 
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR "/ATT_Data_Connect_BT", NULL);
-	g_assert (connection);
-	success = nm_connection_verify (connection, &error);
-	g_assert_no_error (error);
-	g_assert (success);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR "/ATT_Data_Connect_BT");
 
-	/* ===== CONNECTION SETTING ===== */
 	s_con = nm_connection_get_setting_connection (connection);
 	g_assert (s_con);
 	g_assert_cmpstr (nm_setting_connection_get_id (s_con), ==, "AT&T Data Connect BT");
 	g_assert_cmpstr (nm_setting_connection_get_uuid (s_con), ==, "089130ab-ce28-46e4-ad77-d44869b03d19");
 
-	/* ===== BLUETOOTH SETTING ===== */
 	s_bluetooth = nm_connection_get_setting_bluetooth (connection);
 	g_assert (s_bluetooth);
 	bdaddr = nm_setting_bluetooth_get_bdaddr (s_bluetooth);
@@ -1208,14 +1111,12 @@ test_read_bt_dun_connection (void)
 	g_assert (nm_utils_hwaddr_matches (bdaddr, -1, expected_bdaddr, sizeof (expected_bdaddr)));
 	g_assert_cmpstr (nm_setting_bluetooth_get_connection_type (s_bluetooth), ==, NM_SETTING_BLUETOOTH_TYPE_DUN);
 
-	/* ===== GSM SETTING ===== */
 	s_gsm = nm_connection_get_setting_gsm (connection);
 	g_assert (s_gsm);
 	g_assert_cmpstr (nm_setting_gsm_get_apn (s_gsm), ==, "ISP.CINGULAR");
 	g_assert_cmpstr (nm_setting_gsm_get_username (s_gsm), ==, "ISP@CINGULARGPRS.COM");
 	g_assert_cmpstr (nm_setting_gsm_get_password (s_gsm), ==, "CINGULAR1");
 
-	/* ===== SERIAL SETTING ===== */
 	s_serial = nm_connection_get_setting_serial (connection);
 	g_assert (s_serial);
 	g_assert (nm_setting_serial_get_parity (s_serial) == NM_SETTING_SERIAL_PARITY_ODD);
@@ -1288,28 +1189,17 @@ test_read_gsm_connection (void)
 	NMSettingConnection *s_con;
 	NMSettingSerial *s_serial;
 	NMSettingGsm *s_gsm;
-	gs_free_error GError *error = NULL;
-	gboolean success;
 
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR "/ATT_Data_Connect_Plain", &error);
-	g_assert_no_error (error);
-	g_assert (connection);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR "/ATT_Data_Connect_Plain");
 
-	success = nm_connection_verify (connection, &error);
-	g_assert_no_error (error);
-	g_assert (success);
-
-	/* ===== CONNECTION SETTING ===== */
 	s_con = nm_connection_get_setting_connection (connection);
 	g_assert (s_con);
 	g_assert_cmpstr (nm_setting_connection_get_id (s_con), ==, "AT&T Data Connect");
 	g_assert_cmpstr (nm_setting_connection_get_connection_type (s_con), ==, NM_SETTING_GSM_SETTING_NAME);
 
-	/* ===== BLUETOOTH SETTING ===== */
 	/* Plain GSM, so no BT setting expected */
 	g_assert (nm_connection_get_setting_bluetooth (connection) == NULL);
 
-	/* ===== GSM SETTING ===== */
 	s_gsm = nm_connection_get_setting_gsm (connection);
 	g_assert (s_gsm);
 	g_assert_cmpstr (nm_setting_gsm_get_apn (s_gsm), ==, "ISP.CINGULAR");
@@ -1321,7 +1211,6 @@ test_read_gsm_connection (void)
 	g_assert_cmpstr (nm_setting_gsm_get_sim_id (s_gsm), ==, "89148000000060671234");
 	g_assert_cmpstr (nm_setting_gsm_get_sim_operator_id (s_gsm), ==, "310260");
 
-	/* ===== SERIAL SETTING ===== */
 	s_serial = nm_connection_get_setting_serial (connection);
 	g_assert (s_serial);
 	g_assert_cmpint (nm_setting_serial_get_parity (s_serial), ==, NM_SETTING_SERIAL_PARITY_ODD);
@@ -1387,25 +1276,16 @@ test_read_wired_8021x_tls_blob_connection (void)
 	gs_unref_object NMConnection *connection = NULL;
 	NMSettingWired *s_wired;
 	NMSetting8021x *s_8021x;
-	gs_free_error GError *error = NULL;
 	const char *tmp;
-	gboolean success;
 	GBytes *blob;
 
 	NMTST_EXPECT_NM_WARN ("keyfile: 802-1x.client-cert: certificate or key file '/CASA/dcbw/Desktop/certinfra/client.pem' does not exist*");
 	NMTST_EXPECT_NM_WARN ("keyfile: 802-1x.private-key: certificate or key file '/CASA/dcbw/Desktop/certinfra/client.pem' does not exist*");
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR "/Test_Wired_TLS_Blob", &error);
-	g_assert_no_error (error);
-	g_assert (connection);
-	success = nm_connection_verify (connection, &error);
-	g_assert_no_error (error);
-	g_assert (success);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR "/Test_Wired_TLS_Blob");
 
-	/* ===== Wired Setting ===== */
 	s_wired = nm_connection_get_setting_wired (connection);
 	g_assert (s_wired != NULL);
 
-	/* ===== 802.1x Setting ===== */
 	s_8021x = nm_connection_get_setting_802_1x (connection);
 	g_assert (s_8021x != NULL);
 
@@ -1445,25 +1325,16 @@ test_read_wired_8021x_tls_bad_path_connection (void)
 	gs_unref_object NMConnection *connection = NULL;
 	NMSettingWired *s_wired;
 	NMSetting8021x *s_8021x;
-	gs_free_error GError *error = NULL;
 	const char *tmp;
 	char *tmp2;
-	gboolean success;
 
 	NMTST_EXPECT_NM_WARN ("*does not exist*");
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR "/Test_Wired_TLS_Path_Missing", &error);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR "/Test_Wired_TLS_Path_Missing");
 	g_test_assert_expected_messages ();
-	g_assert_no_error (error);
-	g_assert (connection);
-	success = nm_connection_verify (connection, &error);
-	g_assert_no_error (error);
-	g_assert (success);
 
-	/* ===== Wired Setting ===== */
 	s_wired = nm_connection_get_setting_wired (connection);
 	g_assert (s_wired != NULL);
 
-	/* ===== 802.1x Setting ===== */
 	s_8021x = nm_connection_get_setting_802_1x (connection);
 	g_assert (s_8021x != NULL);
 
@@ -1499,25 +1370,16 @@ test_read_wired_8021x_tls_old_connection (void)
 	gs_unref_object NMConnection *connection = NULL;
 	NMSettingWired *s_wired;
 	NMSetting8021x *s_8021x;
-	gs_free_error GError *error = NULL;
 	const char *tmp;
-	gboolean success;
 
 	NMTST_EXPECT_NM_WARN ("keyfile: 802-1x.ca-cert: certificate or key file '/CASA/dcbw/Desktop/certinfra/CA/eaptest_ca_cert.pem' does not exist*");
 	NMTST_EXPECT_NM_WARN ("keyfile: 802-1x.client-cert: certificate or key file '/CASA/dcbw/Desktop/certinfra/client.pem' does not exist*");
 	NMTST_EXPECT_NM_WARN ("keyfile: 802-1x.private-key: certificate or key file '/CASA/dcbw/Desktop/certinfra/client.pem' does not exist*");
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR "/Test_Wired_TLS_Old", &error);
-	g_assert_no_error (error);
-	g_assert (connection);
-	success = nm_connection_verify (connection, &error);
-	g_assert_no_error (error);
-	g_assert (success);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR "/Test_Wired_TLS_Old");
 
-	/* ===== Wired Setting ===== */
 	s_wired = nm_connection_get_setting_wired (connection);
 	g_assert (s_wired != NULL);
 
-	/* ===== 802.1x Setting ===== */
 	s_8021x = nm_connection_get_setting_802_1x (connection);
 	g_assert (s_8021x != NULL);
 
@@ -1547,23 +1409,14 @@ test_read_wired_8021x_tls_new_connection (void)
 	gs_unref_object NMConnection *connection = NULL;
 	NMSettingWired *s_wired;
 	NMSetting8021x *s_8021x;
-	gs_free_error GError *error = NULL;
 	const char *tmp;
 	char *tmp2;
-	gboolean success;
 
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR "/Test_Wired_TLS_New", &error);
-	g_assert_no_error (error);
-	g_assert (connection);
-	success = nm_connection_verify (connection, &error);
-	g_assert_no_error (error);
-	g_assert (success);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR "/Test_Wired_TLS_New");
 
-	/* ===== Wired Setting ===== */
 	s_wired = nm_connection_get_setting_wired (connection);
 	g_assert (s_wired != NULL);
 
-	/* ===== 802.1x Setting ===== */
 	s_8021x = nm_connection_get_setting_802_1x (connection);
 	g_assert (s_8021x != NULL);
 
@@ -1701,12 +1554,7 @@ test_write_wired_8021x_tls_connection_path (void)
 	g_clear_object (&reread);
 
 	/* Read the connection back in and compare it to the one we just wrote out */
-	reread = nms_keyfile_reader_from_file (testfile, &error);
-	if (!reread) {
-		g_assert (error);
-		g_warning ("Failed to re-read test connection: %s", error->message);
-		g_assert (reread);
-	}
+	reread = keyfile_read_connection_from_file (testfile);
 
 	success = nm_connection_compare (connection, reread, NM_SETTING_COMPARE_FLAG_EXACT);
 	if (!reread) {
@@ -1817,12 +1665,7 @@ test_write_wired_8021x_tls_connection_blob (void)
 	g_assert (g_file_test (new_priv_key, G_FILE_TEST_EXISTS));
 
 	/* Read the connection back in and compare it to the one we just wrote out */
-	reread = nms_keyfile_reader_from_file (testfile, &error);
-	if (!reread) {
-		g_assert (error);
-		g_warning ("Failed to re-read test connection: %s", error->message);
-		g_assert (reread);
-	}
+	reread = keyfile_read_connection_from_file (testfile);
 
 	/* Ensure the re-read connection's certificates use the path scheme */
 	s_8021x = nm_connection_get_setting_802_1x (reread);
@@ -1862,29 +1705,20 @@ test_read_infiniband_connection (void)
 	gs_unref_object NMConnection *connection = NULL;
 	NMSettingConnection *s_con;
 	NMSettingInfiniband *s_ib;
-	gs_free_error GError *error = NULL;
 	const char *mac;
 	guint8 expected_mac[INFINIBAND_ALEN] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66,
-		0x77, 0x88, 0x99, 0x01, 0x12, 0x23, 0x34, 0x45, 0x56, 0x67, 0x78, 0x89,
-		0x90 };
+	    0x77, 0x88, 0x99, 0x01, 0x12, 0x23, 0x34, 0x45, 0x56, 0x67, 0x78, 0x89,
+	    0x90 };
 	const char *expected_id = "Test InfiniBand Connection";
 	const char *expected_uuid = "4e80a56d-c99f-4aad-a6dd-b449bc398c57";
-	gboolean success;
 
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR "/Test_InfiniBand_Connection", &error);
-	g_assert_no_error (error);
-	g_assert (connection);
-	success = nm_connection_verify (connection, &error);
-	g_assert_no_error (error);
-	g_assert (success);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR "/Test_InfiniBand_Connection");
 
-	/* Connection setting */
 	s_con = nm_connection_get_setting_connection (connection);
 	g_assert (s_con);
 	g_assert_cmpstr (nm_setting_connection_get_id (s_con), ==, expected_id);
 	g_assert_cmpstr (nm_setting_connection_get_uuid (s_con), ==, expected_uuid);
 
-	/* InfiniBand setting */
 	s_ib = nm_connection_get_setting_infiniband (connection);
 	g_assert (s_ib);
 
@@ -1952,31 +1786,21 @@ test_read_bridge_main (void)
 	NMSettingConnection *s_con;
 	NMSettingIPConfig *s_ip4;
 	NMSettingBridge *s_bridge;
-	gs_free_error GError *error = NULL;
 	const char *expected_id = "Test Bridge Main";
 	const char *expected_uuid = "8f061643-fe41-4d4c-a8d9-097d26e2ad3a";
-	gboolean success;
 
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR "/Test_Bridge_Main", &error);
-	g_assert_no_error (error);
-	g_assert (connection);
-	success = nm_connection_verify (connection, &error);
-	g_assert_no_error (error);
-	g_assert (success);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR "/Test_Bridge_Main");
 
-	/* Connection setting */
 	s_con = nm_connection_get_setting_connection (connection);
 	g_assert (s_con);
 	g_assert_cmpstr (nm_setting_connection_get_id (s_con), ==, expected_id);
 	g_assert_cmpstr (nm_setting_connection_get_uuid (s_con), ==, expected_uuid);
 	g_assert_cmpstr (nm_setting_connection_get_interface_name (s_con), ==, "br0");
 
-	/* IPv4 setting */
 	s_ip4 = nm_connection_get_setting_ip4_config (connection);
 	g_assert (s_ip4);
 	g_assert_cmpstr (nm_setting_ip_config_get_method (s_ip4), ==, NM_SETTING_IP4_CONFIG_METHOD_AUTO);
 
-	/* Bridge setting */
 	s_bridge = nm_connection_get_setting_bridge (connection);
 	g_assert (s_bridge);
 	g_assert_cmpuint (nm_setting_bridge_get_forward_delay (s_bridge), ==, 2);
@@ -2049,19 +1873,11 @@ test_read_bridge_component (void)
 	NMSettingWired *s_wired;
 	const char *mac;
 	guint8 expected_mac[ETH_ALEN] = { 0x00, 0x22, 0x15, 0x59, 0x62, 0x97 };
-	gs_free_error GError *error = NULL;
 	const char *expected_id = "Test Bridge Component";
 	const char *expected_uuid = "d7b4f96c-c45e-4298-bef8-f48574f8c1c0";
-	gboolean success;
 
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR "/Test_Bridge_Component", &error);
-	g_assert_no_error (error);
-	g_assert (connection);
-	success = nm_connection_verify (connection, &error);
-	g_assert_no_error (error);
-	g_assert (success);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR "/Test_Bridge_Component");
 
-	/* Connection setting */
 	s_con = nm_connection_get_setting_connection (connection);
 	g_assert (s_con);
 	g_assert_cmpstr (nm_setting_connection_get_id (s_con), ==, expected_id);
@@ -2069,14 +1885,12 @@ test_read_bridge_component (void)
 	g_assert_cmpstr (nm_setting_connection_get_master (s_con), ==, "br0");
 	g_assert (nm_setting_connection_is_slave_type (s_con, NM_SETTING_BRIDGE_SETTING_NAME));
 
-	/* Wired setting */
 	s_wired = nm_connection_get_setting_wired (connection);
 	g_assert (s_wired);
 	mac = nm_setting_wired_get_mac_address (s_wired);
 	g_assert (mac);
 	g_assert (nm_utils_hwaddr_matches (mac, -1, expected_mac, sizeof (expected_mac)));
 
-	/* BridgePort setting */
 	s_port = nm_connection_get_setting_bridge_port (connection);
 	g_assert (s_port);
 	g_assert (nm_setting_bridge_port_get_hairpin_mode (s_port));
@@ -2141,17 +1955,9 @@ test_read_new_wired_group_name (void)
 	NMSettingWired *s_wired;
 	const char *mac;
 	guint8 expected_mac[ETH_ALEN] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55 };
-	gs_free_error GError *error = NULL;
-	gboolean success;
 
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR"/Test_New_Wired_Group_Name", &error);
-	g_assert_no_error (error);
-	g_assert (connection);
-	success = nm_connection_verify (connection, &error);
-	g_assert_no_error (error);
-	g_assert (success);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR"/Test_New_Wired_Group_Name");
 
-	/* Wired setting */
 	s_wired = nm_connection_get_setting_wired (connection);
 	g_assert (s_wired);
 	g_assert_cmpint (nm_setting_wired_get_mtu (s_wired), ==, 1400);
@@ -2221,14 +2027,8 @@ test_read_new_wireless_group_names (void)
 	NMSettingWirelessSecurity *s_wsec;
 	GBytes *ssid;
 	const char *expected_ssid = "foobar";
-	gs_free_error GError *error = NULL;
-	gboolean success;
 
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR"/Test_New_Wireless_Group_Names", &error);
-	nmtst_assert_success (connection, error);
-
-	success = nm_connection_verify (connection, &error);
-	nmtst_assert_success (success, error);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR"/Test_New_Wireless_Group_Names");
 
 	s_wifi = nm_connection_get_setting_wireless (connection);
 	g_assert (s_wifi);
@@ -2323,17 +2123,9 @@ test_read_missing_vlan_setting (void)
 {
 	gs_unref_object NMConnection *connection = NULL;
 	NMSettingVlan *s_vlan;
-	gs_free_error GError *error = NULL;
-	gboolean success;
 
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR"/Test_Missing_Vlan_Setting", &error);
-	g_assert_no_error (error);
-	g_assert (connection);
-	success = nm_connection_verify (connection, &error);
-	g_assert_no_error (error);
-	g_assert (success);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR"/Test_Missing_Vlan_Setting");
 
-	/* Ensure the VLAN setting exists */
 	s_vlan = nm_connection_get_setting_vlan (connection);
 	g_assert (s_vlan);
 	g_assert_cmpint (nm_setting_vlan_get_id (s_vlan), ==, 0);
@@ -2345,17 +2137,9 @@ test_read_missing_vlan_flags (void)
 {
 	gs_unref_object NMConnection *connection = NULL;
 	NMSettingVlan *s_vlan;
-	gs_free_error GError *error = NULL;
-	gboolean success;
 
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR"/Test_Missing_Vlan_Flags", &error);
-	g_assert_no_error (error);
-	g_assert (connection);
-	success = nm_connection_verify (connection, &error);
-	g_assert_no_error (error);
-	g_assert (success);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR"/Test_Missing_Vlan_Flags");
 
-	/* Ensure the VLAN setting exists */
 	s_vlan = nm_connection_get_setting_vlan (connection);
 	g_assert (s_vlan);
 
@@ -2368,15 +2152,8 @@ static void
 test_read_missing_id_uuid (void)
 {
 	gs_unref_object NMConnection *connection = NULL;
-	gs_free_error GError *error = NULL;
-	gboolean success;
 
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR"/Test_Missing_ID_UUID", &error);
-	g_assert_no_error (error);
-	g_assert (connection);
-	success = nm_connection_verify (connection, &error);
-	g_assert_no_error (error);
-	g_assert (success);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR"/Test_Missing_ID_UUID");
 
 	/* Ensure the ID and UUID properties are there */
 	g_assert_cmpstr (nm_connection_get_id (connection), ==, "Test_Missing_ID_UUID");
@@ -2468,17 +2245,9 @@ test_read_enum_property (void)
 {
 	gs_unref_object NMConnection *connection = NULL;
 	NMSettingIPConfig *s_ip6;
-	gs_free_error GError *error = NULL;
-	gboolean success;
 
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR"/Test_Enum_Property", &error);
-	g_assert_no_error (error);
-	g_assert (connection);
-	success = nm_connection_verify (connection, &error);
-	g_assert_no_error (error);
-	g_assert (success);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR"/Test_Enum_Property");
 
-	/* IPv6 setting */
 	s_ip6 = nm_connection_get_setting_ip6_config (connection);
 	g_assert (s_ip6);
 	g_assert_cmpint (nm_setting_ip6_config_get_ip6_privacy (NM_SETTING_IP6_CONFIG (s_ip6)), ==, NM_SETTING_IP6_CONFIG_PRIVACY_PREFER_TEMP_ADDR);
@@ -2528,17 +2297,9 @@ test_read_flags_property (void)
 {
 	gs_unref_object NMConnection *connection = NULL;
 	NMSettingGsm *s_gsm;
-	gs_free_error GError *error = NULL;
-	gboolean success;
 
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR"/Test_Flags_Property", &error);
-	g_assert_no_error (error);
-	g_assert (connection);
-	success = nm_connection_verify (connection, &error);
-	g_assert_no_error (error);
-	g_assert (success);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR"/Test_Flags_Property");
 
-	/* GSM setting */
 	s_gsm = nm_connection_get_setting_gsm (connection);
 	g_assert (s_gsm);
 	g_assert_cmpint (nm_setting_gsm_get_password_flags (s_gsm), ==,
@@ -2591,14 +2352,8 @@ test_read_tc_config (void)
 	NMTCQdisc *qdisc1, *qdisc2;
 	NMTCAction *action1, *action2;
 	NMTCTfilter *tfilter1, *tfilter2;
-	gs_free_error GError *error = NULL;
-	gboolean success;
 
-	connection = nms_keyfile_reader_from_file (TEST_KEYFILES_DIR "/Test_TC_Config", NULL);
-	g_assert (connection);
-	success = nm_connection_verify (connection, &error);
-	g_assert_no_error (error);
-	g_assert (success);
+	connection = keyfile_read_connection_from_file (TEST_KEYFILES_DIR "/Test_TC_Config");
 
 	s_tc = nm_connection_get_setting_tc_config (connection);
 	g_assert (s_tc);

--- a/src/settings/plugins/keyfile/tests/test-keyfile.c
+++ b/src/settings/plugins/keyfile/tests/test-keyfile.c
@@ -1537,7 +1537,6 @@ test_write_wired_8021x_tls_connection_path (void)
 	char *tmp, *tmp2;
 	gboolean success;
 	gs_free char *testfile = NULL;
-	gs_free_error GError *error = NULL;
 	gs_unref_keyfile GKeyFile *keyfile = NULL;
 	gboolean relative = FALSE;
 	gboolean reread_same = FALSE;
@@ -1620,7 +1619,6 @@ test_write_wired_8021x_tls_connection_blob (void)
 	char *new_priv_key;
 	const char *uuid;
 	gboolean reread_same = FALSE;
-	gs_free_error GError *error = NULL;
 	GBytes *password_raw;
 
 #define PASSWORD_RAW "password-raw\0test"


### PR DESCRIPTION
We are about to release 1.14.2

nm-1-14 branch recently saw backports of lr/initrd branch. This introduced a new keyfile directory `/var/run/NetworkManager/system-connections`.

I think it's important to iron details out before release, because this affects how keyfiles are persisted to disk. It will be hard to do changes later which prevent to read configurations written by an older version of NetworkManager.


These are all clean backports from master branch, that bring two bits:

- files in /run must have a file extension `.nmconnection`.
- keyfiles allow that `connection.uuid` is missing. In that case it is computed by MD5 hashing the full path. The problem is now, if we have two files `/etc/NetworkManager/system-connection/lala.nmconnection` and `/run/NetworkManager/system-connection/lala.nmconnection`, then they both should generate the same UUID. This is also important, if you copy a keyfile from one directory to another. Then the UUID shouldn't change. The solution is here, to always hash the etc-dirname + basename, regardless of the actual path.

Open pull request, mainly for CI.