### PR TITLE
libnm-core: don't serialize synthetic properties in nm_setting_to_string()

### DIFF
--- a/libnm-core/nm-connection.h
+++ b/libnm-core/nm-connection.h
@@ -121,6 +121,8 @@ typedef enum { /*< flags >*/
 	NM_CONNECTION_SERIALIZE_ALL = 0x00000000,
 	NM_CONNECTION_SERIALIZE_NO_SECRETS = 0x00000001,
 	NM_CONNECTION_SERIALIZE_ONLY_SECRETS = 0x00000002,
+
+	/* 0x80000000 is used for a private flag */
 } NMConnectionSerializationFlags;
 
 GVariant     *nm_connection_to_dbus       (NMConnection *connection,

--- a/libnm-core/nm-core-internal.h
+++ b/libnm-core/nm-core-internal.h
@@ -174,6 +174,13 @@ NMSettingPriority _nm_setting_get_setting_priority (NMSetting *setting);
 
 gboolean _nm_setting_get_property (NMSetting *setting, const char *name, GValue *value);
 
+/* NM_CONNECTION_SERIALIZE_NO_SYNTH: This flag is passed to _nm_setting_to_dbus()
+ * by nm_setting_to_string() to let it know that it shouldn't serialize the
+ * synthetic properties. It wouldn't be able to do so, since the full connection
+ * is not available, only the setting alone.
+ */
+#define NM_CONNECTION_SERIALIZE_NO_SYNTH ((NMConnectionSerializationFlags) 0x80000000)
+
 /*****************************************************************************/
 
 GHashTable *_nm_setting_gendata_hash (NMSetting *setting,


### PR DESCRIPTION
Fixes: f957ea2b343828ad1fa2014bc7a4dedaf854f3bc