### PR TITLE
th/keyfile-filename-utils

### DIFF
--- a/libnm-core/nm-keyfile-internal.h
+++ b/libnm-core/nm-keyfile-internal.h
@@ -170,12 +170,12 @@ gboolean _nm_keyfile_has_values (GKeyFile *keyfile);
 
 /*****************************************************************************/
 
-#define NM_CONFIG_KEYFILE_PATH_IN_MEMORY NMRUNDIR "/system-connections"
+#define NM_KEYFILE_PATH_NAME_RUN                 NMRUNDIR "/system-connections"
 
-#define NMS_KEYFILE_PATH_SUFFIX_NMCONNECTION      ".nmconnection"
+#define NM_KEYFILE_PATH_SUFFIX_NMCONNECTION      ".nmconnection"
 
-gboolean nms_keyfile_utils_should_ignore_file (const char *filename, gboolean require_extension);
+gboolean nm_keyfile_utils_ignore_filename (const char *filename, gboolean require_extension);
 
-char *nms_keyfile_utils_escape_filename (const char *filename, gboolean with_extension);
+char *nm_keyfile_utils_create_filename (const char *filename, gboolean with_extension);
 
 #endif /* __NM_KEYFILE_INTERNAL_H__ */

--- a/libnm-core/nm-keyfile-internal.h
+++ b/libnm-core/nm-keyfile-internal.h
@@ -170,6 +170,7 @@ gboolean _nm_keyfile_has_values (GKeyFile *keyfile);
 
 /*****************************************************************************/
 
+#define NM_KEYFILE_PATH_NAME_ETC_DEFAULT         NMCONFDIR "/system-connections"
 #define NM_KEYFILE_PATH_NAME_RUN                 NMRUNDIR "/system-connections"
 
 #define NM_KEYFILE_PATH_SUFFIX_NMCONNECTION      ".nmconnection"

--- a/libnm-core/nm-keyfile-internal.h
+++ b/libnm-core/nm-keyfile-internal.h
@@ -168,4 +168,14 @@ gboolean _nm_keyfile_a_contains_all_in_b (GKeyFile *kf_a, GKeyFile *kf_b);
 gboolean _nm_keyfile_equals (GKeyFile *kf_a, GKeyFile *kf_b, gboolean consider_order);
 gboolean _nm_keyfile_has_values (GKeyFile *keyfile);
 
+/*****************************************************************************/
+
+#define NM_CONFIG_KEYFILE_PATH_IN_MEMORY NMRUNDIR "/system-connections"
+
+#define NMS_KEYFILE_PATH_SUFFIX_NMCONNECTION      ".nmconnection"
+
+gboolean nms_keyfile_utils_should_ignore_file (const char *filename, gboolean require_extension);
+
+char *nms_keyfile_utils_escape_filename (const char *filename, gboolean with_extension);
+
 #endif /* __NM_KEYFILE_INTERNAL_H__ */

--- a/libnm-core/nm-keyfile.c
+++ b/libnm-core/nm-keyfile.c
@@ -3205,7 +3205,7 @@ check_suffix (const char *base, const char *tag)
 #define DER_TAG ".der"
 
 gboolean
-nms_keyfile_utils_should_ignore_file (const char *filename, gboolean require_extension)
+nm_keyfile_utils_ignore_filename (const char *filename, gboolean require_extension)
 {
 	gs_free char *base = NULL;
 
@@ -3228,8 +3228,8 @@ nms_keyfile_utils_should_ignore_file (const char *filename, gboolean require_ext
 	if (require_extension) {
 		gsize l = strlen (base);
 
-		if (   l <= NM_STRLEN (NMS_KEYFILE_PATH_SUFFIX_NMCONNECTION)
-		    || !g_str_has_suffix (base, NMS_KEYFILE_PATH_SUFFIX_NMCONNECTION))
+		if (   l <= NM_STRLEN (NM_KEYFILE_PATH_SUFFIX_NMCONNECTION)
+		    || !g_str_has_suffix (base, NM_KEYFILE_PATH_SUFFIX_NMCONNECTION))
 			return TRUE;
 	}
 
@@ -3237,11 +3237,11 @@ nms_keyfile_utils_should_ignore_file (const char *filename, gboolean require_ext
 }
 
 char *
-nms_keyfile_utils_escape_filename (const char *filename,
-                                   gboolean with_extension)
+nm_keyfile_utils_create_filename (const char *name,
+                                  gboolean with_extension)
 {
 	GString *str;
-	const char *f = filename;
+	const char *f = name;
 	/* keyfile used to escape with '*', do not change that behavior.
 	 *
 	 * But for newly added escapings, use '_' instead.
@@ -3249,12 +3249,12 @@ nms_keyfile_utils_escape_filename (const char *filename,
 	const char ESCAPE_CHAR = with_extension ? '_' : '*';
 	const char ESCAPE_CHAR2 = '_';
 
-	g_return_val_if_fail (filename && filename[0], NULL);
+	g_return_val_if_fail (name && name[0], NULL);
 
 	str = g_string_sized_new (60);
 
 	/* Convert '/' to ESCAPE_CHAR */
-	for (f = filename; f[0]; f++) {
+	for (f = name; f[0]; f++) {
 		if (f[0] == '/')
 			g_string_append_c (str, ESCAPE_CHAR);
 		else
@@ -3273,7 +3273,7 @@ nms_keyfile_utils_escape_filename (const char *filename,
 		g_string_append_c (str, ESCAPE_CHAR2);
 
 	if (with_extension)
-		g_string_append (str, NMS_KEYFILE_PATH_SUFFIX_NMCONNECTION);
+		g_string_append (str, NM_KEYFILE_PATH_SUFFIX_NMCONNECTION);
 
 	return g_string_free (str, FALSE);;
 }

--- a/libnm-core/nm-keyfile.c
+++ b/libnm-core/nm-keyfile.c
@@ -3153,3 +3153,127 @@ nm_keyfile_write (NMConnection *connection,
 
 	return info.keyfile;
 }
+
+/*****************************************************************************/
+
+static const char temp_letters[] =
+"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+/*
+ * Check '.[a-zA-Z0-9]{6}' file suffix used for temporary files by g_file_set_contents() (mkstemp()).
+ */
+static gboolean
+check_mkstemp_suffix (const char *path)
+{
+	const char *ptr;
+
+	g_return_val_if_fail (path != NULL, FALSE);
+
+	/* Matches *.[a-zA-Z0-9]{6} suffix of mkstemp()'s temporary files */
+	ptr = strrchr (path, '.');
+	if (ptr && (strspn (ptr + 1, temp_letters) == 6) && (! ptr[7]))
+		return TRUE;
+	return FALSE;
+}
+
+static gboolean
+check_prefix_dot (const char *base)
+{
+	nm_assert (base && base[0]);
+
+	return base[0] == '.';
+}
+
+static gboolean
+check_suffix (const char *base, const char *tag)
+{
+	int len, tag_len;
+
+	g_return_val_if_fail (base != NULL, TRUE);
+	g_return_val_if_fail (tag != NULL, TRUE);
+
+	len = strlen (base);
+	tag_len = strlen (tag);
+	if ((len > tag_len) && !g_ascii_strcasecmp (base + len - tag_len, tag))
+		return TRUE;
+	return FALSE;
+}
+
+#define SWP_TAG ".swp"
+#define SWPX_TAG ".swpx"
+#define PEM_TAG ".pem"
+#define DER_TAG ".der"
+
+gboolean
+nms_keyfile_utils_should_ignore_file (const char *filename, gboolean require_extension)
+{
+	gs_free char *base = NULL;
+
+	g_return_val_if_fail (filename != NULL, TRUE);
+
+	base = g_path_get_basename (filename);
+	g_return_val_if_fail (base != NULL, TRUE);
+
+	/* Ignore hidden and backup files */
+	/* should_ignore_file() must mirror escape_filename() */
+	if (check_prefix_dot (base) || check_suffix (base, "~"))
+		return TRUE;
+	/* Ignore temporary files */
+	if (check_mkstemp_suffix (base))
+		return TRUE;
+	/* Ignore 802.1x certificates and keys */
+	if (check_suffix (base, PEM_TAG) || check_suffix (base, DER_TAG))
+		return TRUE;
+
+	if (require_extension) {
+		gsize l = strlen (base);
+
+		if (   l <= NM_STRLEN (NMS_KEYFILE_PATH_SUFFIX_NMCONNECTION)
+		    || !g_str_has_suffix (base, NMS_KEYFILE_PATH_SUFFIX_NMCONNECTION))
+			return TRUE;
+	}
+
+	return FALSE;
+}
+
+char *
+nms_keyfile_utils_escape_filename (const char *filename,
+                                   gboolean with_extension)
+{
+	GString *str;
+	const char *f = filename;
+	/* keyfile used to escape with '*', do not change that behavior.
+	 *
+	 * But for newly added escapings, use '_' instead.
+	 * Also, @with_extension is new-style. */
+	const char ESCAPE_CHAR = with_extension ? '_' : '*';
+	const char ESCAPE_CHAR2 = '_';
+
+	g_return_val_if_fail (filename && filename[0], NULL);
+
+	str = g_string_sized_new (60);
+
+	/* Convert '/' to ESCAPE_CHAR */
+	for (f = filename; f[0]; f++) {
+		if (f[0] == '/')
+			g_string_append_c (str, ESCAPE_CHAR);
+		else
+			g_string_append_c (str, f[0]);
+	}
+
+	/* escape_filename() must avoid anything that should_ignore_file() would reject.
+	 * We can escape here more aggressivly then what we would read back. */
+	if (check_prefix_dot (str->str))
+		str->str[0] = ESCAPE_CHAR2;
+	if (check_suffix (str->str, "~"))
+		str->str[str->len - 1] = ESCAPE_CHAR2;
+	if (   check_mkstemp_suffix (str->str)
+	    || check_suffix (str->str, PEM_TAG)
+	    || check_suffix (str->str, DER_TAG))
+		g_string_append_c (str, ESCAPE_CHAR2);
+
+	if (with_extension)
+		g_string_append (str, NMS_KEYFILE_PATH_SUFFIX_NMCONNECTION);
+
+	return g_string_free (str, FALSE);;
+}

--- a/src/initrd/nm-initrd-generator.c
+++ b/src/initrd/nm-initrd-generator.c
@@ -60,9 +60,8 @@ output_conn (gpointer key, gpointer value, gpointer user_data)
 		gs_free char *filename = NULL;
 		gs_free char *full_filename = NULL;
 
-		full_filename = g_build_filename (connections_dir,
-		                                  nm_construct_name_a ("%s.nmconnection", basename, &filename),
-		                                  NULL);
+		filename = nm_keyfile_utils_create_filename (basename, TRUE);
+		full_filename = g_build_filename (connections_dir, filename,NULL);
 
 		if (!nm_utils_file_set_contents (filename, data, len, 0600, &error))
 			goto err_out;
@@ -74,7 +73,6 @@ err_out:
 	g_print ("%s\n", error->message);
 }
 
-#define DEFAULT_CONNECTIONS_DIR  NMRUNDIR "/system-connections"
 #define DEFAULT_SYSFS_DIR        "/sys"
 
 int
@@ -86,7 +84,7 @@ main (int argc, char *argv[])
 	gboolean dump_to_stdout = FALSE;
 	gs_strfreev char **remaining = NULL;
 	GOptionEntry option_entries[] = {
-		{ "connections-dir", 'c', 0, G_OPTION_ARG_FILENAME, &connections_dir, "Output connection directory", DEFAULT_CONNECTIONS_DIR },
+		{ "connections-dir", 'c', 0, G_OPTION_ARG_FILENAME, &connections_dir, "Output connection directory", NM_KEYFILE_PATH_NAME_RUN },
 		{ "sysfs-dir", 'd', 0, G_OPTION_ARG_FILENAME, &sysfs_dir, "The sysfs mount point", DEFAULT_SYSFS_DIR },
 		{ "stdout", 's', 0, G_OPTION_ARG_NONE, &dump_to_stdout, "Dump connections to standard output", NULL },
 		{ G_OPTION_REMAINING, '\0', 0, G_OPTION_ARG_STRING_ARRAY, &remaining, NULL, NULL },
@@ -116,7 +114,7 @@ main (int argc, char *argv[])
 	}
 
 	if (!connections_dir)
-		connections_dir = g_strdup (DEFAULT_CONNECTIONS_DIR);
+		connections_dir = g_strdup (NM_KEYFILE_PATH_NAME_RUN);
 	if (!sysfs_dir)
 		sysfs_dir = g_strdup (DEFAULT_SYSFS_DIR);
 	if (dump_to_stdout)

--- a/src/settings/plugins/keyfile/nms-keyfile-plugin.c
+++ b/src/settings/plugins/keyfile/nms-keyfile-plugin.c
@@ -182,8 +182,8 @@ update_connection (NMSKeyfilePlugin *self,
 
 	if (g_str_has_prefix (full_path, nms_keyfile_utils_get_path ())) {
 		dir_len = strlen (nms_keyfile_utils_get_path ());
-	} else if (g_str_has_prefix (full_path, NM_CONFIG_KEYFILE_PATH_IN_MEMORY)) {
-		dir_len = NM_STRLEN (NM_CONFIG_KEYFILE_PATH_IN_MEMORY);
+	} else if (g_str_has_prefix (full_path, NM_KEYFILE_PATH_NAME_RUN)) {
+		dir_len = NM_STRLEN (NM_KEYFILE_PATH_NAME_RUN);
 	} else {
 		/* Just make sure the file name is not going go pass the following check. */
 		dir_len = strlen (full_path);
@@ -323,7 +323,7 @@ dir_changed (GFileMonitor *monitor,
 	gboolean exists;
 
 	full_path = g_file_get_path (file);
-	if (nms_keyfile_utils_should_ignore_file (full_path, FALSE)) {
+	if (nm_keyfile_utils_ignore_filename (full_path, FALSE)) {
 		g_free (full_path);
 		return;
 	}
@@ -445,7 +445,7 @@ _read_dir (GPtrArray *filenames,
 	}
 
 	while ((item = g_dir_read_name (dir))) {
-		if (nms_keyfile_utils_should_ignore_file (item, require_extension))
+		if (nm_keyfile_utils_ignore_filename (item, require_extension))
 			continue;
 		g_ptr_array_add (filenames, g_build_filename (path, item, NULL));
 	}
@@ -468,7 +468,7 @@ read_connections (NMSettingsPlugin *config)
 
 	filenames = g_ptr_array_new_with_free_func (g_free);
 
-	_read_dir (filenames, NM_CONFIG_KEYFILE_PATH_IN_MEMORY, TRUE);
+	_read_dir (filenames, NM_KEYFILE_PATH_NAME_RUN, TRUE);
 	_read_dir (filenames, nms_keyfile_utils_get_path (), FALSE);
 
 	alive_connections = g_hash_table_new (nm_direct_hash, NULL);
@@ -573,12 +573,12 @@ load_connection (NMSettingsPlugin *config,
 	 * which would actually also point to the same file. */
 	if (_file_is_in_path (filename, nms_keyfile_utils_get_path ()))
 		require_extension = FALSE;
-	else if (_file_is_in_path (filename, NM_CONFIG_KEYFILE_PATH_IN_MEMORY))
+	else if (_file_is_in_path (filename, NM_KEYFILE_PATH_NAME_RUN))
 		require_extension = TRUE;
 	else
 		return FALSE;
 
-	if (nms_keyfile_utils_should_ignore_file (filename, require_extension))
+	if (nm_keyfile_utils_ignore_filename (filename, require_extension))
 		return FALSE;
 
 	connection = update_connection (self, NULL, filename, find_by_path (self, filename), TRUE, NULL, NULL);

--- a/src/settings/plugins/keyfile/nms-keyfile-plugin.c
+++ b/src/settings/plugins/keyfile/nms-keyfile-plugin.c
@@ -36,6 +36,7 @@
 #include "nm-utils.h"
 #include "nm-config.h"
 #include "nm-core-internal.h"
+#include "nm-keyfile-internal.h"
 
 #include "settings/nm-settings-plugin.h"
 

--- a/src/settings/plugins/keyfile/nms-keyfile-reader.c
+++ b/src/settings/plugins/keyfile/nms-keyfile-reader.c
@@ -142,11 +142,11 @@ nms_keyfile_reader_from_keyfile (GKeyFile *key_file,
 	if (!connection)
 		return NULL;
 
-	if (g_str_has_suffix (filename, NMS_KEYFILE_PATH_SUFFIX_NMCONNECTION)) {
+	if (g_str_has_suffix (filename, NM_KEYFILE_PATH_SUFFIX_NMCONNECTION)) {
 		gsize l = strlen (filename);
 
-		if (l > NM_STRLEN (NMS_KEYFILE_PATH_SUFFIX_NMCONNECTION))
-			filename_id = g_strndup (filename, l - NM_STRLEN (NMS_KEYFILE_PATH_SUFFIX_NMCONNECTION));
+		if (l > NM_STRLEN (NM_KEYFILE_PATH_SUFFIX_NMCONNECTION))
+			filename_id = g_strndup (filename, l - NM_STRLEN (NM_KEYFILE_PATH_SUFFIX_NMCONNECTION));
 	}
 
 	nm_keyfile_read_ensure_id (connection, filename_id ?: filename);

--- a/src/settings/plugins/keyfile/nms-keyfile-utils.c
+++ b/src/settings/plugins/keyfile/nms-keyfile-utils.c
@@ -26,12 +26,11 @@
 #include <string.h>
 #include <sys/stat.h>
 
+#include "nm-keyfile-internal.h"
 #include "nm-setting-wired.h"
 #include "nm-setting-wireless.h"
 #include "nm-setting-wireless-security.h"
 #include "nm-config.h"
-
-#define NM_CONFIG_KEYFILE_PATH_DEFAULT NMCONFDIR "/system-connections"
 
 /*****************************************************************************/
 
@@ -103,7 +102,7 @@ nms_keyfile_utils_get_path (void)
 		                                 NM_CONFIG_KEYFILE_KEY_KEYFILE_PATH,
 		                                 NM_CONFIG_GET_VALUE_STRIP | NM_CONFIG_GET_VALUE_NO_EMPTY);
 		if (!path)
-			path = g_strdup (""NM_CONFIG_KEYFILE_PATH_DEFAULT"");
+			path = g_strdup (""NM_KEYFILE_PATH_NAME_ETC_DEFAULT"");
 	}
 	return path;
 }

--- a/src/settings/plugins/keyfile/nms-keyfile-utils.c
+++ b/src/settings/plugins/keyfile/nms-keyfile-utils.c
@@ -35,88 +35,6 @@
 
 /*****************************************************************************/
 
-static const char temp_letters[] =
-"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-
-/*
- * Check '.[a-zA-Z0-9]{6}' file suffix used for temporary files by g_file_set_contents() (mkstemp()).
- */
-static gboolean
-check_mkstemp_suffix (const char *path)
-{
-	const char *ptr;
-
-	g_return_val_if_fail (path != NULL, FALSE);
-
-	/* Matches *.[a-zA-Z0-9]{6} suffix of mkstemp()'s temporary files */
-	ptr = strrchr (path, '.');
-	if (ptr && (strspn (ptr + 1, temp_letters) == 6) && (! ptr[7]))
-		return TRUE;
-	return FALSE;
-}
-
-static gboolean
-check_prefix_dot (const char *base)
-{
-	nm_assert (base && base[0]);
-
-	return base[0] == '.';
-}
-
-static gboolean
-check_suffix (const char *base, const char *tag)
-{
-	int len, tag_len;
-
-	g_return_val_if_fail (base != NULL, TRUE);
-	g_return_val_if_fail (tag != NULL, TRUE);
-
-	len = strlen (base);
-	tag_len = strlen (tag);
-	if ((len > tag_len) && !g_ascii_strcasecmp (base + len - tag_len, tag))
-		return TRUE;
-	return FALSE;
-}
-
-#define SWP_TAG ".swp"
-#define SWPX_TAG ".swpx"
-#define PEM_TAG ".pem"
-#define DER_TAG ".der"
-
-gboolean
-nms_keyfile_utils_should_ignore_file (const char *filename, gboolean require_extension)
-{
-	gs_free char *base = NULL;
-
-	g_return_val_if_fail (filename != NULL, TRUE);
-
-	base = g_path_get_basename (filename);
-	g_return_val_if_fail (base != NULL, TRUE);
-
-	/* Ignore hidden and backup files */
-	/* should_ignore_file() must mirror escape_filename() */
-	if (check_prefix_dot (base) || check_suffix (base, "~"))
-		return TRUE;
-	/* Ignore temporary files */
-	if (check_mkstemp_suffix (base))
-		return TRUE;
-	/* Ignore 802.1x certificates and keys */
-	if (check_suffix (base, PEM_TAG) || check_suffix (base, DER_TAG))
-		return TRUE;
-
-	if (require_extension) {
-		gsize l = strlen (base);
-
-		if (   l <= NM_STRLEN (NMS_KEYFILE_PATH_SUFFIX_NMCONNECTION)
-		    || !g_str_has_suffix (base, NMS_KEYFILE_PATH_SUFFIX_NMCONNECTION))
-			return TRUE;
-	}
-
-	return FALSE;
-}
-
-/*****************************************************************************/
-
 gboolean
 nms_keyfile_utils_check_file_permissions_stat (const struct stat *st,
                                                GError **error)
@@ -170,50 +88,6 @@ nms_keyfile_utils_check_file_permissions (const char *filename,
 
 	NM_SET_OUT (out_st, st);
 	return TRUE;
-}
-
-/*****************************************************************************/
-
-char *
-nms_keyfile_utils_escape_filename (const char *filename,
-                                   gboolean with_extension)
-{
-	GString *str;
-	const char *f = filename;
-	/* keyfile used to escape with '*', do not change that behavior.
-	 *
-	 * But for newly added escapings, use '_' instead.
-	 * Also, @with_extension is new-style. */
-	const char ESCAPE_CHAR = with_extension ? '_' : '*';
-	const char ESCAPE_CHAR2 = '_';
-
-	g_return_val_if_fail (filename && filename[0], NULL);
-
-	str = g_string_sized_new (60);
-
-	/* Convert '/' to ESCAPE_CHAR */
-	for (f = filename; f[0]; f++) {
-		if (f[0] == '/')
-			g_string_append_c (str, ESCAPE_CHAR);
-		else
-			g_string_append_c (str, f[0]);
-	}
-
-	/* escape_filename() must avoid anything that should_ignore_file() would reject.
-	 * We can escape here more aggressivly then what we would read back. */
-	if (check_prefix_dot (str->str))
-		str->str[0] = ESCAPE_CHAR2;
-	if (check_suffix (str->str, "~"))
-		str->str[str->len - 1] = ESCAPE_CHAR2;
-	if (   check_mkstemp_suffix (str->str)
-	    || check_suffix (str->str, PEM_TAG)
-	    || check_suffix (str->str, DER_TAG))
-		g_string_append_c (str, ESCAPE_CHAR2);
-
-	if (with_extension)
-		g_string_append (str, NMS_KEYFILE_PATH_SUFFIX_NMCONNECTION);
-
-	return g_string_free (str, FALSE);;
 }
 
 /*****************************************************************************/

--- a/src/settings/plugins/keyfile/nms-keyfile-utils.h
+++ b/src/settings/plugins/keyfile/nms-keyfile-utils.h
@@ -23,19 +23,11 @@
 
 #include "NetworkManagerUtils.h"
 
-#define NM_CONFIG_KEYFILE_PATH_IN_MEMORY NMRUNDIR "/system-connections"
-
-#define NMS_KEYFILE_PATH_SUFFIX_NMCONNECTION      ".nmconnection"
-
 #define NMS_KEYFILE_CONNECTION_LOG_PATH(path)  ((path) ?: "in-memory")
 #define NMS_KEYFILE_CONNECTION_LOG_FMT         "%s (%s,\"%s\")"
 #define NMS_KEYFILE_CONNECTION_LOG_ARG(con)    NMS_KEYFILE_CONNECTION_LOG_PATH (nm_settings_connection_get_filename ((NMSettingsConnection *) (con))), nm_settings_connection_get_uuid ((NMSettingsConnection *) (con)), nm_settings_connection_get_id ((NMSettingsConnection *) (con))
 #define NMS_KEYFILE_CONNECTION_LOG_FMTD        "%s (%s,\"%s\",%p)"
 #define NMS_KEYFILE_CONNECTION_LOG_ARGD(con)   NMS_KEYFILE_CONNECTION_LOG_PATH (nm_settings_connection_get_filename ((NMSettingsConnection *) (con))), nm_settings_connection_get_uuid ((NMSettingsConnection *) (con)), nm_settings_connection_get_id ((NMSettingsConnection *) (con)), (con)
-
-gboolean nms_keyfile_utils_should_ignore_file (const char *filename, gboolean require_extension);
-
-char *nms_keyfile_utils_escape_filename (const char *filename, gboolean with_extension);
 
 const char *nms_keyfile_utils_get_path (void);
 

--- a/src/settings/plugins/keyfile/nms-keyfile-writer.c
+++ b/src/settings/plugins/keyfile/nms-keyfile-writer.c
@@ -230,7 +230,7 @@ _internal_write_connection (NMConnection *connection,
 	if (existing_path != NULL && !rename) {
 		path = g_strdup (existing_path);
 	} else {
-		char *filename_escaped = nms_keyfile_utils_escape_filename (id, with_extension);
+		char *filename_escaped = nm_keyfile_utils_create_filename (id, with_extension);
 
 		path = g_build_filename (keyfile_dir, filename_escaped, NULL);
 		g_free (filename_escaped);
@@ -256,7 +256,7 @@ _internal_write_connection (NMConnection *connection,
 			else
 				filename = g_strdup_printf ("%s-%s-%u", id, nm_connection_get_uuid (connection), i);
 
-			filename_escaped = nms_keyfile_utils_escape_filename (filename, with_extension);
+			filename_escaped = nm_keyfile_utils_create_filename (filename, with_extension);
 
 			g_free (path);
 			path = g_strdup_printf ("%s/%s", keyfile_dir, filename_escaped);
@@ -356,7 +356,7 @@ nms_keyfile_writer_connection (NMConnection *connection,
 	if (save_to_disk)
 		keyfile_dir = nms_keyfile_utils_get_path ();
 	else
-		keyfile_dir = NM_CONFIG_KEYFILE_PATH_IN_MEMORY;
+		keyfile_dir = NM_KEYFILE_PATH_NAME_RUN;
 
 	return _internal_write_connection (connection,
 	                                   keyfile_dir,

--- a/src/settings/plugins/keyfile/nms-keyfile-writer.c
+++ b/src/settings/plugins/keyfile/nms-keyfile-writer.c
@@ -173,7 +173,6 @@ static gboolean
 _internal_write_connection (NMConnection *connection,
                             const char *keyfile_dir,
                             const char *profile_dir,
-                            gboolean with_extension,
                             uid_t owner_uid,
                             pid_t owner_grp,
                             const char *existing_path,
@@ -230,7 +229,7 @@ _internal_write_connection (NMConnection *connection,
 	if (existing_path != NULL && !rename) {
 		path = g_strdup (existing_path);
 	} else {
-		char *filename_escaped = nm_keyfile_utils_create_filename (id, with_extension);
+		char *filename_escaped = nm_keyfile_utils_create_filename (id, TRUE);
 
 		path = g_build_filename (keyfile_dir, filename_escaped, NULL);
 		g_free (filename_escaped);
@@ -256,7 +255,7 @@ _internal_write_connection (NMConnection *connection,
 			else
 				filename = g_strdup_printf ("%s-%s-%u", id, nm_connection_get_uuid (connection), i);
 
-			filename_escaped = nm_keyfile_utils_create_filename (filename, with_extension);
+			filename_escaped = nm_keyfile_utils_create_filename (filename, TRUE);
 
 			g_free (path);
 			path = g_strdup_printf ("%s/%s", keyfile_dir, filename_escaped);
@@ -361,7 +360,6 @@ nms_keyfile_writer_connection (NMConnection *connection,
 	return _internal_write_connection (connection,
 	                                   keyfile_dir,
 	                                   nms_keyfile_utils_get_path (),
-	                                   TRUE,
 	                                   0,
 	                                   0,
 	                                   existing_path,
@@ -385,7 +383,6 @@ nms_keyfile_writer_test_connection (NMConnection *connection,
 	return _internal_write_connection (connection,
 	                                   keyfile_dir,
 	                                   keyfile_dir,
-	                                   FALSE,
 	                                   owner_uid,
 	                                   owner_grp,
 	                                   NULL,

--- a/src/settings/plugins/keyfile/tests/test-keyfile.c
+++ b/src/settings/plugins/keyfile/tests/test-keyfile.c
@@ -2466,18 +2466,18 @@ _escape_filename (gboolean with_extension, const char *filename, gboolean would_
 
 	g_assert (filename && filename[0]);
 
-	if (!!would_be_ignored != !!nms_keyfile_utils_should_ignore_file (filename, with_extension)) {
+	if (!!would_be_ignored != !!nm_keyfile_utils_ignore_filename (filename, with_extension)) {
 		if (would_be_ignored)
 			g_error ("We expect filename \"%s\" to be ignored, but it isn't", filename);
 		else
 			g_error ("We expect filename \"%s\" not to be ignored, but it is", filename);
 	}
 
-	esc = nms_keyfile_utils_escape_filename (filename, with_extension);
+	esc = nm_keyfile_utils_create_filename (filename, with_extension);
 	g_assert (esc && esc[0]);
 	g_assert (!strchr (esc, '/'));
 
-	if (nms_keyfile_utils_should_ignore_file (esc, with_extension))
+	if (nm_keyfile_utils_ignore_filename (esc, with_extension))
 		g_error ("Escaping filename \"%s\" yielded \"%s\", but this is ignored", filename, esc);
 }
 


### PR DESCRIPTION
Move keyfile helpers related to filenames from src/ to libnm-core/

This way, it can be used by initrd generator.

In general, as keyfile one day may become public API, users want to write keyfiles to file. And they need to escape the filename in a suitable way, so that NetworkManager accepts it. These utility functions really belong there, where general keyfile handling is done.