### PR TITLE
th/file-is-in-path

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1453,6 +1453,8 @@ src_libsystemd_nm_la_libadd = \
 src_libsystemd_nm_la_SOURCES = \
 	src/systemd/nm-sd.c \
 	src/systemd/nm-sd.h \
+	src/systemd/nm-sd-utils.c \
+	src/systemd/nm-sd-utils.h \
 	src/systemd/sd-adapt/nm-sd-adapt.c \
 	src/systemd/sd-adapt/nm-sd-adapt.h \
 	src/systemd/sd-adapt/architecture.h \

--- a/src/NetworkManagerUtils.h
+++ b/src/NetworkManagerUtils.h
@@ -86,4 +86,10 @@ void nm_shutdown_wait_obj_unregister (NMShutdownWaitObjHandle *handle);
 
 /*****************************************************************************/
 
+const char *
+nm_utils_file_is_in_path (const char *abs_filename,
+                          const char *abs_path);
+
+/*****************************************************************************/
+
 #endif /* __NETWORKMANAGER_UTILS_H__ */

--- a/src/nm-core-utils.c
+++ b/src/nm-core-utils.c
@@ -47,6 +47,10 @@
 #include "nm-setting-wireless.h"
 #include "nm-setting-wireless-security.h"
 
+#ifdef __NM_SD_UTILS_H__
+#error "nm-core-utils.c should stay independent of systemd utils. Are you looking for NetworkMangerUtils.c? "
+#endif
+
 G_STATIC_ASSERT (sizeof (NMUtilsTestFlags) <= sizeof (int));
 static int _nm_utils_testing = 0;
 

--- a/src/settings/plugins/ifcfg-rh/nms-ifcfg-rh-plugin.c
+++ b/src/settings/plugins/ifcfg-rh/nms-ifcfg-rh-plugin.c
@@ -602,12 +602,9 @@ load_connection (NMSettingsPlugin *config,
 {
 	SettingsPluginIfcfg *plugin = SETTINGS_PLUGIN_IFCFG (config);
 	NMIfcfgConnection *connection;
-	int dir_len = strlen (IFCFG_DIR);
 	char *ifcfg_path;
 
-	if (   strncmp (filename, IFCFG_DIR, dir_len) != 0
-	    || filename[dir_len] != '/'
-	    || strchr (filename + dir_len + 1, '/') != NULL)
+	if (!nm_utils_file_is_in_path (filename, IFCFG_DIR))
 		return FALSE;
 
 	/* get the real ifcfg-path. This allows us to properly

--- a/src/systemd/meson.build
+++ b/src/systemd/meson.build
@@ -49,7 +49,8 @@ sources = files(
   'src/libsystemd/sd-id128/id128-util.c',
   'src/libsystemd/sd-id128/sd-id128.c',
   'src/shared/dns-domain.c',
-  'nm-sd.c'
+  'nm-sd.c',
+  'nm-sd-utils.c',
 )
 
 incs = [

--- a/src/systemd/nm-sd-utils.c
+++ b/src/systemd/nm-sd-utils.c
@@ -1,0 +1,45 @@
+/* This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ * Copyright (C) 2018 Red Hat, Inc.
+ */
+
+#include "nm-default.h"
+
+#include "nm-sd-utils.h"
+
+#include "nm-sd-adapt.h"
+
+#include "path-util.h"
+
+/*****************************************************************************/
+
+gboolean
+nm_sd_utils_path_equal (const char *a, const char *b)
+{
+	return path_equal (a, b);
+}
+
+char *
+nm_sd_utils_path_simplify (char *path, gboolean kill_dots)
+{
+	return path_simplify (path, kill_dots);
+}
+
+const char *
+nm_sd_utils_path_startswith (const char *path, const char *prefix)
+{
+	return path_startswith (path, prefix);
+}

--- a/src/systemd/nm-sd-utils.h
+++ b/src/systemd/nm-sd-utils.h
@@ -1,0 +1,33 @@
+/* This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ * Copyright (C) 2018 Red Hat, Inc.
+ */
+
+#ifndef __NM_SD_UTILS_H__
+#define __NM_SD_UTILS_H__
+
+/*****************************************************************************/
+
+gboolean nm_sd_utils_path_equal (const char *a, const char *b);
+
+char *nm_sd_utils_path_simplify (char *path, gboolean kill_dots);
+
+const char *nm_sd_utils_path_startswith (const char *path, const char *prefix);
+
+/*****************************************************************************/
+
+#endif /* __NM_SD_UTILS_H__ */
+

--- a/src/systemd/src/basic/path-util.c
+++ b/src/systemd/src/basic/path-util.c
@@ -337,11 +337,14 @@ char *path_simplify(char *path, bool kill_dots) {
         /* Removes redundant inner and trailing slashes. Also removes unnecessary dots
          * if kill_dots is true. Modifies the passed string in-place.
          *
-         * ///foo//./bar/.   becomes /foo/./bar/.  (if kill_dots is false)
-         * ///foo//./bar/.   becomes /foo/bar      (if kill_dots is true)
-         * .//./foo//./bar/. becomes ./foo/bar     (if kill_dots is false)
-         * .//./foo//./bar/. becomes foo/bar       (if kill_dots is true)
+         * ///foo//./bar/.   becomes /foo/./bar/.      (if kill_dots is false)
+         * ///foo//./bar/.   becomes /foo/bar          (if kill_dots is true)
+         * .//./foo//./bar/. becomes ././foo/./bar/.   (if kill_dots is false)
+         * .//./foo//./bar/. becomes foo/bar           (if kill_dots is true)
          */
+
+        if (isempty(path))
+            return path;
 
         absolute = path_is_absolute(path);
 
@@ -372,9 +375,14 @@ char *path_simplify(char *path, bool kill_dots) {
                 *(t++) = *f;
         }
 
-        /* Special rule, if we are talking of the root directory, a trailing slash is good */
-        if (absolute && t == path)
-                *(t++) = '/';
+        /* Special rule, if we stripped everything, we either need a "/" (for the root directory)
+         * or "." for the current directory */
+        if (t == path) {
+                if (absolute)
+                        *(t++) = '/';
+                else
+                        *(t++) = '.';
+        }
 
         *t = 0;
         return path;

--- a/src/systemd/src/basic/path-util.c
+++ b/src/systemd/src/basic/path-util.c
@@ -380,7 +380,6 @@ char *path_simplify(char *path, bool kill_dots) {
         return path;
 }
 
-#if 0 /* NM_IGNORED */
 char* path_startswith(const char *path, const char *prefix) {
         assert(path);
         assert(prefix);
@@ -423,7 +422,6 @@ char* path_startswith(const char *path, const char *prefix) {
                 prefix += b;
         }
 }
-#endif /* NM_IGNORED */
 
 int path_compare(const char *a, const char *b) {
         int d;

--- a/src/tests/test-general.c
+++ b/src/tests/test-general.c
@@ -1845,6 +1845,25 @@ test_nm_utils_exp10 (void)
 
 /*****************************************************************************/
 
+static void
+test_utils_file_is_in_path (void)
+{
+	g_assert (!nm_utils_file_is_in_path ("/", "/"));
+	g_assert (!nm_utils_file_is_in_path ("//", "/"));
+	g_assert (!nm_utils_file_is_in_path ("/a/", "/"));
+	g_assert ( nm_utils_file_is_in_path ("/a", "/"));
+	g_assert ( nm_utils_file_is_in_path ("///a", "/"));
+	g_assert ( nm_utils_file_is_in_path ("//b/a", "/b//"));
+	g_assert ( nm_utils_file_is_in_path ("//b///a", "/b//"));
+	g_assert (!nm_utils_file_is_in_path ("//b///a/", "/b//"));
+	g_assert (!nm_utils_file_is_in_path ("//b///a/", "/b/a/"));
+	g_assert (!nm_utils_file_is_in_path ("//b///a", "/b/a/"));
+	g_assert ( nm_utils_file_is_in_path ("//b///a/.", "/b/a/"));
+	g_assert ( nm_utils_file_is_in_path ("//b///a/..", "/b/a/"));
+}
+
+/*****************************************************************************/
+
 NMTST_DEFINE ();
 
 int
@@ -1890,6 +1909,8 @@ main (int argc, char **argv)
 
 	g_test_add_func ("/general/stable-id/parse", test_stable_id_parse);
 	g_test_add_func ("/general/stable-id/generated-complete", test_stable_id_generated_complete);
+
+	g_test_add_func ("/general/test_utils_file_is_in_path", test_utils_file_is_in_path);
 
 	return g_test_run ();
 }

--- a/src/tests/test-systemd.c
+++ b/src/tests/test-systemd.c
@@ -201,16 +201,16 @@ test_path_equal (void)
 	} G_STMT_END
 
 	_path_equal_check ("",                  "",                NULL);
-	_path_equal_check (".",                 ".",               "");
+	_path_equal_check (".",                 ".",               NULL);
 	_path_equal_check ("..",                "..",              NULL);
 	_path_equal_check ("/..",               "/..",             NULL);
 	_path_equal_check ("//..",              "/..",             NULL);
 	_path_equal_check ("/.",                "/.",              "/");
-	_path_equal_check ("./",                ".",               "");
-	_path_equal_check ("./.",               "./.",             "");
-	_path_equal_check (".///.",             "./.",             "");
-	_path_equal_check (".///./",            "./.",             "");
-	_path_equal_check (".////",             ".",               "");
+	_path_equal_check ("./",                ".",               ".");
+	_path_equal_check ("./.",               "./.",             ".");
+	_path_equal_check (".///.",             "./.",             ".");
+	_path_equal_check (".///./",            "./.",             ".");
+	_path_equal_check (".////",             ".",               ".");
 	_path_equal_check ("//..//foo/",        "/../foo",         NULL);
 	_path_equal_check ("///foo//./bar/.",   "/foo/./bar/.",    "/foo/bar");
 	_path_equal_check (".//./foo//./bar/.", "././foo/./bar/.", "foo/bar");

--- a/src/tests/test-systemd.c
+++ b/src/tests/test-systemd.c
@@ -20,6 +20,7 @@
 #include "nm-default.h"
 
 #include "systemd/nm-sd.h"
+#include "systemd/nm-sd-utils.h"
 
 #include "nm-test-utils-core.h"
 
@@ -173,6 +174,50 @@ test_sd_event (void)
 
 /*****************************************************************************/
 
+static void
+test_path_equal (void)
+{
+#define _path_equal_check1(path, kill_dots, expected) \
+	G_STMT_START { \
+		const gboolean _kill_dots = (kill_dots); \
+		const char *_path0 = (path); \
+		const char *_expected = (expected); \
+		gs_free char *_path = g_strdup (_path0); \
+		const char *_path_result; \
+		\
+		if (   !_kill_dots \
+		    && !nm_sd_utils_path_equal (_path0, _expected)) \
+			g_error ("Paths \"%s\" and \"%s\" don't compare equal", _path0, _expected); \
+		\
+		_path_result = nm_sd_utils_path_simplify (_path, _kill_dots); \
+		g_assert (_path_result == _path); \
+		g_assert_cmpstr (_path, ==, _expected); \
+	} G_STMT_END
+
+#define _path_equal_check(path, expected_no_kill_dots, expected_kill_dots) \
+	G_STMT_START { \
+		_path_equal_check1 (path, FALSE, expected_no_kill_dots); \
+		_path_equal_check1 (path, TRUE,  expected_kill_dots ?: expected_no_kill_dots); \
+	} G_STMT_END
+
+	_path_equal_check ("",                  "",                NULL);
+	_path_equal_check (".",                 ".",               "");
+	_path_equal_check ("..",                "..",              NULL);
+	_path_equal_check ("/..",               "/..",             NULL);
+	_path_equal_check ("//..",              "/..",             NULL);
+	_path_equal_check ("/.",                "/.",              "/");
+	_path_equal_check ("./",                ".",               "");
+	_path_equal_check ("./.",               "./.",             "");
+	_path_equal_check (".///.",             "./.",             "");
+	_path_equal_check (".///./",            "./.",             "");
+	_path_equal_check (".////",             ".",               "");
+	_path_equal_check ("//..//foo/",        "/../foo",         NULL);
+	_path_equal_check ("///foo//./bar/.",   "/foo/./bar/.",    "/foo/bar");
+	_path_equal_check (".//./foo//./bar/.", "././foo/./bar/.", "foo/bar");
+}
+
+/*****************************************************************************/
+
 NMTST_DEFINE ();
 
 int
@@ -183,6 +228,7 @@ main (int argc, char **argv)
 	g_test_add_func ("/systemd/dhcp/create", test_dhcp_create);
 	g_test_add_func ("/systemd/lldp/create", test_lldp_create);
 	g_test_add_func ("/systemd/sd-event", test_sd_event);
+	g_test_add_func ("/systemd/test_path_equal", test_path_equal);
 
 	return g_test_run ();
 }


### PR DESCRIPTION
add a helper function for checking whether a file is inside a patch. With this,
`nmcli connection load //etc/NetworkManager/system-connections/profile` no longer fails

Also, there is something new here: I expose and use API from internal `src/systemd`. Up to now, we avoided that, and only used a minimal of systemd code that we required. I think there are a loot of goodies there, and we should carefully pick a few that we like and use them. Of course, we need to add unit-tests for them (ensuring that a future systemd import won't break them).

Also, don't directly include systemd code, because then it easily gets out of hand. Instead, have one particular header `src/systemd/nm-sd-utils.h` which exposes this functionality in a clean way.