### PR TITLE
lr/ac-sort: improve sorting of active connections

### DIFF
--- a/clients/cli/connections.c
+++ b/clients/cli/connections.c
@@ -141,8 +141,8 @@ active_connection_get_state_ord (NMActiveConnection *active)
 	return -1;
 }
 
-static int
-active_connection_cmp (NMActiveConnection *ac_a, NMActiveConnection *ac_b)
+int
+nmc_active_connection_cmp (NMActiveConnection *ac_a, NMActiveConnection *ac_b)
 {
 	NM_CMP_SELF (ac_a, ac_b);
 	NM_CMP_DIRECT (active_connection_get_state_ord (ac_b),
@@ -1149,7 +1149,7 @@ get_ac_for_connection_cmp (gconstpointer pa, gconstpointer pb, gpointer user_dat
 	NMActiveConnection *ac_a = *((NMActiveConnection *const*) pa);
 	NMActiveConnection *ac_b = *((NMActiveConnection *const*) pb);
 
-	return active_connection_cmp (ac_a, ac_b);
+	return nmc_active_connection_cmp (ac_a, ac_b);
 }
 
 static NMActiveConnection *
@@ -1682,7 +1682,7 @@ con_show_get_items_cmp (gconstpointer pa, gconstpointer pb, gpointer user_data)
 		 * active connections... */
 	}
 
-	return active_connection_cmp (ac_a, ac_b);
+	return nmc_active_connection_cmp (ac_a, ac_b);
 }
 
 static GPtrArray *

--- a/clients/cli/connections.c
+++ b/clients/cli/connections.c
@@ -1693,12 +1693,10 @@ con_show_get_items_cmp (gconstpointer pa, gconstpointer pb, gpointer user_data)
 			switch (item) {
 
 			case NMC_SORT_ACTIVE:
-				NM_CMP_DIRECT (active_connection_get_state_ord (ac_b),
-				               active_connection_get_state_ord (ac_a));
+				NM_CMP_RETURN (nmc_active_connection_cmp (ac_b, ac_a));
 				break;
 			case NMC_SORT_ACTIVE_INV:
-				NM_CMP_DIRECT (active_connection_get_state_ord (ac_a),
-				               active_connection_get_state_ord (ac_b));
+				NM_CMP_RETURN (nmc_active_connection_cmp (ac_a, ac_b));
 				break;
 
 			case NMC_SORT_TYPE:

--- a/clients/cli/connections.h
+++ b/clients/cli/connections.h
@@ -35,6 +35,8 @@ nmc_read_connection_properties (NmCli *nmc,
 
 NMMetaColor nmc_active_connection_state_to_color (NMActiveConnectionState state);
 
+int nmc_active_connection_cmp (NMActiveConnection *ac_a, NMActiveConnection *ac_b);
+
 extern const NmcMetaGenericInfo *const metagen_con_show[];
 extern const NmcMetaGenericInfo *const metagen_con_active_general[];
 extern const NmcMetaGenericInfo *const metagen_con_active_vpn[];

--- a/clients/tests/test-client.check-on-disk/test_003.expected
+++ b/clients/tests/test-client.check-on-disk/test_003.expected
@@ -882,11 +882,11 @@ returncode: 0
 stdout: 1272 bytes
 >>>
 DEVICE  TYPE      STATE        IP4-CONNECTIVITY  IP6-CONNECTIVITY  DBUS-PATH                                  CONNECTION  CON-UUID                              CON-PATH                                           
+eth0    ethernet  unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/1  ethernet    UUID-ethernet-REPLACED-REPLACED-REPL  /org/freedesktop/NetworkManager/ActiveConnection/1 
 eth1    ethernet  unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/2  --          --                                    --                                                 
 wlan0   wifi      unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/3  --          --                                    --                                                 
 wlan1   wifi      unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/4  --          --                                    --                                                 
 wlan1   wifi      unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/5  --          --                                    --                                                 
-eth0    ethernet  unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/1  ethernet    UUID-ethernet-REPLACED-REPLACED-REPL  /org/freedesktop/NetworkManager/ActiveConnection/1 
 
 <<<
 stderr: 24 bytes
@@ -902,11 +902,11 @@ returncode: 0
 stdout: 1277 bytes
 >>>
 DEVICE  TYPE      STATE        IP4-CONNECTIVITY  IP6-CONNECTIVITY  DBUS-PATH                                  CONNECTION  CON-UUID                              CON-PATH                                           
+eth0    ethernet  niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/1  ethernet    UUID-ethernet-REPLACED-REPLACED-REPL  /org/freedesktop/NetworkManager/ActiveConnection/1 
 eth1    ethernet  niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/2  --          --                                    --                                                 
 wlan0   wifi      niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/3  --          --                                    --                                                 
 wlan1   wifi      niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/4  --          --                                    --                                                 
 wlan1   wifi      niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/5  --          --                                    --                                                 
-eth0    ethernet  niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/1  ethernet    UUID-ethernet-REPLACED-REPLACED-REPL  /org/freedesktop/NetworkManager/ActiveConnection/1 
 
 <<<
 stderr: 24 bytes
@@ -1760,11 +1760,11 @@ returncode: 0
 stdout: 1272 bytes
 >>>
 DEVICE  TYPE      STATE        IP4-CONNECTIVITY  IP6-CONNECTIVITY  DBUS-PATH                                  CONNECTION  CON-UUID                              CON-PATH                                           
+eth0    ethernet  unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/1  ethernet    UUID-ethernet-REPLACED-REPLACED-REPL  /org/freedesktop/NetworkManager/ActiveConnection/1 
+eth1    ethernet  unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/2  ethernet    UUID-ethernet-REPLACED-REPLACED-REPL  /org/freedesktop/NetworkManager/ActiveConnection/2 
 wlan0   wifi      unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/3  --          --                                    --                                                 
 wlan1   wifi      unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/4  --          --                                    --                                                 
 wlan1   wifi      unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/5  --          --                                    --                                                 
-eth0    ethernet  unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/1  ethernet    UUID-ethernet-REPLACED-REPLACED-REPL  /org/freedesktop/NetworkManager/ActiveConnection/1 
-eth1    ethernet  unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/2  ethernet    UUID-ethernet-REPLACED-REPLACED-REPL  /org/freedesktop/NetworkManager/ActiveConnection/2 
 
 <<<
 stderr: 24 bytes
@@ -1780,11 +1780,11 @@ returncode: 0
 stdout: 1277 bytes
 >>>
 DEVICE  TYPE      STATE        IP4-CONNECTIVITY  IP6-CONNECTIVITY  DBUS-PATH                                  CONNECTION  CON-UUID                              CON-PATH                                           
+eth0    ethernet  niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/1  ethernet    UUID-ethernet-REPLACED-REPLACED-REPL  /org/freedesktop/NetworkManager/ActiveConnection/1 
+eth1    ethernet  niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/2  ethernet    UUID-ethernet-REPLACED-REPLACED-REPL  /org/freedesktop/NetworkManager/ActiveConnection/2 
 wlan0   wifi      niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/3  --          --                                    --                                                 
 wlan1   wifi      niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/4  --          --                                    --                                                 
 wlan1   wifi      niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/5  --          --                                    --                                                 
-eth0    ethernet  niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/1  ethernet    UUID-ethernet-REPLACED-REPLACED-REPL  /org/freedesktop/NetworkManager/ActiveConnection/1 
-eth1    ethernet  niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/2  ethernet    UUID-ethernet-REPLACED-REPLACED-REPL  /org/freedesktop/NetworkManager/ActiveConnection/2 
 
 <<<
 stderr: 24 bytes
@@ -2064,8 +2064,8 @@ returncode: 0
 stdout: 1938 bytes
 >>>
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE         ACTIVE-PATH                                         SLAVE  FILENAME                                        
-ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/4  yes     eth1    activated     /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/4  yes     eth0    deactivating  /org/freedesktop/NetworkManager/ActiveConnection/1  --     /etc/NetworkManager/system-connections/ethernet 
+ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/4  yes     eth1    activated     /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/1  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          never           no           0                     no        /org/freedesktop/NetworkManager/Settings/Connection/3  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/2  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -2079,8 +2079,8 @@ returncode: 0
 stdout: 1950 bytes
 >>>
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE           ACTIVE-PATH                                         SLAVE  FILENAME                                        
-ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/4  tak     eth1    aktywowano      /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/4  tak     eth0    dezaktywowanie  /org/freedesktop/NetworkManager/ActiveConnection/1  --     /etc/NetworkManager/system-connections/ethernet 
+ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/4  tak     eth1    aktywowano      /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/1  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          nigdy           nie          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/3  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/2  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -2688,8 +2688,8 @@ returncode: 0
 stdout: 2208 bytes
 >>>
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE         ACTIVE-PATH                                         SLAVE  FILENAME                                        
-[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m0[0m          [32mnever[0m           [32myes[0m          [32m0[0m                     [32mno[0m        [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32myes[0m     [32meth1[0m    [32mactivated[0m     [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 [31methernet[0m  [31mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [31methernet[0m  [31m0[0m          [31mnever[0m           [31myes[0m          [31m0[0m                     [31mno[0m        [31m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [31myes[0m     [31meth0[0m    [31mdeactivating[0m  [31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m  [31m--[0m     [31m/etc/NetworkManager/system-connections/ethernet[0m 
+[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m0[0m          [32mnever[0m           [32myes[0m          [32m0[0m                     [32mno[0m        [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32myes[0m     [32meth1[0m    [32mactivated[0m     [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/1  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          never           no           0                     no        /org/freedesktop/NetworkManager/Settings/Connection/3  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/2  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -2703,8 +2703,8 @@ returncode: 0
 stdout: 2220 bytes
 >>>
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE           ACTIVE-PATH                                         SLAVE  FILENAME                                        
-[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m0[0m          [32mnigdy[0m           [32mtak[0m          [32m0[0m                     [32mnie[0m       [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32mtak[0m     [32meth1[0m    [32maktywowano[0m      [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 [31methernet[0m  [31mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [31methernet[0m  [31m0[0m          [31mnigdy[0m           [31mtak[0m          [31m0[0m                     [31mnie[0m       [31m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [31mtak[0m     [31meth0[0m    [31mdezaktywowanie[0m  [31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m  [31m--[0m     [31m/etc/NetworkManager/system-connections/ethernet[0m 
+[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m0[0m          [32mnigdy[0m           [32mtak[0m          [32m0[0m                     [32mnie[0m       [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32mtak[0m     [32meth1[0m    [32maktywowano[0m      [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/1  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          nigdy           nie          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/3  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/2  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -3316,8 +3316,8 @@ stdout: 2415 bytes
 ======================================
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE         ACTIVE-PATH                                         SLAVE  FILENAME                                        
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/4  yes     eth1    activated     /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/4  yes     eth0    deactivating  /org/freedesktop/NetworkManager/ActiveConnection/1  --     /etc/NetworkManager/system-connections/ethernet 
+ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/4  yes     eth1    activated     /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/1  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          never           no           0                     no        /org/freedesktop/NetworkManager/Settings/Connection/3  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/2  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -3335,8 +3335,8 @@ stdout: 2449 bytes
 ==========================================
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE           ACTIVE-PATH                                         SLAVE  FILENAME                                        
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/4  tak     eth1    aktywowano      /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/4  tak     eth0    dezaktywowanie  /org/freedesktop/NetworkManager/ActiveConnection/1  --     /etc/NetworkManager/system-connections/ethernet 
+ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/4  tak     eth1    aktywowano      /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/1  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          nigdy           nie          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/3  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/2  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -4034,8 +4034,8 @@ stdout: 2685 bytes
 ======================================
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE         ACTIVE-PATH                                         SLAVE  FILENAME                                        
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m0[0m          [32mnever[0m           [32myes[0m          [32m0[0m                     [32mno[0m        [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32myes[0m     [32meth1[0m    [32mactivated[0m     [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 [31methernet[0m  [31mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [31methernet[0m  [31m0[0m          [31mnever[0m           [31myes[0m          [31m0[0m                     [31mno[0m        [31m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [31myes[0m     [31meth0[0m    [31mdeactivating[0m  [31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m  [31m--[0m     [31m/etc/NetworkManager/system-connections/ethernet[0m 
+[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m0[0m          [32mnever[0m           [32myes[0m          [32m0[0m                     [32mno[0m        [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32myes[0m     [32meth1[0m    [32mactivated[0m     [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/1  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          never           no           0                     no        /org/freedesktop/NetworkManager/Settings/Connection/3  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/2  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -4053,8 +4053,8 @@ stdout: 2719 bytes
 ==========================================
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE           ACTIVE-PATH                                         SLAVE  FILENAME                                        
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m0[0m          [32mnigdy[0m           [32mtak[0m          [32m0[0m                     [32mnie[0m       [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32mtak[0m     [32meth1[0m    [32maktywowano[0m      [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 [31methernet[0m  [31mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [31methernet[0m  [31m0[0m          [31mnigdy[0m           [31mtak[0m          [31m0[0m                     [31mnie[0m       [31m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [31mtak[0m     [31meth0[0m    [31mdezaktywowanie[0m  [31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m  [31m--[0m     [31m/etc/NetworkManager/system-connections/ethernet[0m 
+[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m0[0m          [32mnigdy[0m           [32mtak[0m          [32m0[0m                     [32mnie[0m       [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32mtak[0m     [32meth1[0m    [32maktywowano[0m      [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/1  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          nigdy           nie          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/3  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/2  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -4747,8 +4747,8 @@ lang: C
 returncode: 0
 stdout: 1046 bytes
 >>>
-ethernet:UUID-ethernet-REPLACED-REPLACED-REPL:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/4:yes:eth1:activated:/org/freedesktop/NetworkManager/ActiveConnection/2::/etc/NetworkManager/system-connections/ethernet
 ethernet:UUID-ethernet-REPLACED-REPLACED-REPL:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/4:yes:eth0:deactivating:/org/freedesktop/NetworkManager/ActiveConnection/1::/etc/NetworkManager/system-connections/ethernet
+ethernet:UUID-ethernet-REPLACED-REPLACED-REPL:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/4:yes:eth1:activated:/org/freedesktop/NetworkManager/ActiveConnection/2::/etc/NetworkManager/system-connections/ethernet
 con-1:5fcfd6d7-1e63-3332-8826-a7eda103792d:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/1:no:::::/etc/NetworkManager/system-connections/con-1
 con-gsm1:UUID-con-gsm1-REPLACED-REPLACED-REPL:gsm:0:never:no:0:no:/org/freedesktop/NetworkManager/Settings/Connection/3:no:::::/etc/NetworkManager/system-connections/con-gsm1
 con-xx1:UUID-con-xx1-REPLACED-REPLACED-REPLA:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/2:no:::::/etc/NetworkManager/system-connections/con-xx1
@@ -4761,8 +4761,8 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 1046 bytes
 >>>
-ethernet:UUID-ethernet-REPLACED-REPLACED-REPL:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/4:yes:eth1:activated:/org/freedesktop/NetworkManager/ActiveConnection/2::/etc/NetworkManager/system-connections/ethernet
 ethernet:UUID-ethernet-REPLACED-REPLACED-REPL:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/4:yes:eth0:deactivating:/org/freedesktop/NetworkManager/ActiveConnection/1::/etc/NetworkManager/system-connections/ethernet
+ethernet:UUID-ethernet-REPLACED-REPLACED-REPL:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/4:yes:eth1:activated:/org/freedesktop/NetworkManager/ActiveConnection/2::/etc/NetworkManager/system-connections/ethernet
 con-1:5fcfd6d7-1e63-3332-8826-a7eda103792d:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/1:no:::::/etc/NetworkManager/system-connections/con-1
 con-gsm1:UUID-con-gsm1-REPLACED-REPLACED-REPL:gsm:0:never:no:0:no:/org/freedesktop/NetworkManager/Settings/Connection/3:no:::::/etc/NetworkManager/system-connections/con-gsm1
 con-xx1:UUID-con-xx1-REPLACED-REPLACED-REPLA:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/2:no:::::/etc/NetworkManager/system-connections/con-xx1
@@ -5367,8 +5367,8 @@ lang: C
 returncode: 0
 stdout: 1316 bytes
 >>>
-[32methernet[0m:[32mUUID-ethernet-REPLACED-REPLACED-REPL[0m:[32m802-3-ethernet[0m:[32m0[0m:[32mnever[0m:[32myes[0m:[32m0[0m:[32mno[0m:[32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m:[32myes[0m:[32meth1[0m:[32mactivated[0m:[32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m:[32m[0m:[32m/etc/NetworkManager/system-connections/ethernet[0m
 [31methernet[0m:[31mUUID-ethernet-REPLACED-REPLACED-REPL[0m:[31m802-3-ethernet[0m:[31m0[0m:[31mnever[0m:[31myes[0m:[31m0[0m:[31mno[0m:[31m/org/freedesktop/NetworkManager/Settings/Connection/4[0m:[31myes[0m:[31meth0[0m:[31mdeactivating[0m:[31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m:[31m[0m:[31m/etc/NetworkManager/system-connections/ethernet[0m
+[32methernet[0m:[32mUUID-ethernet-REPLACED-REPLACED-REPL[0m:[32m802-3-ethernet[0m:[32m0[0m:[32mnever[0m:[32myes[0m:[32m0[0m:[32mno[0m:[32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m:[32myes[0m:[32meth1[0m:[32mactivated[0m:[32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m:[32m[0m:[32m/etc/NetworkManager/system-connections/ethernet[0m
 con-1:5fcfd6d7-1e63-3332-8826-a7eda103792d:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/1:no:::::/etc/NetworkManager/system-connections/con-1
 con-gsm1:UUID-con-gsm1-REPLACED-REPLACED-REPL:gsm:0:never:no:0:no:/org/freedesktop/NetworkManager/Settings/Connection/3:no:::::/etc/NetworkManager/system-connections/con-gsm1
 con-xx1:UUID-con-xx1-REPLACED-REPLACED-REPLA:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/2:no:::::/etc/NetworkManager/system-connections/con-xx1
@@ -5381,8 +5381,8 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 1316 bytes
 >>>
-[32methernet[0m:[32mUUID-ethernet-REPLACED-REPLACED-REPL[0m:[32m802-3-ethernet[0m:[32m0[0m:[32mnever[0m:[32myes[0m:[32m0[0m:[32mno[0m:[32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m:[32myes[0m:[32meth1[0m:[32mactivated[0m:[32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m:[32m[0m:[32m/etc/NetworkManager/system-connections/ethernet[0m
 [31methernet[0m:[31mUUID-ethernet-REPLACED-REPLACED-REPL[0m:[31m802-3-ethernet[0m:[31m0[0m:[31mnever[0m:[31myes[0m:[31m0[0m:[31mno[0m:[31m/org/freedesktop/NetworkManager/Settings/Connection/4[0m:[31myes[0m:[31meth0[0m:[31mdeactivating[0m:[31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m:[31m[0m:[31m/etc/NetworkManager/system-connections/ethernet[0m
+[32methernet[0m:[32mUUID-ethernet-REPLACED-REPLACED-REPL[0m:[32m802-3-ethernet[0m:[32m0[0m:[32mnever[0m:[32myes[0m:[32m0[0m:[32mno[0m:[32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m:[32myes[0m:[32meth1[0m:[32mactivated[0m:[32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m:[32m[0m:[32m/etc/NetworkManager/system-connections/ethernet[0m
 con-1:5fcfd6d7-1e63-3332-8826-a7eda103792d:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/1:no:::::/etc/NetworkManager/system-connections/con-1
 con-gsm1:UUID-con-gsm1-REPLACED-REPLACED-REPL:gsm:0:never:no:0:no:/org/freedesktop/NetworkManager/Settings/Connection/3:no:::::/etc/NetworkManager/system-connections/con-gsm1
 con-xx1:UUID-con-xx1-REPLACED-REPLACED-REPLA:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/2:no:::::/etc/NetworkManager/system-connections/con-xx1
@@ -5988,8 +5988,8 @@ returncode: 0
 stdout: 1938 bytes
 >>>
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE         ACTIVE-PATH                                         SLAVE  FILENAME                                        
-ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/4  yes     eth1    activated     /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/4  yes     eth0    deactivating  /org/freedesktop/NetworkManager/ActiveConnection/1  --     /etc/NetworkManager/system-connections/ethernet 
+ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/4  yes     eth1    activated     /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/1  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          never           no           0                     no        /org/freedesktop/NetworkManager/Settings/Connection/3  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/2  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -6003,8 +6003,8 @@ returncode: 0
 stdout: 1950 bytes
 >>>
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE           ACTIVE-PATH                                         SLAVE  FILENAME                                        
-ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/4  tak     eth1    aktywowano      /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/4  tak     eth0    dezaktywowanie  /org/freedesktop/NetworkManager/ActiveConnection/1  --     /etc/NetworkManager/system-connections/ethernet 
+ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/4  tak     eth1    aktywowano      /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/1  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          nigdy           nie          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/3  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/2  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -6226,8 +6226,8 @@ returncode: 0
 stdout: 2208 bytes
 >>>
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE         ACTIVE-PATH                                         SLAVE  FILENAME                                        
-[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m0[0m          [32mnever[0m           [32myes[0m          [32m0[0m                     [32mno[0m        [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32myes[0m     [32meth1[0m    [32mactivated[0m     [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 [31methernet[0m  [31mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [31methernet[0m  [31m0[0m          [31mnever[0m           [31myes[0m          [31m0[0m                     [31mno[0m        [31m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [31myes[0m     [31meth0[0m    [31mdeactivating[0m  [31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m  [31m--[0m     [31m/etc/NetworkManager/system-connections/ethernet[0m 
+[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m0[0m          [32mnever[0m           [32myes[0m          [32m0[0m                     [32mno[0m        [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32myes[0m     [32meth1[0m    [32mactivated[0m     [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/1  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          never           no           0                     no        /org/freedesktop/NetworkManager/Settings/Connection/3  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/2  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -6241,8 +6241,8 @@ returncode: 0
 stdout: 2220 bytes
 >>>
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE           ACTIVE-PATH                                         SLAVE  FILENAME                                        
-[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m0[0m          [32mnigdy[0m           [32mtak[0m          [32m0[0m                     [32mnie[0m       [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32mtak[0m     [32meth1[0m    [32maktywowano[0m      [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 [31methernet[0m  [31mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [31methernet[0m  [31m0[0m          [31mnigdy[0m           [31mtak[0m          [31m0[0m                     [31mnie[0m       [31m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [31mtak[0m     [31meth0[0m    [31mdezaktywowanie[0m  [31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m  [31m--[0m     [31m/etc/NetworkManager/system-connections/ethernet[0m 
+[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m0[0m          [32mnigdy[0m           [32mtak[0m          [32m0[0m                     [32mnie[0m       [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32mtak[0m     [32meth1[0m    [32maktywowano[0m      [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/1  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          nigdy           nie          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/3  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/2  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -6468,8 +6468,8 @@ stdout: 2415 bytes
 ======================================
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE         ACTIVE-PATH                                         SLAVE  FILENAME                                        
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/4  yes     eth1    activated     /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/4  yes     eth0    deactivating  /org/freedesktop/NetworkManager/ActiveConnection/1  --     /etc/NetworkManager/system-connections/ethernet 
+ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/4  yes     eth1    activated     /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/1  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          never           no           0                     no        /org/freedesktop/NetworkManager/Settings/Connection/3  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/2  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -6487,8 +6487,8 @@ stdout: 2449 bytes
 ==========================================
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE           ACTIVE-PATH                                         SLAVE  FILENAME                                        
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/4  tak     eth1    aktywowano      /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/4  tak     eth0    dezaktywowanie  /org/freedesktop/NetworkManager/ActiveConnection/1  --     /etc/NetworkManager/system-connections/ethernet 
+ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/4  tak     eth1    aktywowano      /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/1  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          nigdy           nie          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/3  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/2  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -6800,8 +6800,8 @@ stdout: 2685 bytes
 ======================================
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE         ACTIVE-PATH                                         SLAVE  FILENAME                                        
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m0[0m          [32mnever[0m           [32myes[0m          [32m0[0m                     [32mno[0m        [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32myes[0m     [32meth1[0m    [32mactivated[0m     [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 [31methernet[0m  [31mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [31methernet[0m  [31m0[0m          [31mnever[0m           [31myes[0m          [31m0[0m                     [31mno[0m        [31m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [31myes[0m     [31meth0[0m    [31mdeactivating[0m  [31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m  [31m--[0m     [31m/etc/NetworkManager/system-connections/ethernet[0m 
+[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m0[0m          [32mnever[0m           [32myes[0m          [32m0[0m                     [32mno[0m        [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32myes[0m     [32meth1[0m    [32mactivated[0m     [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/1  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          never           no           0                     no        /org/freedesktop/NetworkManager/Settings/Connection/3  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/2  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -6819,8 +6819,8 @@ stdout: 2719 bytes
 ==========================================
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE           ACTIVE-PATH                                         SLAVE  FILENAME                                        
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m0[0m          [32mnigdy[0m           [32mtak[0m          [32m0[0m                     [32mnie[0m       [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32mtak[0m     [32meth1[0m    [32maktywowano[0m      [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 [31methernet[0m  [31mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [31methernet[0m  [31m0[0m          [31mnigdy[0m           [31mtak[0m          [31m0[0m                     [31mnie[0m       [31m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [31mtak[0m     [31meth0[0m    [31mdezaktywowanie[0m  [31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m  [31m--[0m     [31m/etc/NetworkManager/system-connections/ethernet[0m 
+[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m0[0m          [32mnigdy[0m           [32mtak[0m          [32m0[0m                     [32mnie[0m       [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32mtak[0m     [32meth1[0m    [32maktywowano[0m      [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/1  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          nigdy           nie          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/3  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/2  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -7127,8 +7127,8 @@ lang: C
 returncode: 0
 stdout: 1046 bytes
 >>>
-ethernet:UUID-ethernet-REPLACED-REPLACED-REPL:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/4:yes:eth1:activated:/org/freedesktop/NetworkManager/ActiveConnection/2::/etc/NetworkManager/system-connections/ethernet
 ethernet:UUID-ethernet-REPLACED-REPLACED-REPL:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/4:yes:eth0:deactivating:/org/freedesktop/NetworkManager/ActiveConnection/1::/etc/NetworkManager/system-connections/ethernet
+ethernet:UUID-ethernet-REPLACED-REPLACED-REPL:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/4:yes:eth1:activated:/org/freedesktop/NetworkManager/ActiveConnection/2::/etc/NetworkManager/system-connections/ethernet
 con-1:5fcfd6d7-1e63-3332-8826-a7eda103792d:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/1:no:::::/etc/NetworkManager/system-connections/con-1
 con-gsm1:UUID-con-gsm1-REPLACED-REPLACED-REPL:gsm:0:never:no:0:no:/org/freedesktop/NetworkManager/Settings/Connection/3:no:::::/etc/NetworkManager/system-connections/con-gsm1
 con-xx1:UUID-con-xx1-REPLACED-REPLACED-REPLA:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/2:no:::::/etc/NetworkManager/system-connections/con-xx1
@@ -7141,8 +7141,8 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 1046 bytes
 >>>
-ethernet:UUID-ethernet-REPLACED-REPLACED-REPL:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/4:yes:eth1:activated:/org/freedesktop/NetworkManager/ActiveConnection/2::/etc/NetworkManager/system-connections/ethernet
 ethernet:UUID-ethernet-REPLACED-REPLACED-REPL:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/4:yes:eth0:deactivating:/org/freedesktop/NetworkManager/ActiveConnection/1::/etc/NetworkManager/system-connections/ethernet
+ethernet:UUID-ethernet-REPLACED-REPLACED-REPL:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/4:yes:eth1:activated:/org/freedesktop/NetworkManager/ActiveConnection/2::/etc/NetworkManager/system-connections/ethernet
 con-1:5fcfd6d7-1e63-3332-8826-a7eda103792d:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/1:no:::::/etc/NetworkManager/system-connections/con-1
 con-gsm1:UUID-con-gsm1-REPLACED-REPLACED-REPL:gsm:0:never:no:0:no:/org/freedesktop/NetworkManager/Settings/Connection/3:no:::::/etc/NetworkManager/system-connections/con-gsm1
 con-xx1:UUID-con-xx1-REPLACED-REPLACED-REPLA:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/2:no:::::/etc/NetworkManager/system-connections/con-xx1
@@ -7279,8 +7279,8 @@ lang: C
 returncode: 0
 stdout: 1316 bytes
 >>>
-[32methernet[0m:[32mUUID-ethernet-REPLACED-REPLACED-REPL[0m:[32m802-3-ethernet[0m:[32m0[0m:[32mnever[0m:[32myes[0m:[32m0[0m:[32mno[0m:[32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m:[32myes[0m:[32meth1[0m:[32mactivated[0m:[32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m:[32m[0m:[32m/etc/NetworkManager/system-connections/ethernet[0m
 [31methernet[0m:[31mUUID-ethernet-REPLACED-REPLACED-REPL[0m:[31m802-3-ethernet[0m:[31m0[0m:[31mnever[0m:[31myes[0m:[31m0[0m:[31mno[0m:[31m/org/freedesktop/NetworkManager/Settings/Connection/4[0m:[31myes[0m:[31meth0[0m:[31mdeactivating[0m:[31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m:[31m[0m:[31m/etc/NetworkManager/system-connections/ethernet[0m
+[32methernet[0m:[32mUUID-ethernet-REPLACED-REPLACED-REPL[0m:[32m802-3-ethernet[0m:[32m0[0m:[32mnever[0m:[32myes[0m:[32m0[0m:[32mno[0m:[32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m:[32myes[0m:[32meth1[0m:[32mactivated[0m:[32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m:[32m[0m:[32m/etc/NetworkManager/system-connections/ethernet[0m
 con-1:5fcfd6d7-1e63-3332-8826-a7eda103792d:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/1:no:::::/etc/NetworkManager/system-connections/con-1
 con-gsm1:UUID-con-gsm1-REPLACED-REPLACED-REPL:gsm:0:never:no:0:no:/org/freedesktop/NetworkManager/Settings/Connection/3:no:::::/etc/NetworkManager/system-connections/con-gsm1
 con-xx1:UUID-con-xx1-REPLACED-REPLACED-REPLA:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/2:no:::::/etc/NetworkManager/system-connections/con-xx1
@@ -7293,8 +7293,8 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 1316 bytes
 >>>
-[32methernet[0m:[32mUUID-ethernet-REPLACED-REPLACED-REPL[0m:[32m802-3-ethernet[0m:[32m0[0m:[32mnever[0m:[32myes[0m:[32m0[0m:[32mno[0m:[32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m:[32myes[0m:[32meth1[0m:[32mactivated[0m:[32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m:[32m[0m:[32m/etc/NetworkManager/system-connections/ethernet[0m
 [31methernet[0m:[31mUUID-ethernet-REPLACED-REPLACED-REPL[0m:[31m802-3-ethernet[0m:[31m0[0m:[31mnever[0m:[31myes[0m:[31m0[0m:[31mno[0m:[31m/org/freedesktop/NetworkManager/Settings/Connection/4[0m:[31myes[0m:[31meth0[0m:[31mdeactivating[0m:[31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m:[31m[0m:[31m/etc/NetworkManager/system-connections/ethernet[0m
+[32methernet[0m:[32mUUID-ethernet-REPLACED-REPLACED-REPL[0m:[32m802-3-ethernet[0m:[32m0[0m:[32mnever[0m:[32myes[0m:[32m0[0m:[32mno[0m:[32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m:[32myes[0m:[32meth1[0m:[32mactivated[0m:[32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m:[32m[0m:[32m/etc/NetworkManager/system-connections/ethernet[0m
 con-1:5fcfd6d7-1e63-3332-8826-a7eda103792d:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/1:no:::::/etc/NetworkManager/system-connections/con-1
 con-gsm1:UUID-con-gsm1-REPLACED-REPLACED-REPL:gsm:0:never:no:0:no:/org/freedesktop/NetworkManager/Settings/Connection/3:no:::::/etc/NetworkManager/system-connections/con-gsm1
 con-xx1:UUID-con-xx1-REPLACED-REPLACED-REPLA:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/2:no:::::/etc/NetworkManager/system-connections/con-xx1
@@ -7441,9 +7441,9 @@ AUTOCONNECT-PRIORITY:                   0
 READONLY:                               no
 DBUS-PATH:                              /org/freedesktop/NetworkManager/Settings/Connection/4
 ACTIVE:                                 yes
-DEVICE:                                 eth1
-STATE:                                  activated
-ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/2
+DEVICE:                                 eth0
+STATE:                                  deactivating
+ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/1
 SLAVE:                                  --
 FILENAME:                               /etc/NetworkManager/system-connections/ethernet
 NAME:                                   ethernet
@@ -7456,9 +7456,9 @@ AUTOCONNECT-PRIORITY:                   0
 READONLY:                               no
 DBUS-PATH:                              /org/freedesktop/NetworkManager/Settings/Connection/4
 ACTIVE:                                 yes
-DEVICE:                                 eth0
-STATE:                                  deactivating
-ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/1
+DEVICE:                                 eth1
+STATE:                                  activated
+ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/2
 SLAVE:                                  --
 FILENAME:                               /etc/NetworkManager/system-connections/ethernet
 NAME:                                   con-1
@@ -7525,9 +7525,9 @@ AUTOCONNECT-PRIORITY:                   0
 READONLY:                               nie
 DBUS-PATH:                              /org/freedesktop/NetworkManager/Settings/Connection/4
 ACTIVE:                                 tak
-DEVICE:                                 eth1
-STATE:                                  aktywowano
-ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/2
+DEVICE:                                 eth0
+STATE:                                  dezaktywowanie
+ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/1
 SLAVE:                                  --
 FILENAME:                               /etc/NetworkManager/system-connections/ethernet
 NAME:                                   ethernet
@@ -7540,9 +7540,9 @@ AUTOCONNECT-PRIORITY:                   0
 READONLY:                               nie
 DBUS-PATH:                              /org/freedesktop/NetworkManager/Settings/Connection/4
 ACTIVE:                                 tak
-DEVICE:                                 eth0
-STATE:                                  dezaktywowanie
-ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/1
+DEVICE:                                 eth1
+STATE:                                  aktywowano
+ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/2
 SLAVE:                                  --
 FILENAME:                               /etc/NetworkManager/system-connections/ethernet
 NAME:                                   con-1
@@ -8199,21 +8199,6 @@ lang: C
 returncode: 0
 stdout: 4320 bytes
 >>>
-NAME:                                   [32methernet[0m
-UUID:                                   [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m
-TYPE:                                   [32methernet[0m
-TIMESTAMP:                              [32m0[0m
-TIMESTAMP-REAL:                         [32mnever[0m
-AUTOCONNECT:                            [32myes[0m
-AUTOCONNECT-PRIORITY:                   [32m0[0m
-READONLY:                               [32mno[0m
-DBUS-PATH:                              [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m
-ACTIVE:                                 [32myes[0m
-DEVICE:                                 [32meth1[0m
-STATE:                                  [32mactivated[0m
-ACTIVE-PATH:                            [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
-SLAVE:                                  [32m--[0m
-FILENAME:                               [32m/etc/NetworkManager/system-connections/ethernet[0m
 NAME:                                   [31methernet[0m
 UUID:                                   [31mUUID-ethernet-REPLACED-REPLACED-REPL[0m
 TYPE:                                   [31methernet[0m
@@ -8229,6 +8214,21 @@ STATE:                                  [31mdeactivating[0m
 ACTIVE-PATH:                            [31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m
 SLAVE:                                  [31m--[0m
 FILENAME:                               [31m/etc/NetworkManager/system-connections/ethernet[0m
+NAME:                                   [32methernet[0m
+UUID:                                   [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m
+TYPE:                                   [32methernet[0m
+TIMESTAMP:                              [32m0[0m
+TIMESTAMP-REAL:                         [32mnever[0m
+AUTOCONNECT:                            [32myes[0m
+AUTOCONNECT-PRIORITY:                   [32m0[0m
+READONLY:                               [32mno[0m
+DBUS-PATH:                              [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m
+ACTIVE:                                 [32myes[0m
+DEVICE:                                 [32meth1[0m
+STATE:                                  [32mactivated[0m
+ACTIVE-PATH:                            [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
+SLAVE:                                  [32m--[0m
+FILENAME:                               [32m/etc/NetworkManager/system-connections/ethernet[0m
 NAME:                                   con-1
 UUID:                                   5fcfd6d7-1e63-3332-8826-a7eda103792d
 TYPE:                                   ethernet
@@ -8283,21 +8283,6 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 4332 bytes
 >>>
-NAME:                                   [32methernet[0m
-UUID:                                   [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m
-TYPE:                                   [32methernet[0m
-TIMESTAMP:                              [32m0[0m
-TIMESTAMP-REAL:                         [32mnigdy[0m
-AUTOCONNECT:                            [32mtak[0m
-AUTOCONNECT-PRIORITY:                   [32m0[0m
-READONLY:                               [32mnie[0m
-DBUS-PATH:                              [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m
-ACTIVE:                                 [32mtak[0m
-DEVICE:                                 [32meth1[0m
-STATE:                                  [32maktywowano[0m
-ACTIVE-PATH:                            [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
-SLAVE:                                  [32m--[0m
-FILENAME:                               [32m/etc/NetworkManager/system-connections/ethernet[0m
 NAME:                                   [31methernet[0m
 UUID:                                   [31mUUID-ethernet-REPLACED-REPLACED-REPL[0m
 TYPE:                                   [31methernet[0m
@@ -8313,6 +8298,21 @@ STATE:                                  [31mdezaktywowanie[0m
 ACTIVE-PATH:                            [31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m
 SLAVE:                                  [31m--[0m
 FILENAME:                               [31m/etc/NetworkManager/system-connections/ethernet[0m
+NAME:                                   [32methernet[0m
+UUID:                                   [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m
+TYPE:                                   [32methernet[0m
+TIMESTAMP:                              [32m0[0m
+TIMESTAMP-REAL:                         [32mnigdy[0m
+AUTOCONNECT:                            [32mtak[0m
+AUTOCONNECT-PRIORITY:                   [32m0[0m
+READONLY:                               [32mnie[0m
+DBUS-PATH:                              [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m
+ACTIVE:                                 [32mtak[0m
+DEVICE:                                 [32meth1[0m
+STATE:                                  [32maktywowano[0m
+ACTIVE-PATH:                            [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
+SLAVE:                                  [32m--[0m
+FILENAME:                               [32m/etc/NetworkManager/system-connections/ethernet[0m
 NAME:                                   con-1
 UUID:                                   5fcfd6d7-1e63-3332-8826-a7eda103792d
 TYPE:                                   ethernet
@@ -8980,9 +8980,9 @@ AUTOCONNECT-PRIORITY:                   0
 READONLY:                               no
 DBUS-PATH:                              /org/freedesktop/NetworkManager/Settings/Connection/4
 ACTIVE:                                 yes
-DEVICE:                                 eth1
-STATE:                                  activated
-ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/2
+DEVICE:                                 eth0
+STATE:                                  deactivating
+ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/1
 SLAVE:                                  --
 FILENAME:                               /etc/NetworkManager/system-connections/ethernet
 -------------------------------------------------------------------------------
@@ -8996,9 +8996,9 @@ AUTOCONNECT-PRIORITY:                   0
 READONLY:                               no
 DBUS-PATH:                              /org/freedesktop/NetworkManager/Settings/Connection/4
 ACTIVE:                                 yes
-DEVICE:                                 eth0
-STATE:                                  deactivating
-ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/1
+DEVICE:                                 eth1
+STATE:                                  activated
+ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/2
 SLAVE:                                  --
 FILENAME:                               /etc/NetworkManager/system-connections/ethernet
 -------------------------------------------------------------------------------
@@ -9072,9 +9072,9 @@ AUTOCONNECT-PRIORITY:                   0
 READONLY:                               nie
 DBUS-PATH:                              /org/freedesktop/NetworkManager/Settings/Connection/4
 ACTIVE:                                 tak
-DEVICE:                                 eth1
-STATE:                                  aktywowano
-ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/2
+DEVICE:                                 eth0
+STATE:                                  dezaktywowanie
+ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/1
 SLAVE:                                  --
 FILENAME:                               /etc/NetworkManager/system-connections/ethernet
 -------------------------------------------------------------------------------
@@ -9088,9 +9088,9 @@ AUTOCONNECT-PRIORITY:                   0
 READONLY:                               nie
 DBUS-PATH:                              /org/freedesktop/NetworkManager/Settings/Connection/4
 ACTIVE:                                 tak
-DEVICE:                                 eth0
-STATE:                                  dezaktywowanie
-ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/1
+DEVICE:                                 eth1
+STATE:                                  aktywowano
+ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/2
 SLAVE:                                  --
 FILENAME:                               /etc/NetworkManager/system-connections/ethernet
 -------------------------------------------------------------------------------
@@ -9846,22 +9846,6 @@ stdout: 4937 bytes
 ===============================================================================
                       NetworkManager connection profiles
 ===============================================================================
-NAME:                                   [32methernet[0m
-UUID:                                   [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m
-TYPE:                                   [32methernet[0m
-TIMESTAMP:                              [32m0[0m
-TIMESTAMP-REAL:                         [32mnever[0m
-AUTOCONNECT:                            [32myes[0m
-AUTOCONNECT-PRIORITY:                   [32m0[0m
-READONLY:                               [32mno[0m
-DBUS-PATH:                              [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m
-ACTIVE:                                 [32myes[0m
-DEVICE:                                 [32meth1[0m
-STATE:                                  [32mactivated[0m
-ACTIVE-PATH:                            [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
-SLAVE:                                  [32m--[0m
-FILENAME:                               [32m/etc/NetworkManager/system-connections/ethernet[0m
--------------------------------------------------------------------------------
 NAME:                                   [31methernet[0m
 UUID:                                   [31mUUID-ethernet-REPLACED-REPLACED-REPL[0m
 TYPE:                                   [31methernet[0m
@@ -9877,6 +9861,22 @@ STATE:                                  [31mdeactivating[0m
 ACTIVE-PATH:                            [31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m
 SLAVE:                                  [31m--[0m
 FILENAME:                               [31m/etc/NetworkManager/system-connections/ethernet[0m
+-------------------------------------------------------------------------------
+NAME:                                   [32methernet[0m
+UUID:                                   [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m
+TYPE:                                   [32methernet[0m
+TIMESTAMP:                              [32m0[0m
+TIMESTAMP-REAL:                         [32mnever[0m
+AUTOCONNECT:                            [32myes[0m
+AUTOCONNECT-PRIORITY:                   [32m0[0m
+READONLY:                               [32mno[0m
+DBUS-PATH:                              [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m
+ACTIVE:                                 [32myes[0m
+DEVICE:                                 [32meth1[0m
+STATE:                                  [32mactivated[0m
+ACTIVE-PATH:                            [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
+SLAVE:                                  [32m--[0m
+FILENAME:                               [32m/etc/NetworkManager/system-connections/ethernet[0m
 -------------------------------------------------------------------------------
 NAME:                                   con-1
 UUID:                                   5fcfd6d7-1e63-3332-8826-a7eda103792d
@@ -9938,22 +9938,6 @@ stdout: 4955 bytes
 ===============================================================================
                     Profile połączeń usługi NetworkManager
 ===============================================================================
-NAME:                                   [32methernet[0m
-UUID:                                   [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m
-TYPE:                                   [32methernet[0m
-TIMESTAMP:                              [32m0[0m
-TIMESTAMP-REAL:                         [32mnigdy[0m
-AUTOCONNECT:                            [32mtak[0m
-AUTOCONNECT-PRIORITY:                   [32m0[0m
-READONLY:                               [32mnie[0m
-DBUS-PATH:                              [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m
-ACTIVE:                                 [32mtak[0m
-DEVICE:                                 [32meth1[0m
-STATE:                                  [32maktywowano[0m
-ACTIVE-PATH:                            [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
-SLAVE:                                  [32m--[0m
-FILENAME:                               [32m/etc/NetworkManager/system-connections/ethernet[0m
--------------------------------------------------------------------------------
 NAME:                                   [31methernet[0m
 UUID:                                   [31mUUID-ethernet-REPLACED-REPLACED-REPL[0m
 TYPE:                                   [31methernet[0m
@@ -9969,6 +9953,22 @@ STATE:                                  [31mdezaktywowanie[0m
 ACTIVE-PATH:                            [31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m
 SLAVE:                                  [31m--[0m
 FILENAME:                               [31m/etc/NetworkManager/system-connections/ethernet[0m
+-------------------------------------------------------------------------------
+NAME:                                   [32methernet[0m
+UUID:                                   [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m
+TYPE:                                   [32methernet[0m
+TIMESTAMP:                              [32m0[0m
+TIMESTAMP-REAL:                         [32mnigdy[0m
+AUTOCONNECT:                            [32mtak[0m
+AUTOCONNECT-PRIORITY:                   [32m0[0m
+READONLY:                               [32mnie[0m
+DBUS-PATH:                              [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m
+ACTIVE:                                 [32mtak[0m
+DEVICE:                                 [32meth1[0m
+STATE:                                  [32maktywowano[0m
+ACTIVE-PATH:                            [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
+SLAVE:                                  [32m--[0m
+FILENAME:                               [32m/etc/NetworkManager/system-connections/ethernet[0m
 -------------------------------------------------------------------------------
 NAME:                                   con-1
 UUID:                                   5fcfd6d7-1e63-3332-8826-a7eda103792d
@@ -10729,9 +10729,9 @@ AUTOCONNECT-PRIORITY:0
 READONLY:no
 DBUS-PATH:/org/freedesktop/NetworkManager/Settings/Connection/4
 ACTIVE:yes
-DEVICE:eth1
-STATE:activated
-ACTIVE-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
+DEVICE:eth0
+STATE:deactivating
+ACTIVE-PATH:/org/freedesktop/NetworkManager/ActiveConnection/1
 SLAVE:
 FILENAME:/etc/NetworkManager/system-connections/ethernet
 NAME:ethernet
@@ -10744,9 +10744,9 @@ AUTOCONNECT-PRIORITY:0
 READONLY:no
 DBUS-PATH:/org/freedesktop/NetworkManager/Settings/Connection/4
 ACTIVE:yes
-DEVICE:eth0
-STATE:deactivating
-ACTIVE-PATH:/org/freedesktop/NetworkManager/ActiveConnection/1
+DEVICE:eth1
+STATE:activated
+ACTIVE-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
 SLAVE:
 FILENAME:/etc/NetworkManager/system-connections/ethernet
 NAME:con-1
@@ -10813,9 +10813,9 @@ AUTOCONNECT-PRIORITY:0
 READONLY:no
 DBUS-PATH:/org/freedesktop/NetworkManager/Settings/Connection/4
 ACTIVE:yes
-DEVICE:eth1
-STATE:activated
-ACTIVE-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
+DEVICE:eth0
+STATE:deactivating
+ACTIVE-PATH:/org/freedesktop/NetworkManager/ActiveConnection/1
 SLAVE:
 FILENAME:/etc/NetworkManager/system-connections/ethernet
 NAME:ethernet
@@ -10828,9 +10828,9 @@ AUTOCONNECT-PRIORITY:0
 READONLY:no
 DBUS-PATH:/org/freedesktop/NetworkManager/Settings/Connection/4
 ACTIVE:yes
-DEVICE:eth0
-STATE:deactivating
-ACTIVE-PATH:/org/freedesktop/NetworkManager/ActiveConnection/1
+DEVICE:eth1
+STATE:activated
+ACTIVE-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
 SLAVE:
 FILENAME:/etc/NetworkManager/system-connections/ethernet
 NAME:con-1
@@ -11487,21 +11487,6 @@ lang: C
 returncode: 0
 stdout: 2011 bytes
 >>>
-NAME:[32methernet[0m
-UUID:[32mUUID-ethernet-REPLACED-REPLACED-REPL[0m
-TYPE:[32m802-3-ethernet[0m
-TIMESTAMP:[32m0[0m
-TIMESTAMP-REAL:[32mnever[0m
-AUTOCONNECT:[32myes[0m
-AUTOCONNECT-PRIORITY:[32m0[0m
-READONLY:[32mno[0m
-DBUS-PATH:[32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m
-ACTIVE:[32myes[0m
-DEVICE:[32meth1[0m
-STATE:[32mactivated[0m
-ACTIVE-PATH:[32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
-SLAVE:[32m[0m
-FILENAME:[32m/etc/NetworkManager/system-connections/ethernet[0m
 NAME:[31methernet[0m
 UUID:[31mUUID-ethernet-REPLACED-REPLACED-REPL[0m
 TYPE:[31m802-3-ethernet[0m
@@ -11517,6 +11502,21 @@ STATE:[31mdeactivating[0m
 ACTIVE-PATH:[31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m
 SLAVE:[31m[0m
 FILENAME:[31m/etc/NetworkManager/system-connections/ethernet[0m
+NAME:[32methernet[0m
+UUID:[32mUUID-ethernet-REPLACED-REPLACED-REPL[0m
+TYPE:[32m802-3-ethernet[0m
+TIMESTAMP:[32m0[0m
+TIMESTAMP-REAL:[32mnever[0m
+AUTOCONNECT:[32myes[0m
+AUTOCONNECT-PRIORITY:[32m0[0m
+READONLY:[32mno[0m
+DBUS-PATH:[32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m
+ACTIVE:[32myes[0m
+DEVICE:[32meth1[0m
+STATE:[32mactivated[0m
+ACTIVE-PATH:[32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
+SLAVE:[32m[0m
+FILENAME:[32m/etc/NetworkManager/system-connections/ethernet[0m
 NAME:con-1
 UUID:5fcfd6d7-1e63-3332-8826-a7eda103792d
 TYPE:802-3-ethernet
@@ -11571,21 +11571,6 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 2011 bytes
 >>>
-NAME:[32methernet[0m
-UUID:[32mUUID-ethernet-REPLACED-REPLACED-REPL[0m
-TYPE:[32m802-3-ethernet[0m
-TIMESTAMP:[32m0[0m
-TIMESTAMP-REAL:[32mnever[0m
-AUTOCONNECT:[32myes[0m
-AUTOCONNECT-PRIORITY:[32m0[0m
-READONLY:[32mno[0m
-DBUS-PATH:[32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m
-ACTIVE:[32myes[0m
-DEVICE:[32meth1[0m
-STATE:[32mactivated[0m
-ACTIVE-PATH:[32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
-SLAVE:[32m[0m
-FILENAME:[32m/etc/NetworkManager/system-connections/ethernet[0m
 NAME:[31methernet[0m
 UUID:[31mUUID-ethernet-REPLACED-REPLACED-REPL[0m
 TYPE:[31m802-3-ethernet[0m
@@ -11601,6 +11586,21 @@ STATE:[31mdeactivating[0m
 ACTIVE-PATH:[31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m
 SLAVE:[31m[0m
 FILENAME:[31m/etc/NetworkManager/system-connections/ethernet[0m
+NAME:[32methernet[0m
+UUID:[32mUUID-ethernet-REPLACED-REPLACED-REPL[0m
+TYPE:[32m802-3-ethernet[0m
+TIMESTAMP:[32m0[0m
+TIMESTAMP-REAL:[32mnever[0m
+AUTOCONNECT:[32myes[0m
+AUTOCONNECT-PRIORITY:[32m0[0m
+READONLY:[32mno[0m
+DBUS-PATH:[32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m
+ACTIVE:[32myes[0m
+DEVICE:[32meth1[0m
+STATE:[32mactivated[0m
+ACTIVE-PATH:[32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
+SLAVE:[32m[0m
+FILENAME:[32m/etc/NetworkManager/system-connections/ethernet[0m
 NAME:con-1
 UUID:5fcfd6d7-1e63-3332-8826-a7eda103792d
 TYPE:802-3-ethernet
@@ -12256,8 +12256,8 @@ returncode: 0
 stdout: 1938 bytes
 >>>
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE         ACTIVE-PATH                                         SLAVE  FILENAME                                        
-ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  --         --              --           --                    --        /org/freedesktop/NetworkManager/Settings/Connection/4  yes     eth1    activated     /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  --         --              --           --                    --        /org/freedesktop/NetworkManager/Settings/Connection/4  yes     eth0    deactivating  /org/freedesktop/NetworkManager/ActiveConnection/1  --     /etc/NetworkManager/system-connections/ethernet 
+ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  --         --              --           --                    --        /org/freedesktop/NetworkManager/Settings/Connection/4  yes     eth1    activated     /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/1  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          never           no           0                     no        /org/freedesktop/NetworkManager/Settings/Connection/3  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/2  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -12271,8 +12271,8 @@ returncode: 0
 stdout: 1950 bytes
 >>>
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE           ACTIVE-PATH                                         SLAVE  FILENAME                                        
-ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  --         --              --           --                    --        /org/freedesktop/NetworkManager/Settings/Connection/4  tak     eth1    aktywowano      /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  --         --              --           --                    --        /org/freedesktop/NetworkManager/Settings/Connection/4  tak     eth0    dezaktywowanie  /org/freedesktop/NetworkManager/ActiveConnection/1  --     /etc/NetworkManager/system-connections/ethernet 
+ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  --         --              --           --                    --        /org/freedesktop/NetworkManager/Settings/Connection/4  tak     eth1    aktywowano      /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/1  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          nigdy           nie          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/3  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/2  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -12506,8 +12506,8 @@ returncode: 0
 stdout: 2208 bytes
 >>>
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE         ACTIVE-PATH                                         SLAVE  FILENAME                                        
-[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m--[0m         [32m--[0m              [32m--[0m           [32m--[0m                    [32m--[0m        [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32myes[0m     [32meth1[0m    [32mactivated[0m     [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 [31methernet[0m  [31mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [31methernet[0m  [31m--[0m         [31m--[0m              [31m--[0m           [31m--[0m                    [31m--[0m        [31m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [31myes[0m     [31meth0[0m    [31mdeactivating[0m  [31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m  [31m--[0m     [31m/etc/NetworkManager/system-connections/ethernet[0m 
+[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m--[0m         [32m--[0m              [32m--[0m           [32m--[0m                    [32m--[0m        [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32myes[0m     [32meth1[0m    [32mactivated[0m     [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/1  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          never           no           0                     no        /org/freedesktop/NetworkManager/Settings/Connection/3  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/2  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -12521,8 +12521,8 @@ returncode: 0
 stdout: 2220 bytes
 >>>
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE           ACTIVE-PATH                                         SLAVE  FILENAME                                        
-[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m--[0m         [32m--[0m              [32m--[0m           [32m--[0m                    [32m--[0m        [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32mtak[0m     [32meth1[0m    [32maktywowano[0m      [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 [31methernet[0m  [31mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [31methernet[0m  [31m--[0m         [31m--[0m              [31m--[0m           [31m--[0m                    [31m--[0m        [31m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [31mtak[0m     [31meth0[0m    [31mdezaktywowanie[0m  [31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m  [31m--[0m     [31m/etc/NetworkManager/system-connections/ethernet[0m 
+[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m--[0m         [32m--[0m              [32m--[0m           [32m--[0m                    [32m--[0m        [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32mtak[0m     [32meth1[0m    [32maktywowano[0m      [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/1  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          nigdy           nie          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/3  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/2  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -12760,8 +12760,8 @@ stdout: 2415 bytes
 ======================================
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE         ACTIVE-PATH                                         SLAVE  FILENAME                                        
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  --         --              --           --                    --        /org/freedesktop/NetworkManager/Settings/Connection/4  yes     eth1    activated     /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  --         --              --           --                    --        /org/freedesktop/NetworkManager/Settings/Connection/4  yes     eth0    deactivating  /org/freedesktop/NetworkManager/ActiveConnection/1  --     /etc/NetworkManager/system-connections/ethernet 
+ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  --         --              --           --                    --        /org/freedesktop/NetworkManager/Settings/Connection/4  yes     eth1    activated     /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/1  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          never           no           0                     no        /org/freedesktop/NetworkManager/Settings/Connection/3  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/2  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -12779,8 +12779,8 @@ stdout: 2449 bytes
 ==========================================
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE           ACTIVE-PATH                                         SLAVE  FILENAME                                        
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  --         --              --           --                    --        /org/freedesktop/NetworkManager/Settings/Connection/4  tak     eth1    aktywowano      /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  --         --              --           --                    --        /org/freedesktop/NetworkManager/Settings/Connection/4  tak     eth0    dezaktywowanie  /org/freedesktop/NetworkManager/ActiveConnection/1  --     /etc/NetworkManager/system-connections/ethernet 
+ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  --         --              --           --                    --        /org/freedesktop/NetworkManager/Settings/Connection/4  tak     eth1    aktywowano      /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/1  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          nigdy           nie          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/3  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/2  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -13062,8 +13062,8 @@ stdout: 2685 bytes
 ======================================
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE         ACTIVE-PATH                                         SLAVE  FILENAME                                        
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m--[0m         [32m--[0m              [32m--[0m           [32m--[0m                    [32m--[0m        [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32myes[0m     [32meth1[0m    [32mactivated[0m     [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 [31methernet[0m  [31mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [31methernet[0m  [31m--[0m         [31m--[0m              [31m--[0m           [31m--[0m                    [31m--[0m        [31m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [31myes[0m     [31meth0[0m    [31mdeactivating[0m  [31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m  [31m--[0m     [31m/etc/NetworkManager/system-connections/ethernet[0m 
+[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m--[0m         [32m--[0m              [32m--[0m           [32m--[0m                    [32m--[0m        [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32myes[0m     [32meth1[0m    [32mactivated[0m     [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/1  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          never           no           0                     no        /org/freedesktop/NetworkManager/Settings/Connection/3  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/2  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -13081,8 +13081,8 @@ stdout: 2719 bytes
 ==========================================
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE           ACTIVE-PATH                                         SLAVE  FILENAME                                        
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m--[0m         [32m--[0m              [32m--[0m           [32m--[0m                    [32m--[0m        [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32mtak[0m     [32meth1[0m    [32maktywowano[0m      [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 [31methernet[0m  [31mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [31methernet[0m  [31m--[0m         [31m--[0m              [31m--[0m           [31m--[0m                    [31m--[0m        [31m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [31mtak[0m     [31meth0[0m    [31mdezaktywowanie[0m  [31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m  [31m--[0m     [31m/etc/NetworkManager/system-connections/ethernet[0m 
+[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m--[0m         [32m--[0m              [32m--[0m           [32m--[0m                    [32m--[0m        [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32mtak[0m     [32meth1[0m    [32maktywowano[0m      [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/1  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          nigdy           nie          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/3  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/2  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -13359,8 +13359,8 @@ lang: C
 returncode: 0
 stdout: 1022 bytes
 >>>
-ethernet:UUID-ethernet-REPLACED-REPLACED-REPL:802-3-ethernet::::::/org/freedesktop/NetworkManager/Settings/Connection/4:yes:eth1:activated:/org/freedesktop/NetworkManager/ActiveConnection/2::/etc/NetworkManager/system-connections/ethernet
 ethernet:UUID-ethernet-REPLACED-REPLACED-REPL:802-3-ethernet::::::/org/freedesktop/NetworkManager/Settings/Connection/4:yes:eth0:deactivating:/org/freedesktop/NetworkManager/ActiveConnection/1::/etc/NetworkManager/system-connections/ethernet
+ethernet:UUID-ethernet-REPLACED-REPLACED-REPL:802-3-ethernet::::::/org/freedesktop/NetworkManager/Settings/Connection/4:yes:eth1:activated:/org/freedesktop/NetworkManager/ActiveConnection/2::/etc/NetworkManager/system-connections/ethernet
 con-1:5fcfd6d7-1e63-3332-8826-a7eda103792d:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/1:no:::::/etc/NetworkManager/system-connections/con-1
 con-gsm1:UUID-con-gsm1-REPLACED-REPLACED-REPL:gsm:0:never:no:0:no:/org/freedesktop/NetworkManager/Settings/Connection/3:no:::::/etc/NetworkManager/system-connections/con-gsm1
 con-xx1:UUID-con-xx1-REPLACED-REPLACED-REPLA:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/2:no:::::/etc/NetworkManager/system-connections/con-xx1
@@ -13373,8 +13373,8 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 1022 bytes
 >>>
-ethernet:UUID-ethernet-REPLACED-REPLACED-REPL:802-3-ethernet::::::/org/freedesktop/NetworkManager/Settings/Connection/4:yes:eth1:activated:/org/freedesktop/NetworkManager/ActiveConnection/2::/etc/NetworkManager/system-connections/ethernet
 ethernet:UUID-ethernet-REPLACED-REPLACED-REPL:802-3-ethernet::::::/org/freedesktop/NetworkManager/Settings/Connection/4:yes:eth0:deactivating:/org/freedesktop/NetworkManager/ActiveConnection/1::/etc/NetworkManager/system-connections/ethernet
+ethernet:UUID-ethernet-REPLACED-REPLACED-REPL:802-3-ethernet::::::/org/freedesktop/NetworkManager/Settings/Connection/4:yes:eth1:activated:/org/freedesktop/NetworkManager/ActiveConnection/2::/etc/NetworkManager/system-connections/ethernet
 con-1:5fcfd6d7-1e63-3332-8826-a7eda103792d:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/1:no:::::/etc/NetworkManager/system-connections/con-1
 con-gsm1:UUID-con-gsm1-REPLACED-REPLACED-REPL:gsm:0:never:no:0:no:/org/freedesktop/NetworkManager/Settings/Connection/3:no:::::/etc/NetworkManager/system-connections/con-gsm1
 con-xx1:UUID-con-xx1-REPLACED-REPLACED-REPLA:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/2:no:::::/etc/NetworkManager/system-connections/con-xx1
@@ -13605,8 +13605,8 @@ lang: C
 returncode: 0
 stdout: 1292 bytes
 >>>
-[32methernet[0m:[32mUUID-ethernet-REPLACED-REPLACED-REPL[0m:[32m802-3-ethernet[0m:[32m[0m:[32m[0m:[32m[0m:[32m[0m:[32m[0m:[32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m:[32myes[0m:[32meth1[0m:[32mactivated[0m:[32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m:[32m[0m:[32m/etc/NetworkManager/system-connections/ethernet[0m
 [31methernet[0m:[31mUUID-ethernet-REPLACED-REPLACED-REPL[0m:[31m802-3-ethernet[0m:[31m[0m:[31m[0m:[31m[0m:[31m[0m:[31m[0m:[31m/org/freedesktop/NetworkManager/Settings/Connection/4[0m:[31myes[0m:[31meth0[0m:[31mdeactivating[0m:[31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m:[31m[0m:[31m/etc/NetworkManager/system-connections/ethernet[0m
+[32methernet[0m:[32mUUID-ethernet-REPLACED-REPLACED-REPL[0m:[32m802-3-ethernet[0m:[32m[0m:[32m[0m:[32m[0m:[32m[0m:[32m[0m:[32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m:[32myes[0m:[32meth1[0m:[32mactivated[0m:[32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m:[32m[0m:[32m/etc/NetworkManager/system-connections/ethernet[0m
 con-1:5fcfd6d7-1e63-3332-8826-a7eda103792d:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/1:no:::::/etc/NetworkManager/system-connections/con-1
 con-gsm1:UUID-con-gsm1-REPLACED-REPLACED-REPL:gsm:0:never:no:0:no:/org/freedesktop/NetworkManager/Settings/Connection/3:no:::::/etc/NetworkManager/system-connections/con-gsm1
 con-xx1:UUID-con-xx1-REPLACED-REPLACED-REPLA:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/2:no:::::/etc/NetworkManager/system-connections/con-xx1
@@ -13619,8 +13619,8 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 1292 bytes
 >>>
-[32methernet[0m:[32mUUID-ethernet-REPLACED-REPLACED-REPL[0m:[32m802-3-ethernet[0m:[32m[0m:[32m[0m:[32m[0m:[32m[0m:[32m[0m:[32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m:[32myes[0m:[32meth1[0m:[32mactivated[0m:[32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m:[32m[0m:[32m/etc/NetworkManager/system-connections/ethernet[0m
 [31methernet[0m:[31mUUID-ethernet-REPLACED-REPLACED-REPL[0m:[31m802-3-ethernet[0m:[31m[0m:[31m[0m:[31m[0m:[31m[0m:[31m[0m:[31m/org/freedesktop/NetworkManager/Settings/Connection/4[0m:[31myes[0m:[31meth0[0m:[31mdeactivating[0m:[31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m:[31m[0m:[31m/etc/NetworkManager/system-connections/ethernet[0m
+[32methernet[0m:[32mUUID-ethernet-REPLACED-REPLACED-REPL[0m:[32m802-3-ethernet[0m:[32m[0m:[32m[0m:[32m[0m:[32m[0m:[32m[0m:[32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m:[32myes[0m:[32meth1[0m:[32mactivated[0m:[32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m:[32m[0m:[32m/etc/NetworkManager/system-connections/ethernet[0m
 con-1:5fcfd6d7-1e63-3332-8826-a7eda103792d:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/1:no:::::/etc/NetworkManager/system-connections/con-1
 con-gsm1:UUID-con-gsm1-REPLACED-REPLACED-REPL:gsm:0:never:no:0:no:/org/freedesktop/NetworkManager/Settings/Connection/3:no:::::/etc/NetworkManager/system-connections/con-gsm1
 con-xx1:UUID-con-xx1-REPLACED-REPLACED-REPLA:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/2:no:::::/etc/NetworkManager/system-connections/con-xx1
@@ -13852,8 +13852,8 @@ returncode: 0
 stdout: 1938 bytes
 >>>
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE         ACTIVE-PATH                                         SLAVE  FILENAME                                        
-ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  --         --              --           --                    --        /org/freedesktop/NetworkManager/Settings/Connection/4  yes     eth1    activated     /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  --         --              --           --                    --        /org/freedesktop/NetworkManager/Settings/Connection/4  yes     eth0    deactivating  /org/freedesktop/NetworkManager/ActiveConnection/1  --     /etc/NetworkManager/system-connections/ethernet 
+ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  --         --              --           --                    --        /org/freedesktop/NetworkManager/Settings/Connection/4  yes     eth1    activated     /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/1  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          never           no           0                     no        /org/freedesktop/NetworkManager/Settings/Connection/3  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/2  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -13867,8 +13867,8 @@ returncode: 0
 stdout: 1950 bytes
 >>>
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE           ACTIVE-PATH                                         SLAVE  FILENAME                                        
-ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  --         --              --           --                    --        /org/freedesktop/NetworkManager/Settings/Connection/4  tak     eth1    aktywowano      /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  --         --              --           --                    --        /org/freedesktop/NetworkManager/Settings/Connection/4  tak     eth0    dezaktywowanie  /org/freedesktop/NetworkManager/ActiveConnection/1  --     /etc/NetworkManager/system-connections/ethernet 
+ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  --         --              --           --                    --        /org/freedesktop/NetworkManager/Settings/Connection/4  tak     eth1    aktywowano      /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/1  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          nigdy           nie          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/3  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/2  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -14016,8 +14016,8 @@ returncode: 0
 stdout: 2208 bytes
 >>>
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE         ACTIVE-PATH                                         SLAVE  FILENAME                                        
-[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m--[0m         [32m--[0m              [32m--[0m           [32m--[0m                    [32m--[0m        [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32myes[0m     [32meth1[0m    [32mactivated[0m     [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 [31methernet[0m  [31mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [31methernet[0m  [31m--[0m         [31m--[0m              [31m--[0m           [31m--[0m                    [31m--[0m        [31m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [31myes[0m     [31meth0[0m    [31mdeactivating[0m  [31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m  [31m--[0m     [31m/etc/NetworkManager/system-connections/ethernet[0m 
+[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m--[0m         [32m--[0m              [32m--[0m           [32m--[0m                    [32m--[0m        [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32myes[0m     [32meth1[0m    [32mactivated[0m     [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/1  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          never           no           0                     no        /org/freedesktop/NetworkManager/Settings/Connection/3  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/2  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -14031,8 +14031,8 @@ returncode: 0
 stdout: 2220 bytes
 >>>
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE           ACTIVE-PATH                                         SLAVE  FILENAME                                        
-[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m--[0m         [32m--[0m              [32m--[0m           [32m--[0m                    [32m--[0m        [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32mtak[0m     [32meth1[0m    [32maktywowano[0m      [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 [31methernet[0m  [31mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [31methernet[0m  [31m--[0m         [31m--[0m              [31m--[0m           [31m--[0m                    [31m--[0m        [31m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [31mtak[0m     [31meth0[0m    [31mdezaktywowanie[0m  [31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m  [31m--[0m     [31m/etc/NetworkManager/system-connections/ethernet[0m 
+[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m--[0m         [32m--[0m              [32m--[0m           [32m--[0m                    [32m--[0m        [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32mtak[0m     [32meth1[0m    [32maktywowano[0m      [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/1  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          nigdy           nie          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/3  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/2  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -14184,8 +14184,8 @@ stdout: 2415 bytes
 ======================================
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE         ACTIVE-PATH                                         SLAVE  FILENAME                                        
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  --         --              --           --                    --        /org/freedesktop/NetworkManager/Settings/Connection/4  yes     eth1    activated     /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  --         --              --           --                    --        /org/freedesktop/NetworkManager/Settings/Connection/4  yes     eth0    deactivating  /org/freedesktop/NetworkManager/ActiveConnection/1  --     /etc/NetworkManager/system-connections/ethernet 
+ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  --         --              --           --                    --        /org/freedesktop/NetworkManager/Settings/Connection/4  yes     eth1    activated     /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/1  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          never           no           0                     no        /org/freedesktop/NetworkManager/Settings/Connection/3  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/2  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -14203,8 +14203,8 @@ stdout: 2449 bytes
 ==========================================
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE           ACTIVE-PATH                                         SLAVE  FILENAME                                        
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  --         --              --           --                    --        /org/freedesktop/NetworkManager/Settings/Connection/4  tak     eth1    aktywowano      /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  --         --              --           --                    --        /org/freedesktop/NetworkManager/Settings/Connection/4  tak     eth0    dezaktywowanie  /org/freedesktop/NetworkManager/ActiveConnection/1  --     /etc/NetworkManager/system-connections/ethernet 
+ethernet  UUID-ethernet-REPLACED-REPLACED-REPL  ethernet  --         --              --           --                    --        /org/freedesktop/NetworkManager/Settings/Connection/4  tak     eth1    aktywowano      /org/freedesktop/NetworkManager/ActiveConnection/2  --     /etc/NetworkManager/system-connections/ethernet 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/1  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          nigdy           nie          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/3  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/2  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -14400,8 +14400,8 @@ stdout: 2685 bytes
 ======================================
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE         ACTIVE-PATH                                         SLAVE  FILENAME                                        
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m--[0m         [32m--[0m              [32m--[0m           [32m--[0m                    [32m--[0m        [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32myes[0m     [32meth1[0m    [32mactivated[0m     [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 [31methernet[0m  [31mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [31methernet[0m  [31m--[0m         [31m--[0m              [31m--[0m           [31m--[0m                    [31m--[0m        [31m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [31myes[0m     [31meth0[0m    [31mdeactivating[0m  [31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m  [31m--[0m     [31m/etc/NetworkManager/system-connections/ethernet[0m 
+[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m--[0m         [32m--[0m              [32m--[0m           [32m--[0m                    [32m--[0m        [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32myes[0m     [32meth1[0m    [32mactivated[0m     [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/1  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          never           no           0                     no        /org/freedesktop/NetworkManager/Settings/Connection/3  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          never           yes          0                     no        /org/freedesktop/NetworkManager/Settings/Connection/2  no      --      --            --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -14419,8 +14419,8 @@ stdout: 2719 bytes
 ==========================================
 NAME      UUID                                  TYPE      TIMESTAMP  TIMESTAMP-REAL  AUTOCONNECT  AUTOCONNECT-PRIORITY  READONLY  DBUS-PATH                                              ACTIVE  DEVICE  STATE           ACTIVE-PATH                                         SLAVE  FILENAME                                        
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m--[0m         [32m--[0m              [32m--[0m           [32m--[0m                    [32m--[0m        [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32mtak[0m     [32meth1[0m    [32maktywowano[0m      [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 [31methernet[0m  [31mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [31methernet[0m  [31m--[0m         [31m--[0m              [31m--[0m           [31m--[0m                    [31m--[0m        [31m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [31mtak[0m     [31meth0[0m    [31mdezaktywowanie[0m  [31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m  [31m--[0m     [31m/etc/NetworkManager/system-connections/ethernet[0m 
+[32methernet[0m  [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m  [32methernet[0m  [32m--[0m         [32m--[0m              [32m--[0m           [32m--[0m                    [32m--[0m        [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m  [32mtak[0m     [32meth1[0m    [32maktywowano[0m      [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m  [32m--[0m     [32m/etc/NetworkManager/system-connections/ethernet[0m 
 con-1     5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/1  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-1    
 con-gsm1  UUID-con-gsm1-REPLACED-REPLACED-REPL  gsm       0          nigdy           nie          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/3  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-gsm1 
 con-xx1   UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet  0          nigdy           tak          0                     nie       /org/freedesktop/NetworkManager/Settings/Connection/2  nie     --      --              --                                                  --     /etc/NetworkManager/system-connections/con-xx1  
@@ -14611,8 +14611,8 @@ lang: C
 returncode: 0
 stdout: 1022 bytes
 >>>
-ethernet:UUID-ethernet-REPLACED-REPLACED-REPL:802-3-ethernet::::::/org/freedesktop/NetworkManager/Settings/Connection/4:yes:eth1:activated:/org/freedesktop/NetworkManager/ActiveConnection/2::/etc/NetworkManager/system-connections/ethernet
 ethernet:UUID-ethernet-REPLACED-REPLACED-REPL:802-3-ethernet::::::/org/freedesktop/NetworkManager/Settings/Connection/4:yes:eth0:deactivating:/org/freedesktop/NetworkManager/ActiveConnection/1::/etc/NetworkManager/system-connections/ethernet
+ethernet:UUID-ethernet-REPLACED-REPLACED-REPL:802-3-ethernet::::::/org/freedesktop/NetworkManager/Settings/Connection/4:yes:eth1:activated:/org/freedesktop/NetworkManager/ActiveConnection/2::/etc/NetworkManager/system-connections/ethernet
 con-1:5fcfd6d7-1e63-3332-8826-a7eda103792d:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/1:no:::::/etc/NetworkManager/system-connections/con-1
 con-gsm1:UUID-con-gsm1-REPLACED-REPLACED-REPL:gsm:0:never:no:0:no:/org/freedesktop/NetworkManager/Settings/Connection/3:no:::::/etc/NetworkManager/system-connections/con-gsm1
 con-xx1:UUID-con-xx1-REPLACED-REPLACED-REPLA:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/2:no:::::/etc/NetworkManager/system-connections/con-xx1
@@ -14625,8 +14625,8 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 1022 bytes
 >>>
-ethernet:UUID-ethernet-REPLACED-REPLACED-REPL:802-3-ethernet::::::/org/freedesktop/NetworkManager/Settings/Connection/4:yes:eth1:activated:/org/freedesktop/NetworkManager/ActiveConnection/2::/etc/NetworkManager/system-connections/ethernet
 ethernet:UUID-ethernet-REPLACED-REPLACED-REPL:802-3-ethernet::::::/org/freedesktop/NetworkManager/Settings/Connection/4:yes:eth0:deactivating:/org/freedesktop/NetworkManager/ActiveConnection/1::/etc/NetworkManager/system-connections/ethernet
+ethernet:UUID-ethernet-REPLACED-REPLACED-REPL:802-3-ethernet::::::/org/freedesktop/NetworkManager/Settings/Connection/4:yes:eth1:activated:/org/freedesktop/NetworkManager/ActiveConnection/2::/etc/NetworkManager/system-connections/ethernet
 con-1:5fcfd6d7-1e63-3332-8826-a7eda103792d:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/1:no:::::/etc/NetworkManager/system-connections/con-1
 con-gsm1:UUID-con-gsm1-REPLACED-REPLACED-REPL:gsm:0:never:no:0:no:/org/freedesktop/NetworkManager/Settings/Connection/3:no:::::/etc/NetworkManager/system-connections/con-gsm1
 con-xx1:UUID-con-xx1-REPLACED-REPLACED-REPLA:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/2:no:::::/etc/NetworkManager/system-connections/con-xx1
@@ -14737,8 +14737,8 @@ lang: C
 returncode: 0
 stdout: 1292 bytes
 >>>
-[32methernet[0m:[32mUUID-ethernet-REPLACED-REPLACED-REPL[0m:[32m802-3-ethernet[0m:[32m[0m:[32m[0m:[32m[0m:[32m[0m:[32m[0m:[32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m:[32myes[0m:[32meth1[0m:[32mactivated[0m:[32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m:[32m[0m:[32m/etc/NetworkManager/system-connections/ethernet[0m
 [31methernet[0m:[31mUUID-ethernet-REPLACED-REPLACED-REPL[0m:[31m802-3-ethernet[0m:[31m[0m:[31m[0m:[31m[0m:[31m[0m:[31m[0m:[31m/org/freedesktop/NetworkManager/Settings/Connection/4[0m:[31myes[0m:[31meth0[0m:[31mdeactivating[0m:[31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m:[31m[0m:[31m/etc/NetworkManager/system-connections/ethernet[0m
+[32methernet[0m:[32mUUID-ethernet-REPLACED-REPLACED-REPL[0m:[32m802-3-ethernet[0m:[32m[0m:[32m[0m:[32m[0m:[32m[0m:[32m[0m:[32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m:[32myes[0m:[32meth1[0m:[32mactivated[0m:[32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m:[32m[0m:[32m/etc/NetworkManager/system-connections/ethernet[0m
 con-1:5fcfd6d7-1e63-3332-8826-a7eda103792d:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/1:no:::::/etc/NetworkManager/system-connections/con-1
 con-gsm1:UUID-con-gsm1-REPLACED-REPLACED-REPL:gsm:0:never:no:0:no:/org/freedesktop/NetworkManager/Settings/Connection/3:no:::::/etc/NetworkManager/system-connections/con-gsm1
 con-xx1:UUID-con-xx1-REPLACED-REPLACED-REPLA:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/2:no:::::/etc/NetworkManager/system-connections/con-xx1
@@ -14751,8 +14751,8 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 1292 bytes
 >>>
-[32methernet[0m:[32mUUID-ethernet-REPLACED-REPLACED-REPL[0m:[32m802-3-ethernet[0m:[32m[0m:[32m[0m:[32m[0m:[32m[0m:[32m[0m:[32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m:[32myes[0m:[32meth1[0m:[32mactivated[0m:[32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m:[32m[0m:[32m/etc/NetworkManager/system-connections/ethernet[0m
 [31methernet[0m:[31mUUID-ethernet-REPLACED-REPLACED-REPL[0m:[31m802-3-ethernet[0m:[31m[0m:[31m[0m:[31m[0m:[31m[0m:[31m[0m:[31m/org/freedesktop/NetworkManager/Settings/Connection/4[0m:[31myes[0m:[31meth0[0m:[31mdeactivating[0m:[31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m:[31m[0m:[31m/etc/NetworkManager/system-connections/ethernet[0m
+[32methernet[0m:[32mUUID-ethernet-REPLACED-REPLACED-REPL[0m:[32m802-3-ethernet[0m:[32m[0m:[32m[0m:[32m[0m:[32m[0m:[32m[0m:[32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m:[32myes[0m:[32meth1[0m:[32mactivated[0m:[32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m:[32m[0m:[32m/etc/NetworkManager/system-connections/ethernet[0m
 con-1:5fcfd6d7-1e63-3332-8826-a7eda103792d:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/1:no:::::/etc/NetworkManager/system-connections/con-1
 con-gsm1:UUID-con-gsm1-REPLACED-REPLACED-REPL:gsm:0:never:no:0:no:/org/freedesktop/NetworkManager/Settings/Connection/3:no:::::/etc/NetworkManager/system-connections/con-gsm1
 con-xx1:UUID-con-xx1-REPLACED-REPLACED-REPLA:802-3-ethernet:0:never:yes:0:no:/org/freedesktop/NetworkManager/Settings/Connection/2:no:::::/etc/NetworkManager/system-connections/con-xx1
@@ -14873,9 +14873,9 @@ AUTOCONNECT-PRIORITY:                   --
 READONLY:                               --
 DBUS-PATH:                              /org/freedesktop/NetworkManager/Settings/Connection/4
 ACTIVE:                                 yes
-DEVICE:                                 eth1
-STATE:                                  activated
-ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/2
+DEVICE:                                 eth0
+STATE:                                  deactivating
+ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/1
 SLAVE:                                  --
 FILENAME:                               /etc/NetworkManager/system-connections/ethernet
 NAME:                                   ethernet
@@ -14888,9 +14888,9 @@ AUTOCONNECT-PRIORITY:                   --
 READONLY:                               --
 DBUS-PATH:                              /org/freedesktop/NetworkManager/Settings/Connection/4
 ACTIVE:                                 yes
-DEVICE:                                 eth0
-STATE:                                  deactivating
-ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/1
+DEVICE:                                 eth1
+STATE:                                  activated
+ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/2
 SLAVE:                                  --
 FILENAME:                               /etc/NetworkManager/system-connections/ethernet
 NAME:                                   con-1
@@ -14957,9 +14957,9 @@ AUTOCONNECT-PRIORITY:                   --
 READONLY:                               --
 DBUS-PATH:                              /org/freedesktop/NetworkManager/Settings/Connection/4
 ACTIVE:                                 tak
-DEVICE:                                 eth1
-STATE:                                  aktywowano
-ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/2
+DEVICE:                                 eth0
+STATE:                                  dezaktywowanie
+ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/1
 SLAVE:                                  --
 FILENAME:                               /etc/NetworkManager/system-connections/ethernet
 NAME:                                   ethernet
@@ -14972,9 +14972,9 @@ AUTOCONNECT-PRIORITY:                   --
 READONLY:                               --
 DBUS-PATH:                              /org/freedesktop/NetworkManager/Settings/Connection/4
 ACTIVE:                                 tak
-DEVICE:                                 eth0
-STATE:                                  dezaktywowanie
-ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/1
+DEVICE:                                 eth1
+STATE:                                  aktywowano
+ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/2
 SLAVE:                                  --
 FILENAME:                               /etc/NetworkManager/system-connections/ethernet
 NAME:                                   con-1
@@ -15255,21 +15255,6 @@ lang: C
 returncode: 0
 stdout: 4316 bytes
 >>>
-NAME:                                   [32methernet[0m
-UUID:                                   [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m
-TYPE:                                   [32methernet[0m
-TIMESTAMP:                              [32m--[0m
-TIMESTAMP-REAL:                         [32m--[0m
-AUTOCONNECT:                            [32m--[0m
-AUTOCONNECT-PRIORITY:                   [32m--[0m
-READONLY:                               [32m--[0m
-DBUS-PATH:                              [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m
-ACTIVE:                                 [32myes[0m
-DEVICE:                                 [32meth1[0m
-STATE:                                  [32mactivated[0m
-ACTIVE-PATH:                            [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
-SLAVE:                                  [32m--[0m
-FILENAME:                               [32m/etc/NetworkManager/system-connections/ethernet[0m
 NAME:                                   [31methernet[0m
 UUID:                                   [31mUUID-ethernet-REPLACED-REPLACED-REPL[0m
 TYPE:                                   [31methernet[0m
@@ -15285,6 +15270,21 @@ STATE:                                  [31mdeactivating[0m
 ACTIVE-PATH:                            [31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m
 SLAVE:                                  [31m--[0m
 FILENAME:                               [31m/etc/NetworkManager/system-connections/ethernet[0m
+NAME:                                   [32methernet[0m
+UUID:                                   [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m
+TYPE:                                   [32methernet[0m
+TIMESTAMP:                              [32m--[0m
+TIMESTAMP-REAL:                         [32m--[0m
+AUTOCONNECT:                            [32m--[0m
+AUTOCONNECT-PRIORITY:                   [32m--[0m
+READONLY:                               [32m--[0m
+DBUS-PATH:                              [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m
+ACTIVE:                                 [32myes[0m
+DEVICE:                                 [32meth1[0m
+STATE:                                  [32mactivated[0m
+ACTIVE-PATH:                            [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
+SLAVE:                                  [32m--[0m
+FILENAME:                               [32m/etc/NetworkManager/system-connections/ethernet[0m
 NAME:                                   con-1
 UUID:                                   5fcfd6d7-1e63-3332-8826-a7eda103792d
 TYPE:                                   ethernet
@@ -15339,21 +15339,6 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 4326 bytes
 >>>
-NAME:                                   [32methernet[0m
-UUID:                                   [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m
-TYPE:                                   [32methernet[0m
-TIMESTAMP:                              [32m--[0m
-TIMESTAMP-REAL:                         [32m--[0m
-AUTOCONNECT:                            [32m--[0m
-AUTOCONNECT-PRIORITY:                   [32m--[0m
-READONLY:                               [32m--[0m
-DBUS-PATH:                              [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m
-ACTIVE:                                 [32mtak[0m
-DEVICE:                                 [32meth1[0m
-STATE:                                  [32maktywowano[0m
-ACTIVE-PATH:                            [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
-SLAVE:                                  [32m--[0m
-FILENAME:                               [32m/etc/NetworkManager/system-connections/ethernet[0m
 NAME:                                   [31methernet[0m
 UUID:                                   [31mUUID-ethernet-REPLACED-REPLACED-REPL[0m
 TYPE:                                   [31methernet[0m
@@ -15369,6 +15354,21 @@ STATE:                                  [31mdezaktywowanie[0m
 ACTIVE-PATH:                            [31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m
 SLAVE:                                  [31m--[0m
 FILENAME:                               [31m/etc/NetworkManager/system-connections/ethernet[0m
+NAME:                                   [32methernet[0m
+UUID:                                   [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m
+TYPE:                                   [32methernet[0m
+TIMESTAMP:                              [32m--[0m
+TIMESTAMP-REAL:                         [32m--[0m
+AUTOCONNECT:                            [32m--[0m
+AUTOCONNECT-PRIORITY:                   [32m--[0m
+READONLY:                               [32m--[0m
+DBUS-PATH:                              [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m
+ACTIVE:                                 [32mtak[0m
+DEVICE:                                 [32meth1[0m
+STATE:                                  [32maktywowano[0m
+ACTIVE-PATH:                            [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
+SLAVE:                                  [32m--[0m
+FILENAME:                               [32m/etc/NetworkManager/system-connections/ethernet[0m
 NAME:                                   con-1
 UUID:                                   5fcfd6d7-1e63-3332-8826-a7eda103792d
 TYPE:                                   ethernet
@@ -15660,9 +15660,9 @@ AUTOCONNECT-PRIORITY:                   --
 READONLY:                               --
 DBUS-PATH:                              /org/freedesktop/NetworkManager/Settings/Connection/4
 ACTIVE:                                 yes
-DEVICE:                                 eth1
-STATE:                                  activated
-ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/2
+DEVICE:                                 eth0
+STATE:                                  deactivating
+ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/1
 SLAVE:                                  --
 FILENAME:                               /etc/NetworkManager/system-connections/ethernet
 -------------------------------------------------------------------------------
@@ -15676,9 +15676,9 @@ AUTOCONNECT-PRIORITY:                   --
 READONLY:                               --
 DBUS-PATH:                              /org/freedesktop/NetworkManager/Settings/Connection/4
 ACTIVE:                                 yes
-DEVICE:                                 eth0
-STATE:                                  deactivating
-ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/1
+DEVICE:                                 eth1
+STATE:                                  activated
+ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/2
 SLAVE:                                  --
 FILENAME:                               /etc/NetworkManager/system-connections/ethernet
 -------------------------------------------------------------------------------
@@ -15752,9 +15752,9 @@ AUTOCONNECT-PRIORITY:                   --
 READONLY:                               --
 DBUS-PATH:                              /org/freedesktop/NetworkManager/Settings/Connection/4
 ACTIVE:                                 tak
-DEVICE:                                 eth1
-STATE:                                  aktywowano
-ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/2
+DEVICE:                                 eth0
+STATE:                                  dezaktywowanie
+ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/1
 SLAVE:                                  --
 FILENAME:                               /etc/NetworkManager/system-connections/ethernet
 -------------------------------------------------------------------------------
@@ -15768,9 +15768,9 @@ AUTOCONNECT-PRIORITY:                   --
 READONLY:                               --
 DBUS-PATH:                              /org/freedesktop/NetworkManager/Settings/Connection/4
 ACTIVE:                                 tak
-DEVICE:                                 eth0
-STATE:                                  dezaktywowanie
-ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/1
+DEVICE:                                 eth1
+STATE:                                  aktywowano
+ACTIVE-PATH:                            /org/freedesktop/NetworkManager/ActiveConnection/2
 SLAVE:                                  --
 FILENAME:                               /etc/NetworkManager/system-connections/ethernet
 -------------------------------------------------------------------------------
@@ -16106,22 +16106,6 @@ stdout: 4933 bytes
 ===============================================================================
                       NetworkManager connection profiles
 ===============================================================================
-NAME:                                   [32methernet[0m
-UUID:                                   [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m
-TYPE:                                   [32methernet[0m
-TIMESTAMP:                              [32m--[0m
-TIMESTAMP-REAL:                         [32m--[0m
-AUTOCONNECT:                            [32m--[0m
-AUTOCONNECT-PRIORITY:                   [32m--[0m
-READONLY:                               [32m--[0m
-DBUS-PATH:                              [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m
-ACTIVE:                                 [32myes[0m
-DEVICE:                                 [32meth1[0m
-STATE:                                  [32mactivated[0m
-ACTIVE-PATH:                            [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
-SLAVE:                                  [32m--[0m
-FILENAME:                               [32m/etc/NetworkManager/system-connections/ethernet[0m
--------------------------------------------------------------------------------
 NAME:                                   [31methernet[0m
 UUID:                                   [31mUUID-ethernet-REPLACED-REPLACED-REPL[0m
 TYPE:                                   [31methernet[0m
@@ -16137,6 +16121,22 @@ STATE:                                  [31mdeactivating[0m
 ACTIVE-PATH:                            [31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m
 SLAVE:                                  [31m--[0m
 FILENAME:                               [31m/etc/NetworkManager/system-connections/ethernet[0m
+-------------------------------------------------------------------------------
+NAME:                                   [32methernet[0m
+UUID:                                   [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m
+TYPE:                                   [32methernet[0m
+TIMESTAMP:                              [32m--[0m
+TIMESTAMP-REAL:                         [32m--[0m
+AUTOCONNECT:                            [32m--[0m
+AUTOCONNECT-PRIORITY:                   [32m--[0m
+READONLY:                               [32m--[0m
+DBUS-PATH:                              [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m
+ACTIVE:                                 [32myes[0m
+DEVICE:                                 [32meth1[0m
+STATE:                                  [32mactivated[0m
+ACTIVE-PATH:                            [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
+SLAVE:                                  [32m--[0m
+FILENAME:                               [32m/etc/NetworkManager/system-connections/ethernet[0m
 -------------------------------------------------------------------------------
 NAME:                                   con-1
 UUID:                                   5fcfd6d7-1e63-3332-8826-a7eda103792d
@@ -16198,22 +16198,6 @@ stdout: 4949 bytes
 ===============================================================================
                     Profile połączeń usługi NetworkManager
 ===============================================================================
-NAME:                                   [32methernet[0m
-UUID:                                   [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m
-TYPE:                                   [32methernet[0m
-TIMESTAMP:                              [32m--[0m
-TIMESTAMP-REAL:                         [32m--[0m
-AUTOCONNECT:                            [32m--[0m
-AUTOCONNECT-PRIORITY:                   [32m--[0m
-READONLY:                               [32m--[0m
-DBUS-PATH:                              [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m
-ACTIVE:                                 [32mtak[0m
-DEVICE:                                 [32meth1[0m
-STATE:                                  [32maktywowano[0m
-ACTIVE-PATH:                            [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
-SLAVE:                                  [32m--[0m
-FILENAME:                               [32m/etc/NetworkManager/system-connections/ethernet[0m
--------------------------------------------------------------------------------
 NAME:                                   [31methernet[0m
 UUID:                                   [31mUUID-ethernet-REPLACED-REPLACED-REPL[0m
 TYPE:                                   [31methernet[0m
@@ -16229,6 +16213,22 @@ STATE:                                  [31mdezaktywowanie[0m
 ACTIVE-PATH:                            [31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m
 SLAVE:                                  [31m--[0m
 FILENAME:                               [31m/etc/NetworkManager/system-connections/ethernet[0m
+-------------------------------------------------------------------------------
+NAME:                                   [32methernet[0m
+UUID:                                   [32mUUID-ethernet-REPLACED-REPLACED-REPL[0m
+TYPE:                                   [32methernet[0m
+TIMESTAMP:                              [32m--[0m
+TIMESTAMP-REAL:                         [32m--[0m
+AUTOCONNECT:                            [32m--[0m
+AUTOCONNECT-PRIORITY:                   [32m--[0m
+READONLY:                               [32m--[0m
+DBUS-PATH:                              [32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m
+ACTIVE:                                 [32mtak[0m
+DEVICE:                                 [32meth1[0m
+STATE:                                  [32maktywowano[0m
+ACTIVE-PATH:                            [32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
+SLAVE:                                  [32m--[0m
+FILENAME:                               [32m/etc/NetworkManager/system-connections/ethernet[0m
 -------------------------------------------------------------------------------
 NAME:                                   con-1
 UUID:                                   5fcfd6d7-1e63-3332-8826-a7eda103792d
@@ -16569,9 +16569,9 @@ AUTOCONNECT-PRIORITY:
 READONLY:
 DBUS-PATH:/org/freedesktop/NetworkManager/Settings/Connection/4
 ACTIVE:yes
-DEVICE:eth1
-STATE:activated
-ACTIVE-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
+DEVICE:eth0
+STATE:deactivating
+ACTIVE-PATH:/org/freedesktop/NetworkManager/ActiveConnection/1
 SLAVE:
 FILENAME:/etc/NetworkManager/system-connections/ethernet
 NAME:ethernet
@@ -16584,9 +16584,9 @@ AUTOCONNECT-PRIORITY:
 READONLY:
 DBUS-PATH:/org/freedesktop/NetworkManager/Settings/Connection/4
 ACTIVE:yes
-DEVICE:eth0
-STATE:deactivating
-ACTIVE-PATH:/org/freedesktop/NetworkManager/ActiveConnection/1
+DEVICE:eth1
+STATE:activated
+ACTIVE-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
 SLAVE:
 FILENAME:/etc/NetworkManager/system-connections/ethernet
 NAME:con-1
@@ -16653,9 +16653,9 @@ AUTOCONNECT-PRIORITY:
 READONLY:
 DBUS-PATH:/org/freedesktop/NetworkManager/Settings/Connection/4
 ACTIVE:yes
-DEVICE:eth1
-STATE:activated
-ACTIVE-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
+DEVICE:eth0
+STATE:deactivating
+ACTIVE-PATH:/org/freedesktop/NetworkManager/ActiveConnection/1
 SLAVE:
 FILENAME:/etc/NetworkManager/system-connections/ethernet
 NAME:ethernet
@@ -16668,9 +16668,9 @@ AUTOCONNECT-PRIORITY:
 READONLY:
 DBUS-PATH:/org/freedesktop/NetworkManager/Settings/Connection/4
 ACTIVE:yes
-DEVICE:eth0
-STATE:deactivating
-ACTIVE-PATH:/org/freedesktop/NetworkManager/ActiveConnection/1
+DEVICE:eth1
+STATE:activated
+ACTIVE-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
 SLAVE:
 FILENAME:/etc/NetworkManager/system-connections/ethernet
 NAME:con-1
@@ -16951,21 +16951,6 @@ lang: C
 returncode: 0
 stdout: 1987 bytes
 >>>
-NAME:[32methernet[0m
-UUID:[32mUUID-ethernet-REPLACED-REPLACED-REPL[0m
-TYPE:[32m802-3-ethernet[0m
-TIMESTAMP:[32m[0m
-TIMESTAMP-REAL:[32m[0m
-AUTOCONNECT:[32m[0m
-AUTOCONNECT-PRIORITY:[32m[0m
-READONLY:[32m[0m
-DBUS-PATH:[32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m
-ACTIVE:[32myes[0m
-DEVICE:[32meth1[0m
-STATE:[32mactivated[0m
-ACTIVE-PATH:[32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
-SLAVE:[32m[0m
-FILENAME:[32m/etc/NetworkManager/system-connections/ethernet[0m
 NAME:[31methernet[0m
 UUID:[31mUUID-ethernet-REPLACED-REPLACED-REPL[0m
 TYPE:[31m802-3-ethernet[0m
@@ -16981,6 +16966,21 @@ STATE:[31mdeactivating[0m
 ACTIVE-PATH:[31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m
 SLAVE:[31m[0m
 FILENAME:[31m/etc/NetworkManager/system-connections/ethernet[0m
+NAME:[32methernet[0m
+UUID:[32mUUID-ethernet-REPLACED-REPLACED-REPL[0m
+TYPE:[32m802-3-ethernet[0m
+TIMESTAMP:[32m[0m
+TIMESTAMP-REAL:[32m[0m
+AUTOCONNECT:[32m[0m
+AUTOCONNECT-PRIORITY:[32m[0m
+READONLY:[32m[0m
+DBUS-PATH:[32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m
+ACTIVE:[32myes[0m
+DEVICE:[32meth1[0m
+STATE:[32mactivated[0m
+ACTIVE-PATH:[32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
+SLAVE:[32m[0m
+FILENAME:[32m/etc/NetworkManager/system-connections/ethernet[0m
 NAME:con-1
 UUID:5fcfd6d7-1e63-3332-8826-a7eda103792d
 TYPE:802-3-ethernet
@@ -17035,21 +17035,6 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 1987 bytes
 >>>
-NAME:[32methernet[0m
-UUID:[32mUUID-ethernet-REPLACED-REPLACED-REPL[0m
-TYPE:[32m802-3-ethernet[0m
-TIMESTAMP:[32m[0m
-TIMESTAMP-REAL:[32m[0m
-AUTOCONNECT:[32m[0m
-AUTOCONNECT-PRIORITY:[32m[0m
-READONLY:[32m[0m
-DBUS-PATH:[32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m
-ACTIVE:[32myes[0m
-DEVICE:[32meth1[0m
-STATE:[32mactivated[0m
-ACTIVE-PATH:[32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
-SLAVE:[32m[0m
-FILENAME:[32m/etc/NetworkManager/system-connections/ethernet[0m
 NAME:[31methernet[0m
 UUID:[31mUUID-ethernet-REPLACED-REPLACED-REPL[0m
 TYPE:[31m802-3-ethernet[0m
@@ -17065,6 +17050,21 @@ STATE:[31mdeactivating[0m
 ACTIVE-PATH:[31m/org/freedesktop/NetworkManager/ActiveConnection/1[0m
 SLAVE:[31m[0m
 FILENAME:[31m/etc/NetworkManager/system-connections/ethernet[0m
+NAME:[32methernet[0m
+UUID:[32mUUID-ethernet-REPLACED-REPLACED-REPL[0m
+TYPE:[32m802-3-ethernet[0m
+TIMESTAMP:[32m[0m
+TIMESTAMP-REAL:[32m[0m
+AUTOCONNECT:[32m[0m
+AUTOCONNECT-PRIORITY:[32m[0m
+READONLY:[32m[0m
+DBUS-PATH:[32m/org/freedesktop/NetworkManager/Settings/Connection/4[0m
+ACTIVE:[32myes[0m
+DEVICE:[32meth1[0m
+STATE:[32mactivated[0m
+ACTIVE-PATH:[32m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
+SLAVE:[32m[0m
+FILENAME:[32m/etc/NetworkManager/system-connections/ethernet[0m
 NAME:con-1
 UUID:5fcfd6d7-1e63-3332-8826-a7eda103792d
 TYPE:802-3-ethernet

--- a/clients/tests/test-client.check-on-disk/test_004.expected
+++ b/clients/tests/test-client.check-on-disk/test_004.expected
@@ -1372,11 +1372,11 @@ returncode: 0
 stdout: 258 bytes
 >>>
 DEVICE  TYPE      STATE        CONNECTION 
+wlan0   wifi      unavailable  con-vpn-1  
 eth0    ethernet  unavailable  --         
 eth1    ethernet  unavailable  --         
 wlan1   wifi      unavailable  --         
 wlan1   wifi      unavailable  --         
-wlan0   wifi      unavailable  con-vpn-1  
 
 <<<
 size: 398
@@ -1387,11 +1387,11 @@ returncode: 0
 stdout: 263 bytes
 >>>
 DEVICE  TYPE      STATE        CONNECTION 
+wlan0   wifi      niedostępne  con-vpn-1  
 eth0    ethernet  niedostępne  --         
 eth1    ethernet  niedostępne  --         
 wlan1   wifi      niedostępne  --         
 wlan1   wifi      niedostępne  --         
-wlan0   wifi      niedostępne  con-vpn-1  
 
 <<<
 size: 1410
@@ -1402,11 +1402,11 @@ returncode: 0
 stdout: 1272 bytes
 >>>
 DEVICE  TYPE      STATE        IP4-CONNECTIVITY  IP6-CONNECTIVITY  DBUS-PATH                                  CONNECTION  CON-UUID                              CON-PATH                                           
+wlan0   wifi      unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/3  con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2 
 eth0    ethernet  unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/1  --          --                                    --                                                 
 eth1    ethernet  unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/2  --          --                                    --                                                 
 wlan1   wifi      unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/4  --          --                                    --                                                 
 wlan1   wifi      unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/5  --          --                                    --                                                 
-wlan0   wifi      unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/3  con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2 
 
 <<<
 size: 1425
@@ -1417,11 +1417,11 @@ returncode: 0
 stdout: 1277 bytes
 >>>
 DEVICE  TYPE      STATE        IP4-CONNECTIVITY  IP6-CONNECTIVITY  DBUS-PATH                                  CONNECTION  CON-UUID                              CON-PATH                                           
+wlan0   wifi      niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/3  con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2 
 eth0    ethernet  niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/1  --          --                                    --                                                 
 eth1    ethernet  niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/2  --          --                                    --                                                 
 wlan1   wifi      niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/4  --          --                                    --                                                 
 wlan1   wifi      niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/5  --          --                                    --                                                 
-wlan0   wifi      niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/3  con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2 
 
 <<<
 size: 8047
@@ -1431,6 +1431,31 @@ lang: C
 returncode: 0
 stdout: 7918 bytes
 >>>
+GENERAL.DEVICE:                         wlan0
+GENERAL.TYPE:                           wifi
+GENERAL.HWADDR:                         13:E0:74:85:7C:D9
+GENERAL.MTU:                            0
+GENERAL.STATE:                          20 (unavailable)
+GENERAL.CONNECTION:                     con-vpn-1
+GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
+IP4.ADDRESS[1]:                         192.168.228.18/32
+IP4.ADDRESS[2]:                         192.168.209.179/25
+IP4.GATEWAY:                            192.168.41.120
+IP4.DOMAIN[1]:                          sear4.foo2.bar
+IP4.DOMAIN[2]:                          sear4.fo.x.y
+IP4.DOMAIN[3]:                          sear4.foo1.bar
+IP4.DOMAIN[4]:                          sear4.foo4.bar
+IP4.DOMAIN[5]:                          sear4.fo.o.bar
+IP4.WINS[1]:                            192.168.120.79
+IP6.GATEWAY:                            --
+IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
+IP6.DOMAIN[1]:                          sear6.foo2.bar
+IP6.DOMAIN[2]:                          sear6.foo1.bar
+IP6.DOMAIN[3]:                          sear6.fo.x.y
+IP6.DOMAIN[4]:                          sear6.fo.o.bar
+IP6.DOMAIN[5]:                          sear6.foo3.bar
+IP6.DOMAIN[6]:                          sear6.foo4.bar
+
 GENERAL.DEVICE:                         eth0
 GENERAL.TYPE:                           ethernet
 GENERAL.HWADDR:                         AB:B7:BF:E2:48:E8
@@ -1543,31 +1568,6 @@ IP6.ROUTE[2]:                           dst = 2001:a::a976:2488:f49f:b48/106, nh
 IP6.ROUTE[3]:                           dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::
 IP6.DNS[1]:                             2001:a::2934:bd66:550d:ec19
 IP6.DOMAIN[1]:                          sear6.fo.x.y
-
-GENERAL.DEVICE:                         wlan0
-GENERAL.TYPE:                           wifi
-GENERAL.HWADDR:                         13:E0:74:85:7C:D9
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (unavailable)
-GENERAL.CONNECTION:                     con-vpn-1
-GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
-IP4.ADDRESS[1]:                         192.168.228.18/32
-IP4.ADDRESS[2]:                         192.168.209.179/25
-IP4.GATEWAY:                            192.168.41.120
-IP4.DOMAIN[1]:                          sear4.foo2.bar
-IP4.DOMAIN[2]:                          sear4.fo.x.y
-IP4.DOMAIN[3]:                          sear4.foo1.bar
-IP4.DOMAIN[4]:                          sear4.foo4.bar
-IP4.DOMAIN[5]:                          sear4.fo.o.bar
-IP4.WINS[1]:                            192.168.120.79
-IP6.GATEWAY:                            --
-IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
-IP6.DOMAIN[1]:                          sear6.foo2.bar
-IP6.DOMAIN[2]:                          sear6.foo1.bar
-IP6.DOMAIN[3]:                          sear6.fo.x.y
-IP6.DOMAIN[4]:                          sear6.fo.o.bar
-IP6.DOMAIN[5]:                          sear6.foo3.bar
-IP6.DOMAIN[6]:                          sear6.foo4.bar
 
 <<<
 size: 8078
@@ -1577,119 +1577,6 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 7939 bytes
 >>>
-GENERAL.DEVICE:                         eth0
-GENERAL.TYPE:                           ethernet
-GENERAL.HWADDR:                         AB:B7:BF:E2:48:E8
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (niedostępne)
-GENERAL.CONNECTION:                     --
-GENERAL.CON-PATH:                       --
-WIRED-PROPERTIES.CARRIER:               wyłączone
-IP4.ADDRESS[1]:                         192.168.49.34/22
-IP4.ADDRESS[2]:                         192.168.135.86/19
-IP4.GATEWAY:                            --
-IP4.DNS[1]:                             192.168.45.230
-IP4.DNS[2]:                             192.168.180.201
-IP4.DNS[3]:                             192.168.253.2
-IP4.DOMAIN[1]:                          sear4.foo2.bar
-IP4.DOMAIN[2]:                          sear4.foo1.bar
-IP4.WINS[1]:                            192.168.163.23
-IP4.WINS[2]:                            192.168.151.246
-IP6.ADDRESS[1]:                         2001:a::ed81:3d7:c2e9:df82/99
-IP6.GATEWAY:                            --
-IP6.DNS[1]:                             2001:a::2703:f06:9619:d89f
-IP6.DNS[2]:                             2001:a::3a75:3682:c683:8541
-IP6.DNS[3]:                             2001:a::584e:912:d5ee:c74f
-IP6.DOMAIN[1]:                          sear6.foo4.bar
-IP6.DOMAIN[2]:                          sear6.fo.o.bar
-
-GENERAL.DEVICE:                         eth1
-GENERAL.TYPE:                           ethernet
-GENERAL.HWADDR:                         E7:78:B1:93:2B:22
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (niedostępne)
-GENERAL.CONNECTION:                     --
-GENERAL.CON-PATH:                       --
-WIRED-PROPERTIES.CARRIER:               wyłączone
-IP4.ADDRESS[1]:                         192.168.127.210/25
-IP4.GATEWAY:                            192.168.88.4
-IP4.ROUTE[1]:                           dst = 192.168.222.35/19, nh = 192.168.170.142, mt = 3609264321
-IP4.ROUTE[2]:                           dst = 192.168.135.81/32, nh = 192.168.32.11, mt = 1316413247
-IP4.ROUTE[3]:                           dst = 192.168.24.65/26, nh = 192.168.23.163, mt = 3855574583
-IP4.DNS[1]:                             192.168.16.144
-IP4.DNS[2]:                             192.168.79.53
-IP4.DNS[3]:                             192.168.237.155
-IP4.DOMAIN[1]:                          sear4.foo4.bar
-IP4.DOMAIN[2]:                          sear4.foo3.bar
-IP4.DOMAIN[3]:                          sear4.foo1.bar
-IP4.WINS[1]:                            192.168.211.91
-IP4.WINS[2]:                            192.168.58.182
-IP4.WINS[3]:                            192.168.114.97
-IP6.ADDRESS[1]:                         2001:a::1c1:c178:169f:2b80/93
-IP6.ADDRESS[2]:                         2001:a::1f79:e0fb:87b9:3cc6/123
-IP6.GATEWAY:                            --
-IP6.ROUTE[1]:                           dst = 2001:a::3166:7ed1:e4ae:7612/123, nh = ::
-IP6.DNS[1]:                             2001:a::edda:955:dcf4:23d4
-IP6.DNS[2]:                             2001:a::109f:aa0f:fb4a:9d5a
-IP6.DNS[3]:                             2001:a::61cf:7c82:e9c0:c952
-IP6.DOMAIN[1]:                          sear6.foo1.bar
-
-GENERAL.DEVICE:                         wlan1
-GENERAL.TYPE:                           wifi
-GENERAL.HWADDR:                         21:E9:64:81:8C:A8
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (niedostępne)
-GENERAL.CONNECTION:                     --
-GENERAL.CON-PATH:                       --
-IP4.GATEWAY:                            192.168.57.160
-IP4.ROUTE[1]:                           dst = 192.168.36.106/21, nh = 192.168.199.128, mt = 979274165
-IP4.ROUTE[2]:                           dst = 192.168.238.130/19, nh = 0.0.0.0
-IP4.ROUTE[3]:                           dst = 192.168.224.39/32, nh = 192.168.148.69
-IP4.DNS[1]:                             192.168.61.83
-IP4.DOMAIN[1]:                          sear4.foo4.bar
-IP4.DOMAIN[2]:                          sear4.fo.x.y
-IP4.DOMAIN[3]:                          sear4.foo2.bar
-IP4.DOMAIN[4]:                          sear4.foo1.bar
-IP4.DOMAIN[5]:                          sear4.fo.o.bar
-IP4.DOMAIN[6]:                          sear4.foo3.bar
-IP6.ADDRESS[1]:                         2001:a::fa05:2ab4:9300:e8fe/116
-IP6.ADDRESS[2]:                         2001:a::e9cf:bd3:caba:99b3/86
-IP6.ADDRESS[3]:                         2001:a::2be6:44fa:2c95:5559/78
-IP6.GATEWAY:                            2001:a::4d70:d91a:770f:2319
-IP6.ROUTE[1]:                           dst = 2001:a::3cb2:719d:bb00:b22f/66, nh = 2001:a::81b1:58b9:7237:3511, mt = 2280277732
-IP6.ROUTE[2]:                           dst = 2001:a::986f:983c:5eb:1c7d/99, nh = ::, mt = 1204008676
-IP6.DNS[1]:                             2001:a::85e7:3d7d:53e8:50ac
-IP6.DNS[2]:                             2001:a::1c5:9cb5:e86d:25a5
-IP6.DOMAIN[1]:                          sear6.foo4.bar
-IP6.DOMAIN[2]:                          sear6.foo2.bar
-
-GENERAL.DEVICE:                         wlan1
-GENERAL.TYPE:                           wifi
-GENERAL.HWADDR:                         71:52:AD:63:5C:7C
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (niedostępne)
-GENERAL.CONNECTION:                     --
-GENERAL.CON-PATH:                       --
-IP4.ADDRESS[1]:                         192.168.97.124/29
-IP4.ADDRESS[2]:                         192.168.76.154/18
-IP4.GATEWAY:                            --
-IP4.ROUTE[1]:                           dst = 192.168.33.233/22, nh = 192.168.222.210, mt = 2810496551
-IP4.DNS[1]:                             192.168.107.109
-IP4.DOMAIN[1]:                          sear4.fo.o.bar
-IP4.DOMAIN[2]:                          sear4.fo.x.y
-IP4.DOMAIN[3]:                          sear4.foo2.bar
-IP4.DOMAIN[4]:                          sear4.foo3.bar
-IP4.DOMAIN[5]:                          sear4.foo4.bar
-IP4.WINS[1]:                            192.168.60.60
-IP4.WINS[2]:                            192.168.63.92
-IP6.ADDRESS[1]:                         2001:a::88ca:3654:96b:ab44/89
-IP6.GATEWAY:                            --
-IP6.ROUTE[1]:                           dst = 2001:a::cc8b:7c09:4673:bbb0/85, nh = ::, mt = 2821465568
-IP6.ROUTE[2]:                           dst = 2001:a::a976:2488:f49f:b48/106, nh = 2001:a::62ae:c734:fc7b:e931, mt = 2248613879
-IP6.ROUTE[3]:                           dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::
-IP6.DNS[1]:                             2001:a::2934:bd66:550d:ec19
-IP6.DOMAIN[1]:                          sear6.fo.x.y
-
 GENERAL.DEVICE:                         wlan0
 GENERAL.TYPE:                           wifi
 GENERAL.HWADDR:                         13:E0:74:85:7C:D9
@@ -1715,45 +1602,14 @@ IP6.DOMAIN[4]:                          sear6.fo.o.bar
 IP6.DOMAIN[5]:                          sear6.foo3.bar
 IP6.DOMAIN[6]:                          sear6.foo4.bar
 
-<<<
-size: 20670
-location: clients/tests/test-client.py:1050:test_004()/39
-cmd: $NMCLI -f all dev show
-lang: C
-returncode: 0
-stdout: 20533 bytes
->>>
 GENERAL.DEVICE:                         eth0
 GENERAL.TYPE:                           ethernet
-GENERAL.NM-TYPE:                        NMDeviceEthernet
-GENERAL.VENDOR:                         --
-GENERAL.PRODUCT:                        --
-GENERAL.DRIVER:                         virtual
-GENERAL.DRIVER-VERSION:                 --
-GENERAL.FIRMWARE-VERSION:               --
 GENERAL.HWADDR:                         AB:B7:BF:E2:48:E8
 GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (unavailable)
-GENERAL.REASON:                         0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:               0 (unknown)
-GENERAL.IP6-CONNECTIVITY:               0 (unknown)
-GENERAL.UDI:                            /sys/devices/virtual/eth0
-GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    no
-GENERAL.NM-MANAGED:                     yes
-GENERAL.AUTOCONNECT:                    yes
-GENERAL.FIRMWARE-MISSING:               no
-GENERAL.NM-PLUGIN-MISSING:              no
-GENERAL.PHYS-PORT-ID:                   --
+GENERAL.STATE:                          20 (niedostępne)
 GENERAL.CONNECTION:                     --
-GENERAL.CON-UUID:                       --
 GENERAL.CON-PATH:                       --
-GENERAL.METERED:                        unknown
-CAPABILITIES.CARRIER-DETECT:            no
-CAPABILITIES.SPEED:                     100 Mb/s
-CAPABILITIES.IS-SOFTWARE:               no
-CAPABILITIES.SRIOV:                     no
-WIRED-PROPERTIES.CARRIER:               off
+WIRED-PROPERTIES.CARRIER:               wyłączone
 IP4.ADDRESS[1]:                         192.168.49.34/22
 IP4.ADDRESS[2]:                         192.168.135.86/19
 IP4.GATEWAY:                            --
@@ -1764,8 +1620,6 @@ IP4.DOMAIN[1]:                          sear4.foo2.bar
 IP4.DOMAIN[2]:                          sear4.foo1.bar
 IP4.WINS[1]:                            192.168.163.23
 IP4.WINS[2]:                            192.168.151.246
-DHCP4.OPTION[1]:                        dhcp-4-opt-8 = val-8
-DHCP4.OPTION[2]:                        dhcp-4-opt-9 = val-9
 IP6.ADDRESS[1]:                         2001:a::ed81:3d7:c2e9:df82/99
 IP6.GATEWAY:                            --
 IP6.DNS[1]:                             2001:a::2703:f06:9619:d89f
@@ -1773,50 +1627,15 @@ IP6.DNS[2]:                             2001:a::3a75:3682:c683:8541
 IP6.DNS[3]:                             2001:a::584e:912:d5ee:c74f
 IP6.DOMAIN[1]:                          sear6.foo4.bar
 IP6.DOMAIN[2]:                          sear6.fo.o.bar
-DHCP6.OPTION[1]:                        dhcp-6-opt-0 = val-0
-DHCP6.OPTION[2]:                        dhcp-6-opt-1 = val-1
-DHCP6.OPTION[3]:                        dhcp-6-opt-2 = val-2
-DHCP6.OPTION[4]:                        dhcp-6-opt-3 = val-3
-DHCP6.OPTION[5]:                        dhcp-6-opt-4 = val-4
-DHCP6.OPTION[6]:                        dhcp-6-opt-5 = val-5
-DHCP6.OPTION[7]:                        dhcp-6-opt-6 = val-6
-DHCP6.OPTION[8]:                        dhcp-6-opt-7 = val-7
-DHCP6.OPTION[9]:                        dhcp-6-opt-8 = val-8
-DHCP6.OPTION[10]:                       dhcp-6-opt-9 = val-9
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{1}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   5fcfd6d7-1e63-3332-8826-a7eda103792d | con-1
 
 GENERAL.DEVICE:                         eth1
 GENERAL.TYPE:                           ethernet
-GENERAL.NM-TYPE:                        NMDeviceEthernet
-GENERAL.VENDOR:                         --
-GENERAL.PRODUCT:                        --
-GENERAL.DRIVER:                         virtual
-GENERAL.DRIVER-VERSION:                 --
-GENERAL.FIRMWARE-VERSION:               --
 GENERAL.HWADDR:                         E7:78:B1:93:2B:22
 GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (unavailable)
-GENERAL.REASON:                         0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:               0 (unknown)
-GENERAL.IP6-CONNECTIVITY:               0 (unknown)
-GENERAL.UDI:                            /sys/devices/virtual/eth1
-GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    no
-GENERAL.NM-MANAGED:                     yes
-GENERAL.AUTOCONNECT:                    yes
-GENERAL.FIRMWARE-MISSING:               no
-GENERAL.NM-PLUGIN-MISSING:              no
-GENERAL.PHYS-PORT-ID:                   --
+GENERAL.STATE:                          20 (niedostępne)
 GENERAL.CONNECTION:                     --
-GENERAL.CON-UUID:                       --
 GENERAL.CON-PATH:                       --
-GENERAL.METERED:                        unknown
-CAPABILITIES.CARRIER-DETECT:            no
-CAPABILITIES.SPEED:                     100 Mb/s
-CAPABILITIES.IS-SOFTWARE:               no
-CAPABILITIES.SRIOV:                     no
-WIRED-PROPERTIES.CARRIER:               off
+WIRED-PROPERTIES.CARRIER:               wyłączone
 IP4.ADDRESS[1]:                         192.168.127.210/25
 IP4.GATEWAY:                            192.168.88.4
 IP4.ROUTE[1]:                           dst = 192.168.222.35/19, nh = 192.168.170.142, mt = 3609264321
@@ -1831,15 +1650,6 @@ IP4.DOMAIN[3]:                          sear4.foo1.bar
 IP4.WINS[1]:                            192.168.211.91
 IP4.WINS[2]:                            192.168.58.182
 IP4.WINS[3]:                            192.168.114.97
-DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:                        dhcp-4-opt-1 = val-1
-DHCP4.OPTION[3]:                        dhcp-4-opt-2 = val-2
-DHCP4.OPTION[4]:                        dhcp-4-opt-3 = val-3
-DHCP4.OPTION[5]:                        dhcp-4-opt-4 = val-4
-DHCP4.OPTION[6]:                        dhcp-4-opt-5 = val-5
-DHCP4.OPTION[7]:                        dhcp-4-opt-7 = val-7
-DHCP4.OPTION[8]:                        dhcp-4-opt-8 = val-8
-DHCP4.OPTION[9]:                        dhcp-4-opt-9 = val-9
 IP6.ADDRESS[1]:                         2001:a::1c1:c178:169f:2b80/93
 IP6.ADDRESS[2]:                         2001:a::1f79:e0fb:87b9:3cc6/123
 IP6.GATEWAY:                            --
@@ -1848,61 +1658,14 @@ IP6.DNS[1]:                             2001:a::edda:955:dcf4:23d4
 IP6.DNS[2]:                             2001:a::109f:aa0f:fb4a:9d5a
 IP6.DNS[3]:                             2001:a::61cf:7c82:e9c0:c952
 IP6.DOMAIN[1]:                          sear6.foo1.bar
-DHCP6.OPTION[1]:                        dhcp-6-opt-2 = val-2
-DHCP6.OPTION[2]:                        dhcp-6-opt-5 = val-5
-DHCP6.OPTION[3]:                        dhcp-6-opt-6 = val-6
-DHCP6.OPTION[4]:                        dhcp-6-opt-8 = val-8
-DHCP6.OPTION[5]:                        dhcp-6-opt-9 = val-9
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{1}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   5fcfd6d7-1e63-3332-8826-a7eda103792d | con-1
 
 GENERAL.DEVICE:                         wlan1
 GENERAL.TYPE:                           wifi
-GENERAL.NM-TYPE:                        NMDeviceWifi
-GENERAL.VENDOR:                         --
-GENERAL.PRODUCT:                        --
-GENERAL.DRIVER:                         virtual
-GENERAL.DRIVER-VERSION:                 --
-GENERAL.FIRMWARE-VERSION:               --
 GENERAL.HWADDR:                         21:E9:64:81:8C:A8
 GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (unavailable)
-GENERAL.REASON:                         0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:               0 (unknown)
-GENERAL.IP6-CONNECTIVITY:               0 (unknown)
-GENERAL.UDI:                            /sys/devices/virtual/wlan1
-GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    no
-GENERAL.NM-MANAGED:                     yes
-GENERAL.AUTOCONNECT:                    yes
-GENERAL.FIRMWARE-MISSING:               no
-GENERAL.NM-PLUGIN-MISSING:              no
-GENERAL.PHYS-PORT-ID:                   --
+GENERAL.STATE:                          20 (niedostępne)
 GENERAL.CONNECTION:                     --
-GENERAL.CON-UUID:                       --
 GENERAL.CON-PATH:                       --
-GENERAL.METERED:                        unknown
-CAPABILITIES.CARRIER-DETECT:            no
-CAPABILITIES.SPEED:                     unknown
-CAPABILITIES.IS-SOFTWARE:               no
-CAPABILITIES.SRIOV:                     no
-WIFI-PROPERTIES.WEP:                    yes
-WIFI-PROPERTIES.WPA:                    yes
-WIFI-PROPERTIES.WPA2:                   yes
-WIFI-PROPERTIES.TKIP:                   yes
-WIFI-PROPERTIES.CCMP:                   yes
-WIFI-PROPERTIES.AP:                     yes
-WIFI-PROPERTIES.ADHOC:                  yes
-WIFI-PROPERTIES.2GHZ:                   unknown
-WIFI-PROPERTIES.5GHZ:                   unknown
-AP[1].IN-USE:                            
-AP[1].SSID:                             wlan1-ap-4
-AP[1].MODE:                             Infra
-AP[1].CHAN:                             1
-AP[1].RATE:                             54 Mbit/s
-AP[1].SIGNAL:                           48
-AP[1].BARS:                             **  
-AP[1].SECURITY:                         WPA1 WPA2
 IP4.GATEWAY:                            192.168.57.160
 IP4.ROUTE[1]:                           dst = 192.168.36.106/21, nh = 192.168.199.128, mt = 979274165
 IP4.ROUTE[2]:                           dst = 192.168.238.130/19, nh = 0.0.0.0
@@ -1914,14 +1677,6 @@ IP4.DOMAIN[3]:                          sear4.foo2.bar
 IP4.DOMAIN[4]:                          sear4.foo1.bar
 IP4.DOMAIN[5]:                          sear4.fo.o.bar
 IP4.DOMAIN[6]:                          sear4.foo3.bar
-DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:                        dhcp-4-opt-1 = val-1
-DHCP4.OPTION[3]:                        dhcp-4-opt-2 = val-2
-DHCP4.OPTION[4]:                        dhcp-4-opt-4 = val-4
-DHCP4.OPTION[5]:                        dhcp-4-opt-6 = val-6
-DHCP4.OPTION[6]:                        dhcp-4-opt-7 = val-7
-DHCP4.OPTION[7]:                        dhcp-4-opt-8 = val-8
-DHCP4.OPTION[8]:                        dhcp-4-opt-9 = val-9
 IP6.ADDRESS[1]:                         2001:a::fa05:2ab4:9300:e8fe/116
 IP6.ADDRESS[2]:                         2001:a::e9cf:bd3:caba:99b3/86
 IP6.ADDRESS[3]:                         2001:a::2be6:44fa:2c95:5559/78
@@ -1932,57 +1687,14 @@ IP6.DNS[1]:                             2001:a::85e7:3d7d:53e8:50ac
 IP6.DNS[2]:                             2001:a::1c5:9cb5:e86d:25a5
 IP6.DOMAIN[1]:                          sear6.foo4.bar
 IP6.DOMAIN[2]:                          sear6.foo2.bar
-DHCP6.OPTION[1]:                        dhcp-6-opt-0 = val-0
-DHCP6.OPTION[2]:                        dhcp-6-opt-1 = val-1
-DHCP6.OPTION[3]:                        dhcp-6-opt-2 = val-2
-DHCP6.OPTION[4]:                        dhcp-6-opt-3 = val-3
-DHCP6.OPTION[5]:                        dhcp-6-opt-4 = val-4
-DHCP6.OPTION[6]:                        dhcp-6-opt-5 = val-5
-DHCP6.OPTION[7]:                        dhcp-6-opt-6 = val-6
-DHCP6.OPTION[8]:                        dhcp-6-opt-7 = val-7
-DHCP6.OPTION[9]:                        dhcp-6-opt-9 = val-9
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
 GENERAL.DEVICE:                         wlan1
 GENERAL.TYPE:                           wifi
-GENERAL.NM-TYPE:                        NMDeviceWifi
-GENERAL.VENDOR:                         --
-GENERAL.PRODUCT:                        --
-GENERAL.DRIVER:                         virtual
-GENERAL.DRIVER-VERSION:                 --
-GENERAL.FIRMWARE-VERSION:               --
 GENERAL.HWADDR:                         71:52:AD:63:5C:7C
 GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (unavailable)
-GENERAL.REASON:                         0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:               0 (unknown)
-GENERAL.IP6-CONNECTIVITY:               0 (unknown)
-GENERAL.UDI:                            /sys/devices/virtual/wlan1
-GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    no
-GENERAL.NM-MANAGED:                     yes
-GENERAL.AUTOCONNECT:                    yes
-GENERAL.FIRMWARE-MISSING:               no
-GENERAL.NM-PLUGIN-MISSING:              no
-GENERAL.PHYS-PORT-ID:                   --
+GENERAL.STATE:                          20 (niedostępne)
 GENERAL.CONNECTION:                     --
-GENERAL.CON-UUID:                       --
 GENERAL.CON-PATH:                       --
-GENERAL.METERED:                        unknown
-CAPABILITIES.CARRIER-DETECT:            no
-CAPABILITIES.SPEED:                     unknown
-CAPABILITIES.IS-SOFTWARE:               no
-CAPABILITIES.SRIOV:                     no
-WIFI-PROPERTIES.WEP:                    yes
-WIFI-PROPERTIES.WPA:                    yes
-WIFI-PROPERTIES.WPA2:                   yes
-WIFI-PROPERTIES.TKIP:                   yes
-WIFI-PROPERTIES.CCMP:                   yes
-WIFI-PROPERTIES.AP:                     yes
-WIFI-PROPERTIES.ADHOC:                  yes
-WIFI-PROPERTIES.2GHZ:                   unknown
-WIFI-PROPERTIES.5GHZ:                   unknown
 IP4.ADDRESS[1]:                         192.168.97.124/29
 IP4.ADDRESS[2]:                         192.168.76.154/18
 IP4.GATEWAY:                            --
@@ -1995,8 +1707,6 @@ IP4.DOMAIN[4]:                          sear4.foo3.bar
 IP4.DOMAIN[5]:                          sear4.foo4.bar
 IP4.WINS[1]:                            192.168.60.60
 IP4.WINS[2]:                            192.168.63.92
-DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:                        dhcp-4-opt-5 = val-5
 IP6.ADDRESS[1]:                         2001:a::88ca:3654:96b:ab44/89
 IP6.GATEWAY:                            --
 IP6.ROUTE[1]:                           dst = 2001:a::cc8b:7c09:4673:bbb0/85, nh = ::, mt = 2821465568
@@ -2004,14 +1714,15 @@ IP6.ROUTE[2]:                           dst = 2001:a::a976:2488:f49f:b48/106, nh
 IP6.ROUTE[3]:                           dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::
 IP6.DNS[1]:                             2001:a::2934:bd66:550d:ec19
 IP6.DOMAIN[1]:                          sear6.fo.x.y
-DHCP6.OPTION[1]:                        dhcp-6-opt-2 = val-2
-DHCP6.OPTION[2]:                        dhcp-6-opt-6 = val-6
-DHCP6.OPTION[3]:                        dhcp-6-opt-7 = val-7
-DHCP6.OPTION[4]:                        dhcp-6-opt-8 = val-8
-DHCP6.OPTION[5]:                        dhcp-6-opt-9 = val-9
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
+<<<
+size: 20670
+location: clients/tests/test-client.py:1050:test_004()/39
+cmd: $NMCLI -f all dev show
+lang: C
+returncode: 0
+stdout: 20533 bytes
+>>>
 GENERAL.DEVICE:                         wlan0
 GENERAL.TYPE:                           wifi
 GENERAL.NM-TYPE:                        NMDeviceWifi
@@ -2104,6 +1815,295 @@ DHCP6.OPTION[5]:                        dhcp-6-opt-5 = val-5
 CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
+GENERAL.DEVICE:                         eth0
+GENERAL.TYPE:                           ethernet
+GENERAL.NM-TYPE:                        NMDeviceEthernet
+GENERAL.VENDOR:                         --
+GENERAL.PRODUCT:                        --
+GENERAL.DRIVER:                         virtual
+GENERAL.DRIVER-VERSION:                 --
+GENERAL.FIRMWARE-VERSION:               --
+GENERAL.HWADDR:                         AB:B7:BF:E2:48:E8
+GENERAL.MTU:                            0
+GENERAL.STATE:                          20 (unavailable)
+GENERAL.REASON:                         0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:               0 (unknown)
+GENERAL.IP6-CONNECTIVITY:               0 (unknown)
+GENERAL.UDI:                            /sys/devices/virtual/eth0
+GENERAL.IP-IFACE:                       --
+GENERAL.IS-SOFTWARE:                    no
+GENERAL.NM-MANAGED:                     yes
+GENERAL.AUTOCONNECT:                    yes
+GENERAL.FIRMWARE-MISSING:               no
+GENERAL.NM-PLUGIN-MISSING:              no
+GENERAL.PHYS-PORT-ID:                   --
+GENERAL.CONNECTION:                     --
+GENERAL.CON-UUID:                       --
+GENERAL.CON-PATH:                       --
+GENERAL.METERED:                        unknown
+CAPABILITIES.CARRIER-DETECT:            no
+CAPABILITIES.SPEED:                     100 Mb/s
+CAPABILITIES.IS-SOFTWARE:               no
+CAPABILITIES.SRIOV:                     no
+WIRED-PROPERTIES.CARRIER:               off
+IP4.ADDRESS[1]:                         192.168.49.34/22
+IP4.ADDRESS[2]:                         192.168.135.86/19
+IP4.GATEWAY:                            --
+IP4.DNS[1]:                             192.168.45.230
+IP4.DNS[2]:                             192.168.180.201
+IP4.DNS[3]:                             192.168.253.2
+IP4.DOMAIN[1]:                          sear4.foo2.bar
+IP4.DOMAIN[2]:                          sear4.foo1.bar
+IP4.WINS[1]:                            192.168.163.23
+IP4.WINS[2]:                            192.168.151.246
+DHCP4.OPTION[1]:                        dhcp-4-opt-8 = val-8
+DHCP4.OPTION[2]:                        dhcp-4-opt-9 = val-9
+IP6.ADDRESS[1]:                         2001:a::ed81:3d7:c2e9:df82/99
+IP6.GATEWAY:                            --
+IP6.DNS[1]:                             2001:a::2703:f06:9619:d89f
+IP6.DNS[2]:                             2001:a::3a75:3682:c683:8541
+IP6.DNS[3]:                             2001:a::584e:912:d5ee:c74f
+IP6.DOMAIN[1]:                          sear6.foo4.bar
+IP6.DOMAIN[2]:                          sear6.fo.o.bar
+DHCP6.OPTION[1]:                        dhcp-6-opt-0 = val-0
+DHCP6.OPTION[2]:                        dhcp-6-opt-1 = val-1
+DHCP6.OPTION[3]:                        dhcp-6-opt-2 = val-2
+DHCP6.OPTION[4]:                        dhcp-6-opt-3 = val-3
+DHCP6.OPTION[5]:                        dhcp-6-opt-4 = val-4
+DHCP6.OPTION[6]:                        dhcp-6-opt-5 = val-5
+DHCP6.OPTION[7]:                        dhcp-6-opt-6 = val-6
+DHCP6.OPTION[8]:                        dhcp-6-opt-7 = val-7
+DHCP6.OPTION[9]:                        dhcp-6-opt-8 = val-8
+DHCP6.OPTION[10]:                       dhcp-6-opt-9 = val-9
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{1}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   5fcfd6d7-1e63-3332-8826-a7eda103792d | con-1
+
+GENERAL.DEVICE:                         eth1
+GENERAL.TYPE:                           ethernet
+GENERAL.NM-TYPE:                        NMDeviceEthernet
+GENERAL.VENDOR:                         --
+GENERAL.PRODUCT:                        --
+GENERAL.DRIVER:                         virtual
+GENERAL.DRIVER-VERSION:                 --
+GENERAL.FIRMWARE-VERSION:               --
+GENERAL.HWADDR:                         E7:78:B1:93:2B:22
+GENERAL.MTU:                            0
+GENERAL.STATE:                          20 (unavailable)
+GENERAL.REASON:                         0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:               0 (unknown)
+GENERAL.IP6-CONNECTIVITY:               0 (unknown)
+GENERAL.UDI:                            /sys/devices/virtual/eth1
+GENERAL.IP-IFACE:                       --
+GENERAL.IS-SOFTWARE:                    no
+GENERAL.NM-MANAGED:                     yes
+GENERAL.AUTOCONNECT:                    yes
+GENERAL.FIRMWARE-MISSING:               no
+GENERAL.NM-PLUGIN-MISSING:              no
+GENERAL.PHYS-PORT-ID:                   --
+GENERAL.CONNECTION:                     --
+GENERAL.CON-UUID:                       --
+GENERAL.CON-PATH:                       --
+GENERAL.METERED:                        unknown
+CAPABILITIES.CARRIER-DETECT:            no
+CAPABILITIES.SPEED:                     100 Mb/s
+CAPABILITIES.IS-SOFTWARE:               no
+CAPABILITIES.SRIOV:                     no
+WIRED-PROPERTIES.CARRIER:               off
+IP4.ADDRESS[1]:                         192.168.127.210/25
+IP4.GATEWAY:                            192.168.88.4
+IP4.ROUTE[1]:                           dst = 192.168.222.35/19, nh = 192.168.170.142, mt = 3609264321
+IP4.ROUTE[2]:                           dst = 192.168.135.81/32, nh = 192.168.32.11, mt = 1316413247
+IP4.ROUTE[3]:                           dst = 192.168.24.65/26, nh = 192.168.23.163, mt = 3855574583
+IP4.DNS[1]:                             192.168.16.144
+IP4.DNS[2]:                             192.168.79.53
+IP4.DNS[3]:                             192.168.237.155
+IP4.DOMAIN[1]:                          sear4.foo4.bar
+IP4.DOMAIN[2]:                          sear4.foo3.bar
+IP4.DOMAIN[3]:                          sear4.foo1.bar
+IP4.WINS[1]:                            192.168.211.91
+IP4.WINS[2]:                            192.168.58.182
+IP4.WINS[3]:                            192.168.114.97
+DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:                        dhcp-4-opt-1 = val-1
+DHCP4.OPTION[3]:                        dhcp-4-opt-2 = val-2
+DHCP4.OPTION[4]:                        dhcp-4-opt-3 = val-3
+DHCP4.OPTION[5]:                        dhcp-4-opt-4 = val-4
+DHCP4.OPTION[6]:                        dhcp-4-opt-5 = val-5
+DHCP4.OPTION[7]:                        dhcp-4-opt-7 = val-7
+DHCP4.OPTION[8]:                        dhcp-4-opt-8 = val-8
+DHCP4.OPTION[9]:                        dhcp-4-opt-9 = val-9
+IP6.ADDRESS[1]:                         2001:a::1c1:c178:169f:2b80/93
+IP6.ADDRESS[2]:                         2001:a::1f79:e0fb:87b9:3cc6/123
+IP6.GATEWAY:                            --
+IP6.ROUTE[1]:                           dst = 2001:a::3166:7ed1:e4ae:7612/123, nh = ::
+IP6.DNS[1]:                             2001:a::edda:955:dcf4:23d4
+IP6.DNS[2]:                             2001:a::109f:aa0f:fb4a:9d5a
+IP6.DNS[3]:                             2001:a::61cf:7c82:e9c0:c952
+IP6.DOMAIN[1]:                          sear6.foo1.bar
+DHCP6.OPTION[1]:                        dhcp-6-opt-2 = val-2
+DHCP6.OPTION[2]:                        dhcp-6-opt-5 = val-5
+DHCP6.OPTION[3]:                        dhcp-6-opt-6 = val-6
+DHCP6.OPTION[4]:                        dhcp-6-opt-8 = val-8
+DHCP6.OPTION[5]:                        dhcp-6-opt-9 = val-9
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{1}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   5fcfd6d7-1e63-3332-8826-a7eda103792d | con-1
+
+GENERAL.DEVICE:                         wlan1
+GENERAL.TYPE:                           wifi
+GENERAL.NM-TYPE:                        NMDeviceWifi
+GENERAL.VENDOR:                         --
+GENERAL.PRODUCT:                        --
+GENERAL.DRIVER:                         virtual
+GENERAL.DRIVER-VERSION:                 --
+GENERAL.FIRMWARE-VERSION:               --
+GENERAL.HWADDR:                         21:E9:64:81:8C:A8
+GENERAL.MTU:                            0
+GENERAL.STATE:                          20 (unavailable)
+GENERAL.REASON:                         0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:               0 (unknown)
+GENERAL.IP6-CONNECTIVITY:               0 (unknown)
+GENERAL.UDI:                            /sys/devices/virtual/wlan1
+GENERAL.IP-IFACE:                       --
+GENERAL.IS-SOFTWARE:                    no
+GENERAL.NM-MANAGED:                     yes
+GENERAL.AUTOCONNECT:                    yes
+GENERAL.FIRMWARE-MISSING:               no
+GENERAL.NM-PLUGIN-MISSING:              no
+GENERAL.PHYS-PORT-ID:                   --
+GENERAL.CONNECTION:                     --
+GENERAL.CON-UUID:                       --
+GENERAL.CON-PATH:                       --
+GENERAL.METERED:                        unknown
+CAPABILITIES.CARRIER-DETECT:            no
+CAPABILITIES.SPEED:                     unknown
+CAPABILITIES.IS-SOFTWARE:               no
+CAPABILITIES.SRIOV:                     no
+WIFI-PROPERTIES.WEP:                    yes
+WIFI-PROPERTIES.WPA:                    yes
+WIFI-PROPERTIES.WPA2:                   yes
+WIFI-PROPERTIES.TKIP:                   yes
+WIFI-PROPERTIES.CCMP:                   yes
+WIFI-PROPERTIES.AP:                     yes
+WIFI-PROPERTIES.ADHOC:                  yes
+WIFI-PROPERTIES.2GHZ:                   unknown
+WIFI-PROPERTIES.5GHZ:                   unknown
+AP[1].IN-USE:                            
+AP[1].SSID:                             wlan1-ap-4
+AP[1].MODE:                             Infra
+AP[1].CHAN:                             1
+AP[1].RATE:                             54 Mbit/s
+AP[1].SIGNAL:                           48
+AP[1].BARS:                             **  
+AP[1].SECURITY:                         WPA1 WPA2
+IP4.GATEWAY:                            192.168.57.160
+IP4.ROUTE[1]:                           dst = 192.168.36.106/21, nh = 192.168.199.128, mt = 979274165
+IP4.ROUTE[2]:                           dst = 192.168.238.130/19, nh = 0.0.0.0
+IP4.ROUTE[3]:                           dst = 192.168.224.39/32, nh = 192.168.148.69
+IP4.DNS[1]:                             192.168.61.83
+IP4.DOMAIN[1]:                          sear4.foo4.bar
+IP4.DOMAIN[2]:                          sear4.fo.x.y
+IP4.DOMAIN[3]:                          sear4.foo2.bar
+IP4.DOMAIN[4]:                          sear4.foo1.bar
+IP4.DOMAIN[5]:                          sear4.fo.o.bar
+IP4.DOMAIN[6]:                          sear4.foo3.bar
+DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:                        dhcp-4-opt-1 = val-1
+DHCP4.OPTION[3]:                        dhcp-4-opt-2 = val-2
+DHCP4.OPTION[4]:                        dhcp-4-opt-4 = val-4
+DHCP4.OPTION[5]:                        dhcp-4-opt-6 = val-6
+DHCP4.OPTION[6]:                        dhcp-4-opt-7 = val-7
+DHCP4.OPTION[7]:                        dhcp-4-opt-8 = val-8
+DHCP4.OPTION[8]:                        dhcp-4-opt-9 = val-9
+IP6.ADDRESS[1]:                         2001:a::fa05:2ab4:9300:e8fe/116
+IP6.ADDRESS[2]:                         2001:a::e9cf:bd3:caba:99b3/86
+IP6.ADDRESS[3]:                         2001:a::2be6:44fa:2c95:5559/78
+IP6.GATEWAY:                            2001:a::4d70:d91a:770f:2319
+IP6.ROUTE[1]:                           dst = 2001:a::3cb2:719d:bb00:b22f/66, nh = 2001:a::81b1:58b9:7237:3511, mt = 2280277732
+IP6.ROUTE[2]:                           dst = 2001:a::986f:983c:5eb:1c7d/99, nh = ::, mt = 1204008676
+IP6.DNS[1]:                             2001:a::85e7:3d7d:53e8:50ac
+IP6.DNS[2]:                             2001:a::1c5:9cb5:e86d:25a5
+IP6.DOMAIN[1]:                          sear6.foo4.bar
+IP6.DOMAIN[2]:                          sear6.foo2.bar
+DHCP6.OPTION[1]:                        dhcp-6-opt-0 = val-0
+DHCP6.OPTION[2]:                        dhcp-6-opt-1 = val-1
+DHCP6.OPTION[3]:                        dhcp-6-opt-2 = val-2
+DHCP6.OPTION[4]:                        dhcp-6-opt-3 = val-3
+DHCP6.OPTION[5]:                        dhcp-6-opt-4 = val-4
+DHCP6.OPTION[6]:                        dhcp-6-opt-5 = val-5
+DHCP6.OPTION[7]:                        dhcp-6-opt-6 = val-6
+DHCP6.OPTION[8]:                        dhcp-6-opt-7 = val-7
+DHCP6.OPTION[9]:                        dhcp-6-opt-9 = val-9
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
+
+GENERAL.DEVICE:                         wlan1
+GENERAL.TYPE:                           wifi
+GENERAL.NM-TYPE:                        NMDeviceWifi
+GENERAL.VENDOR:                         --
+GENERAL.PRODUCT:                        --
+GENERAL.DRIVER:                         virtual
+GENERAL.DRIVER-VERSION:                 --
+GENERAL.FIRMWARE-VERSION:               --
+GENERAL.HWADDR:                         71:52:AD:63:5C:7C
+GENERAL.MTU:                            0
+GENERAL.STATE:                          20 (unavailable)
+GENERAL.REASON:                         0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:               0 (unknown)
+GENERAL.IP6-CONNECTIVITY:               0 (unknown)
+GENERAL.UDI:                            /sys/devices/virtual/wlan1
+GENERAL.IP-IFACE:                       --
+GENERAL.IS-SOFTWARE:                    no
+GENERAL.NM-MANAGED:                     yes
+GENERAL.AUTOCONNECT:                    yes
+GENERAL.FIRMWARE-MISSING:               no
+GENERAL.NM-PLUGIN-MISSING:              no
+GENERAL.PHYS-PORT-ID:                   --
+GENERAL.CONNECTION:                     --
+GENERAL.CON-UUID:                       --
+GENERAL.CON-PATH:                       --
+GENERAL.METERED:                        unknown
+CAPABILITIES.CARRIER-DETECT:            no
+CAPABILITIES.SPEED:                     unknown
+CAPABILITIES.IS-SOFTWARE:               no
+CAPABILITIES.SRIOV:                     no
+WIFI-PROPERTIES.WEP:                    yes
+WIFI-PROPERTIES.WPA:                    yes
+WIFI-PROPERTIES.WPA2:                   yes
+WIFI-PROPERTIES.TKIP:                   yes
+WIFI-PROPERTIES.CCMP:                   yes
+WIFI-PROPERTIES.AP:                     yes
+WIFI-PROPERTIES.ADHOC:                  yes
+WIFI-PROPERTIES.2GHZ:                   unknown
+WIFI-PROPERTIES.5GHZ:                   unknown
+IP4.ADDRESS[1]:                         192.168.97.124/29
+IP4.ADDRESS[2]:                         192.168.76.154/18
+IP4.GATEWAY:                            --
+IP4.ROUTE[1]:                           dst = 192.168.33.233/22, nh = 192.168.222.210, mt = 2810496551
+IP4.DNS[1]:                             192.168.107.109
+IP4.DOMAIN[1]:                          sear4.fo.o.bar
+IP4.DOMAIN[2]:                          sear4.fo.x.y
+IP4.DOMAIN[3]:                          sear4.foo2.bar
+IP4.DOMAIN[4]:                          sear4.foo3.bar
+IP4.DOMAIN[5]:                          sear4.foo4.bar
+IP4.WINS[1]:                            192.168.60.60
+IP4.WINS[2]:                            192.168.63.92
+DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:                        dhcp-4-opt-5 = val-5
+IP6.ADDRESS[1]:                         2001:a::88ca:3654:96b:ab44/89
+IP6.GATEWAY:                            --
+IP6.ROUTE[1]:                           dst = 2001:a::cc8b:7c09:4673:bbb0/85, nh = ::, mt = 2821465568
+IP6.ROUTE[2]:                           dst = 2001:a::a976:2488:f49f:b48/106, nh = 2001:a::62ae:c734:fc7b:e931, mt = 2248613879
+IP6.ROUTE[3]:                           dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::
+IP6.DNS[1]:                             2001:a::2934:bd66:550d:ec19
+IP6.DOMAIN[1]:                          sear6.fo.x.y
+DHCP6.OPTION[1]:                        dhcp-6-opt-2 = val-2
+DHCP6.OPTION[2]:                        dhcp-6-opt-6 = val-6
+DHCP6.OPTION[3]:                        dhcp-6-opt-7 = val-7
+DHCP6.OPTION[4]:                        dhcp-6-opt-8 = val-8
+DHCP6.OPTION[5]:                        dhcp-6-opt-9 = val-9
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
+
 <<<
 size: 20820
 location: clients/tests/test-client.py:1050:test_004()/40
@@ -2112,6 +2112,98 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 20673 bytes
 >>>
+GENERAL.DEVICE:                         wlan0
+GENERAL.TYPE:                           wifi
+GENERAL.NM-TYPE:                        NMDeviceWifi
+GENERAL.VENDOR:                         --
+GENERAL.PRODUCT:                        --
+GENERAL.DRIVER:                         virtual
+GENERAL.DRIVER-VERSION:                 --
+GENERAL.FIRMWARE-VERSION:               --
+GENERAL.HWADDR:                         13:E0:74:85:7C:D9
+GENERAL.MTU:                            0
+GENERAL.STATE:                          20 (niedostępne)
+GENERAL.REASON:                         0 (Nie podano przyczyny)
+GENERAL.IP4-CONNECTIVITY:               0 (nieznane)
+GENERAL.IP6-CONNECTIVITY:               0 (nieznane)
+GENERAL.UDI:                            /sys/devices/virtual/wlan0
+GENERAL.IP-IFACE:                       --
+GENERAL.IS-SOFTWARE:                    nie
+GENERAL.NM-MANAGED:                     tak
+GENERAL.AUTOCONNECT:                    tak
+GENERAL.FIRMWARE-MISSING:               nie
+GENERAL.NM-PLUGIN-MISSING:              nie
+GENERAL.PHYS-PORT-ID:                   --
+GENERAL.CONNECTION:                     con-vpn-1
+GENERAL.CON-UUID:                       UUID-con-vpn-1-REPLACED-REPLACED-REP
+GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
+GENERAL.METERED:                        nieznane
+CAPABILITIES.CARRIER-DETECT:            nie
+CAPABILITIES.SPEED:                     nieznane
+CAPABILITIES.IS-SOFTWARE:               nie
+CAPABILITIES.SRIOV:                     nie
+WIFI-PROPERTIES.WEP:                    tak
+WIFI-PROPERTIES.WPA:                    tak
+WIFI-PROPERTIES.WPA2:                   tak
+WIFI-PROPERTIES.TKIP:                   tak
+WIFI-PROPERTIES.CCMP:                   tak
+WIFI-PROPERTIES.AP:                     tak
+WIFI-PROPERTIES.ADHOC:                  tak
+WIFI-PROPERTIES.2GHZ:                   nieznane
+WIFI-PROPERTIES.5GHZ:                   nieznane
+AP[1].IN-USE:                            
+AP[1].SSID:                             wlan0-ap-2
+AP[1].MODE:                             Infrastruktura
+AP[1].CHAN:                             1
+AP[1].RATE:                             54 Mb/s
+AP[1].SIGNAL:                           92
+AP[1].BARS:                             ****
+AP[1].SECURITY:                         WPA1 WPA2
+AP[2].IN-USE:                            
+AP[2].SSID:                             wlan0-ap-1
+AP[2].MODE:                             Infrastruktura
+AP[2].CHAN:                             1
+AP[2].RATE:                             54 Mb/s
+AP[2].SIGNAL:                           81
+AP[2].BARS:                             ****
+AP[2].SECURITY:                         WPA1 WPA2
+AP[3].IN-USE:                            
+AP[3].SSID:                             wlan0-ap-3
+AP[3].MODE:                             Infrastruktura
+AP[3].CHAN:                             1
+AP[3].RATE:                             54 Mb/s
+AP[3].SIGNAL:                           55
+AP[3].BARS:                             **  
+AP[3].SECURITY:                         WPA1 WPA2
+IP4.ADDRESS[1]:                         192.168.228.18/32
+IP4.ADDRESS[2]:                         192.168.209.179/25
+IP4.GATEWAY:                            192.168.41.120
+IP4.DOMAIN[1]:                          sear4.foo2.bar
+IP4.DOMAIN[2]:                          sear4.fo.x.y
+IP4.DOMAIN[3]:                          sear4.foo1.bar
+IP4.DOMAIN[4]:                          sear4.foo4.bar
+IP4.DOMAIN[5]:                          sear4.fo.o.bar
+IP4.WINS[1]:                            192.168.120.79
+DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:                        dhcp-4-opt-2 = val-2
+DHCP4.OPTION[3]:                        dhcp-4-opt-4 = val-4
+DHCP4.OPTION[4]:                        dhcp-4-opt-7 = val-7
+IP6.GATEWAY:                            --
+IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
+IP6.DOMAIN[1]:                          sear6.foo2.bar
+IP6.DOMAIN[2]:                          sear6.foo1.bar
+IP6.DOMAIN[3]:                          sear6.fo.x.y
+IP6.DOMAIN[4]:                          sear6.fo.o.bar
+IP6.DOMAIN[5]:                          sear6.foo3.bar
+IP6.DOMAIN[6]:                          sear6.foo4.bar
+DHCP6.OPTION[1]:                        dhcp-6-opt-1 = val-1
+DHCP6.OPTION[2]:                        dhcp-6-opt-2 = val-2
+DHCP6.OPTION[3]:                        dhcp-6-opt-3 = val-3
+DHCP6.OPTION[4]:                        dhcp-6-opt-4 = val-4
+DHCP6.OPTION[5]:                        dhcp-6-opt-5 = val-5
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
+
 GENERAL.DEVICE:                         eth0
 GENERAL.TYPE:                           ethernet
 GENERAL.NM-TYPE:                        NMDeviceEthernet
@@ -2398,98 +2490,6 @@ DHCP6.OPTION[2]:                        dhcp-6-opt-6 = val-6
 DHCP6.OPTION[3]:                        dhcp-6-opt-7 = val-7
 DHCP6.OPTION[4]:                        dhcp-6-opt-8 = val-8
 DHCP6.OPTION[5]:                        dhcp-6-opt-9 = val-9
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
-
-GENERAL.DEVICE:                         wlan0
-GENERAL.TYPE:                           wifi
-GENERAL.NM-TYPE:                        NMDeviceWifi
-GENERAL.VENDOR:                         --
-GENERAL.PRODUCT:                        --
-GENERAL.DRIVER:                         virtual
-GENERAL.DRIVER-VERSION:                 --
-GENERAL.FIRMWARE-VERSION:               --
-GENERAL.HWADDR:                         13:E0:74:85:7C:D9
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (niedostępne)
-GENERAL.REASON:                         0 (Nie podano przyczyny)
-GENERAL.IP4-CONNECTIVITY:               0 (nieznane)
-GENERAL.IP6-CONNECTIVITY:               0 (nieznane)
-GENERAL.UDI:                            /sys/devices/virtual/wlan0
-GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    nie
-GENERAL.NM-MANAGED:                     tak
-GENERAL.AUTOCONNECT:                    tak
-GENERAL.FIRMWARE-MISSING:               nie
-GENERAL.NM-PLUGIN-MISSING:              nie
-GENERAL.PHYS-PORT-ID:                   --
-GENERAL.CONNECTION:                     con-vpn-1
-GENERAL.CON-UUID:                       UUID-con-vpn-1-REPLACED-REPLACED-REP
-GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
-GENERAL.METERED:                        nieznane
-CAPABILITIES.CARRIER-DETECT:            nie
-CAPABILITIES.SPEED:                     nieznane
-CAPABILITIES.IS-SOFTWARE:               nie
-CAPABILITIES.SRIOV:                     nie
-WIFI-PROPERTIES.WEP:                    tak
-WIFI-PROPERTIES.WPA:                    tak
-WIFI-PROPERTIES.WPA2:                   tak
-WIFI-PROPERTIES.TKIP:                   tak
-WIFI-PROPERTIES.CCMP:                   tak
-WIFI-PROPERTIES.AP:                     tak
-WIFI-PROPERTIES.ADHOC:                  tak
-WIFI-PROPERTIES.2GHZ:                   nieznane
-WIFI-PROPERTIES.5GHZ:                   nieznane
-AP[1].IN-USE:                            
-AP[1].SSID:                             wlan0-ap-2
-AP[1].MODE:                             Infrastruktura
-AP[1].CHAN:                             1
-AP[1].RATE:                             54 Mb/s
-AP[1].SIGNAL:                           92
-AP[1].BARS:                             ****
-AP[1].SECURITY:                         WPA1 WPA2
-AP[2].IN-USE:                            
-AP[2].SSID:                             wlan0-ap-1
-AP[2].MODE:                             Infrastruktura
-AP[2].CHAN:                             1
-AP[2].RATE:                             54 Mb/s
-AP[2].SIGNAL:                           81
-AP[2].BARS:                             ****
-AP[2].SECURITY:                         WPA1 WPA2
-AP[3].IN-USE:                            
-AP[3].SSID:                             wlan0-ap-3
-AP[3].MODE:                             Infrastruktura
-AP[3].CHAN:                             1
-AP[3].RATE:                             54 Mb/s
-AP[3].SIGNAL:                           55
-AP[3].BARS:                             **  
-AP[3].SECURITY:                         WPA1 WPA2
-IP4.ADDRESS[1]:                         192.168.228.18/32
-IP4.ADDRESS[2]:                         192.168.209.179/25
-IP4.GATEWAY:                            192.168.41.120
-IP4.DOMAIN[1]:                          sear4.foo2.bar
-IP4.DOMAIN[2]:                          sear4.fo.x.y
-IP4.DOMAIN[3]:                          sear4.foo1.bar
-IP4.DOMAIN[4]:                          sear4.foo4.bar
-IP4.DOMAIN[5]:                          sear4.fo.o.bar
-IP4.WINS[1]:                            192.168.120.79
-DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:                        dhcp-4-opt-2 = val-2
-DHCP4.OPTION[3]:                        dhcp-4-opt-4 = val-4
-DHCP4.OPTION[4]:                        dhcp-4-opt-7 = val-7
-IP6.GATEWAY:                            --
-IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
-IP6.DOMAIN[1]:                          sear6.foo2.bar
-IP6.DOMAIN[2]:                          sear6.foo1.bar
-IP6.DOMAIN[3]:                          sear6.fo.x.y
-IP6.DOMAIN[4]:                          sear6.fo.o.bar
-IP6.DOMAIN[5]:                          sear6.foo3.bar
-IP6.DOMAIN[6]:                          sear6.foo4.bar
-DHCP6.OPTION[1]:                        dhcp-6-opt-1 = val-1
-DHCP6.OPTION[2]:                        dhcp-6-opt-2 = val-2
-DHCP6.OPTION[3]:                        dhcp-6-opt-3 = val-3
-DHCP6.OPTION[4]:                        dhcp-6-opt-4 = val-4
-DHCP6.OPTION[5]:                        dhcp-6-opt-5 = val-5
 CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
@@ -2948,11 +2948,11 @@ returncode: 0
 stdout: 366 bytes
 >>>
 DEVICE  TYPE      DBUS-PATH                                 
+wlan0   wifi      /org/freedesktop/NetworkManager/Devices/3 
 eth0    ethernet  /org/freedesktop/NetworkManager/Devices/1 
 eth1    ethernet  /org/freedesktop/NetworkManager/Devices/2 
 wlan1   wifi      /org/freedesktop/NetworkManager/Devices/4 
 wlan1   wifi      /org/freedesktop/NetworkManager/Devices/5 
-wlan0   wifi      /org/freedesktop/NetworkManager/Devices/3 
 
 <<<
 size: 524
@@ -2963,11 +2963,11 @@ returncode: 0
 stdout: 366 bytes
 >>>
 DEVICE  TYPE      DBUS-PATH                                 
+wlan0   wifi      /org/freedesktop/NetworkManager/Devices/3 
 eth0    ethernet  /org/freedesktop/NetworkManager/Devices/1 
 eth1    ethernet  /org/freedesktop/NetworkManager/Devices/2 
 wlan1   wifi      /org/freedesktop/NetworkManager/Devices/4 
 wlan1   wifi      /org/freedesktop/NetworkManager/Devices/5 
-wlan0   wifi      /org/freedesktop/NetworkManager/Devices/3 
 
 <<<
 size: 1984
@@ -2978,14 +2978,14 @@ returncode: 0
 stdout: 1840 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
-AP[1]  wlan1-ap-4  776C616E312D61702D34  94:2B:E8:F6:D2:86  Infra  1     2412 MHz  54 Mbit/s  48      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan1   no              /org/freedesktop/NetworkManager/AccessPoint/4 
-
-NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
-
-NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infra  1     2412 MHz  54 Mbit/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/2 
 AP[2]  wlan0-ap-1  776C616E302D61702D31  61:95:77:AC:1E:4C  Infra  1     2412 MHz  54 Mbit/s  81      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/1 
 AP[3]  wlan0-ap-3  776C616E302D61702D33  9B:F6:B7:EC:97:76  Infra  1     2412 MHz  54 Mbit/s  55      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/3 
+
+NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+AP[1]  wlan1-ap-4  776C616E312D61702D34  94:2B:E8:F6:D2:86  Infra  1     2412 MHz  54 Mbit/s  48      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan1   no              /org/freedesktop/NetworkManager/AccessPoint/4 
+
+NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 
 <<<
 size: 2052
@@ -2996,14 +2996,14 @@ returncode: 0
 stdout: 1898 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
-AP[1]  wlan1-ap-4  776C616E312D61702D34  94:2B:E8:F6:D2:86  Infrastruktura  1     2412 MHz  54 Mb/s  48      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan1   nie             /org/freedesktop/NetworkManager/AccessPoint/4 
-
-NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
-
-NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infrastruktura  1     2412 MHz  54 Mb/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/2 
 AP[2]  wlan0-ap-1  776C616E302D61702D31  61:95:77:AC:1E:4C  Infrastruktura  1     2412 MHz  54 Mb/s  81      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/1 
 AP[3]  wlan0-ap-3  776C616E302D61702D33  9B:F6:B7:EC:97:76  Infrastruktura  1     2412 MHz  54 Mb/s  55      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/3 
+
+NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+AP[1]  wlan1-ap-4  776C616E312D61702D34  94:2B:E8:F6:D2:86  Infrastruktura  1     2412 MHz  54 Mb/s  48      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan1   nie             /org/freedesktop/NetworkManager/AccessPoint/4 
+
+NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 
 <<<
 size: 618
@@ -3014,14 +3014,14 @@ returncode: 0
 stdout: 472 bytes
 >>>
 IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
-        wlan1-ap-4  Infra  1     54 Mbit/s  48      **    WPA1 WPA2 
-
-IN-USE  SSID  MODE  CHAN  RATE  SIGNAL  BARS  SECURITY 
-
-IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
         wlan0-ap-2  Infra  1     54 Mbit/s  92      ****  WPA1 WPA2 
         wlan0-ap-1  Infra  1     54 Mbit/s  81      ****  WPA1 WPA2 
         wlan0-ap-3  Infra  1     54 Mbit/s  55      **    WPA1 WPA2 
+
+IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
+        wlan1-ap-4  Infra  1     54 Mbit/s  48      **    WPA1 WPA2 
+
+IN-USE  SSID  MODE  CHAN  RATE  SIGNAL  BARS  SECURITY 
 
 <<<
 size: 678
@@ -3032,14 +3032,14 @@ returncode: 0
 stdout: 522 bytes
 >>>
 IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
-        wlan1-ap-4  Infrastruktura  1     54 Mb/s  48      **    WPA1 WPA2 
-
-IN-USE  SSID  MODE  CHAN  RATE  SIGNAL  BARS  SECURITY 
-
-IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
         wlan0-ap-2  Infrastruktura  1     54 Mb/s  92      ****  WPA1 WPA2 
         wlan0-ap-1  Infrastruktura  1     54 Mb/s  81      ****  WPA1 WPA2 
         wlan0-ap-3  Infrastruktura  1     54 Mb/s  55      **    WPA1 WPA2 
+
+IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
+        wlan1-ap-4  Infrastruktura  1     54 Mb/s  48      **    WPA1 WPA2 
+
+IN-USE  SSID  MODE  CHAN  RATE  SIGNAL  BARS  SECURITY 
 
 <<<
 size: 2097
@@ -3050,14 +3050,14 @@ returncode: 0
 stdout: 1840 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
-AP[1]  wlan1-ap-4  776C616E312D61702D34  94:2B:E8:F6:D2:86  Infra  1     2412 MHz  54 Mbit/s  48      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan1   no              /org/freedesktop/NetworkManager/AccessPoint/4 
-
-NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
-
-NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infra  1     2412 MHz  54 Mbit/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/2 
 AP[2]  wlan0-ap-1  776C616E302D61702D31  61:95:77:AC:1E:4C  Infra  1     2412 MHz  54 Mbit/s  81      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/1 
 AP[3]  wlan0-ap-3  776C616E302D61702D33  9B:F6:B7:EC:97:76  Infra  1     2412 MHz  54 Mbit/s  55      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/3 
+
+NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+AP[1]  wlan1-ap-4  776C616E312D61702D34  94:2B:E8:F6:D2:86  Infra  1     2412 MHz  54 Mbit/s  48      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan1   no              /org/freedesktop/NetworkManager/AccessPoint/4 
+
+NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 
 <<<
 size: 2165
@@ -3068,80 +3068,92 @@ returncode: 0
 stdout: 1898 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
-AP[1]  wlan1-ap-4  776C616E312D61702D34  94:2B:E8:F6:D2:86  Infrastruktura  1     2412 MHz  54 Mb/s  48      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan1   nie             /org/freedesktop/NetworkManager/AccessPoint/4 
-
-NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
-
-NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infrastruktura  1     2412 MHz  54 Mb/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/2 
 AP[2]  wlan0-ap-1  776C616E302D61702D31  61:95:77:AC:1E:4C  Infrastruktura  1     2412 MHz  54 Mb/s  81      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/1 
 AP[3]  wlan0-ap-3  776C616E302D61702D33  9B:F6:B7:EC:97:76  Infrastruktura  1     2412 MHz  54 Mb/s  55      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/3 
 
+NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+AP[1]  wlan1-ap-4  776C616E312D61702D34  94:2B:E8:F6:D2:86  Infrastruktura  1     2412 MHz  54 Mb/s  48      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan1   nie             /org/freedesktop/NetworkManager/AccessPoint/4 
+
+NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
+
 <<<
-size: 735
+size: 737
 location: clients/tests/test-client.py:1075:test_004()/57
 cmd: $NMCLI -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 568 bytes
+stdout: 570 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infra  1     2412 MHz  54 Mbit/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/2 
 
+
+
 <<<
-size: 763
+size: 765
 location: clients/tests/test-client.py:1075:test_004()/58
 cmd: $NMCLI -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 586 bytes
+stdout: 588 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infrastruktura  1     2412 MHz  54 Mb/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/2 
 
+
+
 <<<
-size: 308
+size: 310
 location: clients/tests/test-client.py:1077:test_004()/59
 cmd: $NMCLI -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 138 bytes
+stdout: 140 bytes
 >>>
 IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
         wlan0-ap-2  Infra  1     54 Mbit/s  92      ****  WPA1 WPA2 
 
+
+
 <<<
-size: 334
+size: 336
 location: clients/tests/test-client.py:1077:test_004()/60
 cmd: $NMCLI -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 154 bytes
+stdout: 156 bytes
 >>>
 IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
         wlan0-ap-2  Infrastruktura  1     54 Mb/s  92      ****  WPA1 WPA2 
 
+
+
 <<<
-size: 848
+size: 850
 location: clients/tests/test-client.py:1080:test_004()/61
 cmd: $NMCLI -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 568 bytes
+stdout: 570 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infra  1     2412 MHz  54 Mbit/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/2 
 
+
+
 <<<
-size: 876
+size: 878
 location: clients/tests/test-client.py:1080:test_004()/62
 cmd: $NMCLI -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 586 bytes
+stdout: 588 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infrastruktura  1     2412 MHz  54 Mb/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/2 
+
+
 
 <<<
 size: 4860
@@ -4262,11 +4274,11 @@ returncode: 0
 stdout: 418 bytes
 >>>
 DEVICE  TYPE      STATE        CONNECTION 
+[2mwlan0[0m   [2mwifi[0m      [2munavailable[0m  [2mcon-vpn-1[0m  
 [2meth0[0m    [2methernet[0m  [2munavailable[0m  [2m--[0m         
 [2meth1[0m    [2methernet[0m  [2munavailable[0m  [2m--[0m         
 [2mwlan1[0m   [2mwifi[0m      [2munavailable[0m  [2m--[0m         
 [2mwlan1[0m   [2mwifi[0m      [2munavailable[0m  [2m--[0m         
-[2mwlan0[0m   [2mwifi[0m      [2munavailable[0m  [2mcon-vpn-1[0m  
 
 <<<
 size: 570
@@ -4277,11 +4289,11 @@ returncode: 0
 stdout: 423 bytes
 >>>
 DEVICE  TYPE      STATE        CONNECTION 
+[2mwlan0[0m   [2mwifi[0m      [2mniedostępne[0m  [2mcon-vpn-1[0m  
 [2meth0[0m    [2methernet[0m  [2mniedostępne[0m  [2m--[0m         
 [2meth1[0m    [2methernet[0m  [2mniedostępne[0m  [2m--[0m         
 [2mwlan1[0m   [2mwifi[0m      [2mniedostępne[0m  [2m--[0m         
 [2mwlan1[0m   [2mwifi[0m      [2mniedostępne[0m  [2m--[0m         
-[2mwlan0[0m   [2mwifi[0m      [2mniedostępne[0m  [2mcon-vpn-1[0m  
 
 <<<
 size: 1782
@@ -4292,11 +4304,11 @@ returncode: 0
 stdout: 1632 bytes
 >>>
 DEVICE  TYPE      STATE        IP4-CONNECTIVITY  IP6-CONNECTIVITY  DBUS-PATH                                  CONNECTION  CON-UUID                              CON-PATH                                           
+[2mwlan0[0m   [2mwifi[0m      [2munavailable[0m  [2munknown[0m           [2munknown[0m           [2m/org/freedesktop/NetworkManager/Devices/3[0m  [2mcon-vpn-1[0m   [2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m  [2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m 
 [2meth0[0m    [2methernet[0m  [2munavailable[0m  [2munknown[0m           [2munknown[0m           [2m/org/freedesktop/NetworkManager/Devices/1[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
 [2meth1[0m    [2methernet[0m  [2munavailable[0m  [2munknown[0m           [2munknown[0m           [2m/org/freedesktop/NetworkManager/Devices/2[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
 [2mwlan1[0m   [2mwifi[0m      [2munavailable[0m  [2munknown[0m           [2munknown[0m           [2m/org/freedesktop/NetworkManager/Devices/4[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
 [2mwlan1[0m   [2mwifi[0m      [2munavailable[0m  [2munknown[0m           [2munknown[0m           [2m/org/freedesktop/NetworkManager/Devices/5[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
-[2mwlan0[0m   [2mwifi[0m      [2munavailable[0m  [2munknown[0m           [2munknown[0m           [2m/org/freedesktop/NetworkManager/Devices/3[0m  [2mcon-vpn-1[0m   [2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m  [2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m 
 
 <<<
 size: 1797
@@ -4307,11 +4319,11 @@ returncode: 0
 stdout: 1637 bytes
 >>>
 DEVICE  TYPE      STATE        IP4-CONNECTIVITY  IP6-CONNECTIVITY  DBUS-PATH                                  CONNECTION  CON-UUID                              CON-PATH                                           
+[2mwlan0[0m   [2mwifi[0m      [2mniedostępne[0m  [2mnieznane[0m          [2mnieznane[0m          [2m/org/freedesktop/NetworkManager/Devices/3[0m  [2mcon-vpn-1[0m   [2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m  [2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m 
 [2meth0[0m    [2methernet[0m  [2mniedostępne[0m  [2mnieznane[0m          [2mnieznane[0m          [2m/org/freedesktop/NetworkManager/Devices/1[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
 [2meth1[0m    [2methernet[0m  [2mniedostępne[0m  [2mnieznane[0m          [2mnieznane[0m          [2m/org/freedesktop/NetworkManager/Devices/2[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
 [2mwlan1[0m   [2mwifi[0m      [2mniedostępne[0m  [2mnieznane[0m          [2mnieznane[0m          [2m/org/freedesktop/NetworkManager/Devices/4[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
 [2mwlan1[0m   [2mwifi[0m      [2mniedostępne[0m  [2mnieznane[0m          [2mnieznane[0m          [2m/org/freedesktop/NetworkManager/Devices/5[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
-[2mwlan0[0m   [2mwifi[0m      [2mniedostępne[0m  [2mnieznane[0m          [2mnieznane[0m          [2m/org/freedesktop/NetworkManager/Devices/3[0m  [2mcon-vpn-1[0m   [2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m  [2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m 
 
 <<<
 size: 8059
@@ -4321,6 +4333,31 @@ lang: C
 returncode: 0
 stdout: 7918 bytes
 >>>
+GENERAL.DEVICE:                         wlan0
+GENERAL.TYPE:                           wifi
+GENERAL.HWADDR:                         13:E0:74:85:7C:D9
+GENERAL.MTU:                            0
+GENERAL.STATE:                          20 (unavailable)
+GENERAL.CONNECTION:                     con-vpn-1
+GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
+IP4.ADDRESS[1]:                         192.168.228.18/32
+IP4.ADDRESS[2]:                         192.168.209.179/25
+IP4.GATEWAY:                            192.168.41.120
+IP4.DOMAIN[1]:                          sear4.foo2.bar
+IP4.DOMAIN[2]:                          sear4.fo.x.y
+IP4.DOMAIN[3]:                          sear4.foo1.bar
+IP4.DOMAIN[4]:                          sear4.foo4.bar
+IP4.DOMAIN[5]:                          sear4.fo.o.bar
+IP4.WINS[1]:                            192.168.120.79
+IP6.GATEWAY:                            --
+IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
+IP6.DOMAIN[1]:                          sear6.foo2.bar
+IP6.DOMAIN[2]:                          sear6.foo1.bar
+IP6.DOMAIN[3]:                          sear6.fo.x.y
+IP6.DOMAIN[4]:                          sear6.fo.o.bar
+IP6.DOMAIN[5]:                          sear6.foo3.bar
+IP6.DOMAIN[6]:                          sear6.foo4.bar
+
 GENERAL.DEVICE:                         eth0
 GENERAL.TYPE:                           ethernet
 GENERAL.HWADDR:                         AB:B7:BF:E2:48:E8
@@ -4433,31 +4470,6 @@ IP6.ROUTE[2]:                           dst = 2001:a::a976:2488:f49f:b48/106, nh
 IP6.ROUTE[3]:                           dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::
 IP6.DNS[1]:                             2001:a::2934:bd66:550d:ec19
 IP6.DOMAIN[1]:                          sear6.fo.x.y
-
-GENERAL.DEVICE:                         wlan0
-GENERAL.TYPE:                           wifi
-GENERAL.HWADDR:                         13:E0:74:85:7C:D9
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (unavailable)
-GENERAL.CONNECTION:                     con-vpn-1
-GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
-IP4.ADDRESS[1]:                         192.168.228.18/32
-IP4.ADDRESS[2]:                         192.168.209.179/25
-IP4.GATEWAY:                            192.168.41.120
-IP4.DOMAIN[1]:                          sear4.foo2.bar
-IP4.DOMAIN[2]:                          sear4.fo.x.y
-IP4.DOMAIN[3]:                          sear4.foo1.bar
-IP4.DOMAIN[4]:                          sear4.foo4.bar
-IP4.DOMAIN[5]:                          sear4.fo.o.bar
-IP4.WINS[1]:                            192.168.120.79
-IP6.GATEWAY:                            --
-IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
-IP6.DOMAIN[1]:                          sear6.foo2.bar
-IP6.DOMAIN[2]:                          sear6.foo1.bar
-IP6.DOMAIN[3]:                          sear6.fo.x.y
-IP6.DOMAIN[4]:                          sear6.fo.o.bar
-IP6.DOMAIN[5]:                          sear6.foo3.bar
-IP6.DOMAIN[6]:                          sear6.foo4.bar
 
 <<<
 size: 8090
@@ -4467,6 +4479,31 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 7939 bytes
 >>>
+GENERAL.DEVICE:                         wlan0
+GENERAL.TYPE:                           wifi
+GENERAL.HWADDR:                         13:E0:74:85:7C:D9
+GENERAL.MTU:                            0
+GENERAL.STATE:                          20 (niedostępne)
+GENERAL.CONNECTION:                     con-vpn-1
+GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
+IP4.ADDRESS[1]:                         192.168.228.18/32
+IP4.ADDRESS[2]:                         192.168.209.179/25
+IP4.GATEWAY:                            192.168.41.120
+IP4.DOMAIN[1]:                          sear4.foo2.bar
+IP4.DOMAIN[2]:                          sear4.fo.x.y
+IP4.DOMAIN[3]:                          sear4.foo1.bar
+IP4.DOMAIN[4]:                          sear4.foo4.bar
+IP4.DOMAIN[5]:                          sear4.fo.o.bar
+IP4.WINS[1]:                            192.168.120.79
+IP6.GATEWAY:                            --
+IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
+IP6.DOMAIN[1]:                          sear6.foo2.bar
+IP6.DOMAIN[2]:                          sear6.foo1.bar
+IP6.DOMAIN[3]:                          sear6.fo.x.y
+IP6.DOMAIN[4]:                          sear6.fo.o.bar
+IP6.DOMAIN[5]:                          sear6.foo3.bar
+IP6.DOMAIN[6]:                          sear6.foo4.bar
+
 GENERAL.DEVICE:                         eth0
 GENERAL.TYPE:                           ethernet
 GENERAL.HWADDR:                         AB:B7:BF:E2:48:E8
@@ -4580,13 +4617,77 @@ IP6.ROUTE[3]:                           dst = 2001:a::afb7:4449:3787:8bb4/123, n
 IP6.DNS[1]:                             2001:a::2934:bd66:550d:ec19
 IP6.DOMAIN[1]:                          sear6.fo.x.y
 
+<<<
+size: 20970
+location: clients/tests/test-client.py:1050:test_004()/85
+cmd: $NMCLI --color yes -f all dev show
+lang: C
+returncode: 0
+stdout: 20821 bytes
+>>>
 GENERAL.DEVICE:                         wlan0
 GENERAL.TYPE:                           wifi
+GENERAL.NM-TYPE:                        NMDeviceWifi
+GENERAL.VENDOR:                         --
+GENERAL.PRODUCT:                        --
+GENERAL.DRIVER:                         virtual
+GENERAL.DRIVER-VERSION:                 --
+GENERAL.FIRMWARE-VERSION:               --
 GENERAL.HWADDR:                         13:E0:74:85:7C:D9
 GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (niedostępne)
+GENERAL.STATE:                          20 (unavailable)
+GENERAL.REASON:                         0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:               0 (unknown)
+GENERAL.IP6-CONNECTIVITY:               0 (unknown)
+GENERAL.UDI:                            /sys/devices/virtual/wlan0
+GENERAL.IP-IFACE:                       --
+GENERAL.IS-SOFTWARE:                    no
+GENERAL.NM-MANAGED:                     yes
+GENERAL.AUTOCONNECT:                    yes
+GENERAL.FIRMWARE-MISSING:               no
+GENERAL.NM-PLUGIN-MISSING:              no
+GENERAL.PHYS-PORT-ID:                   --
 GENERAL.CONNECTION:                     con-vpn-1
+GENERAL.CON-UUID:                       UUID-con-vpn-1-REPLACED-REPLACED-REP
 GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
+GENERAL.METERED:                        unknown
+CAPABILITIES.CARRIER-DETECT:            no
+CAPABILITIES.SPEED:                     unknown
+CAPABILITIES.IS-SOFTWARE:               no
+CAPABILITIES.SRIOV:                     no
+WIFI-PROPERTIES.WEP:                    yes
+WIFI-PROPERTIES.WPA:                    yes
+WIFI-PROPERTIES.WPA2:                   yes
+WIFI-PROPERTIES.TKIP:                   yes
+WIFI-PROPERTIES.CCMP:                   yes
+WIFI-PROPERTIES.AP:                     yes
+WIFI-PROPERTIES.ADHOC:                  yes
+WIFI-PROPERTIES.2GHZ:                   unknown
+WIFI-PROPERTIES.5GHZ:                   unknown
+AP[1].IN-USE:                           [32m [0m
+AP[1].SSID:                             [32mwlan0-ap-2[0m
+AP[1].MODE:                             [32mInfra[0m
+AP[1].CHAN:                             [32m1[0m
+AP[1].RATE:                             [32m54 Mbit/s[0m
+AP[1].SIGNAL:                           [32m92[0m
+AP[1].BARS:                             [32m****[0m
+AP[1].SECURITY:                         [32mWPA1 WPA2[0m
+AP[2].IN-USE:                           [32m [0m
+AP[2].SSID:                             [32mwlan0-ap-1[0m
+AP[2].MODE:                             [32mInfra[0m
+AP[2].CHAN:                             [32m1[0m
+AP[2].RATE:                             [32m54 Mbit/s[0m
+AP[2].SIGNAL:                           [32m81[0m
+AP[2].BARS:                             [32m****[0m
+AP[2].SECURITY:                         [32mWPA1 WPA2[0m
+AP[3].IN-USE:                           [35m [0m
+AP[3].SSID:                             [35mwlan0-ap-3[0m
+AP[3].MODE:                             [35mInfra[0m
+AP[3].CHAN:                             [35m1[0m
+AP[3].RATE:                             [35m54 Mbit/s[0m
+AP[3].SIGNAL:                           [35m55[0m
+AP[3].BARS:                             [35m**  [0m
+AP[3].SECURITY:                         [35mWPA1 WPA2[0m
 IP4.ADDRESS[1]:                         192.168.228.18/32
 IP4.ADDRESS[2]:                         192.168.209.179/25
 IP4.GATEWAY:                            192.168.41.120
@@ -4596,6 +4697,10 @@ IP4.DOMAIN[3]:                          sear4.foo1.bar
 IP4.DOMAIN[4]:                          sear4.foo4.bar
 IP4.DOMAIN[5]:                          sear4.fo.o.bar
 IP4.WINS[1]:                            192.168.120.79
+DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:                        dhcp-4-opt-2 = val-2
+DHCP4.OPTION[3]:                        dhcp-4-opt-4 = val-4
+DHCP4.OPTION[4]:                        dhcp-4-opt-7 = val-7
 IP6.GATEWAY:                            --
 IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
 IP6.DOMAIN[1]:                          sear6.foo2.bar
@@ -4604,15 +4709,14 @@ IP6.DOMAIN[3]:                          sear6.fo.x.y
 IP6.DOMAIN[4]:                          sear6.fo.o.bar
 IP6.DOMAIN[5]:                          sear6.foo3.bar
 IP6.DOMAIN[6]:                          sear6.foo4.bar
+DHCP6.OPTION[1]:                        dhcp-6-opt-1 = val-1
+DHCP6.OPTION[2]:                        dhcp-6-opt-2 = val-2
+DHCP6.OPTION[3]:                        dhcp-6-opt-3 = val-3
+DHCP6.OPTION[4]:                        dhcp-6-opt-4 = val-4
+DHCP6.OPTION[5]:                        dhcp-6-opt-5 = val-5
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
-<<<
-size: 20970
-location: clients/tests/test-client.py:1050:test_004()/85
-cmd: $NMCLI --color yes -f all dev show
-lang: C
-returncode: 0
-stdout: 20821 bytes
->>>
 GENERAL.DEVICE:                         eth0
 GENERAL.TYPE:                           ethernet
 GENERAL.NM-TYPE:                        NMDeviceEthernet
@@ -4902,6 +5006,14 @@ DHCP6.OPTION[5]:                        dhcp-6-opt-9 = val-9
 CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
+<<<
+size: 21120
+location: clients/tests/test-client.py:1050:test_004()/86
+cmd: $NMCLI --color yes -f all dev show
+lang: pl_PL.UTF-8
+returncode: 0
+stdout: 20961 bytes
+>>>
 GENERAL.DEVICE:                         wlan0
 GENERAL.TYPE:                           wifi
 GENERAL.NM-TYPE:                        NMDeviceWifi
@@ -4912,56 +5024,56 @@ GENERAL.DRIVER-VERSION:                 --
 GENERAL.FIRMWARE-VERSION:               --
 GENERAL.HWADDR:                         13:E0:74:85:7C:D9
 GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (unavailable)
-GENERAL.REASON:                         0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:               0 (unknown)
-GENERAL.IP6-CONNECTIVITY:               0 (unknown)
+GENERAL.STATE:                          20 (niedostępne)
+GENERAL.REASON:                         0 (Nie podano przyczyny)
+GENERAL.IP4-CONNECTIVITY:               0 (nieznane)
+GENERAL.IP6-CONNECTIVITY:               0 (nieznane)
 GENERAL.UDI:                            /sys/devices/virtual/wlan0
 GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    no
-GENERAL.NM-MANAGED:                     yes
-GENERAL.AUTOCONNECT:                    yes
-GENERAL.FIRMWARE-MISSING:               no
-GENERAL.NM-PLUGIN-MISSING:              no
+GENERAL.IS-SOFTWARE:                    nie
+GENERAL.NM-MANAGED:                     tak
+GENERAL.AUTOCONNECT:                    tak
+GENERAL.FIRMWARE-MISSING:               nie
+GENERAL.NM-PLUGIN-MISSING:              nie
 GENERAL.PHYS-PORT-ID:                   --
 GENERAL.CONNECTION:                     con-vpn-1
 GENERAL.CON-UUID:                       UUID-con-vpn-1-REPLACED-REPLACED-REP
 GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
-GENERAL.METERED:                        unknown
-CAPABILITIES.CARRIER-DETECT:            no
-CAPABILITIES.SPEED:                     unknown
-CAPABILITIES.IS-SOFTWARE:               no
-CAPABILITIES.SRIOV:                     no
-WIFI-PROPERTIES.WEP:                    yes
-WIFI-PROPERTIES.WPA:                    yes
-WIFI-PROPERTIES.WPA2:                   yes
-WIFI-PROPERTIES.TKIP:                   yes
-WIFI-PROPERTIES.CCMP:                   yes
-WIFI-PROPERTIES.AP:                     yes
-WIFI-PROPERTIES.ADHOC:                  yes
-WIFI-PROPERTIES.2GHZ:                   unknown
-WIFI-PROPERTIES.5GHZ:                   unknown
+GENERAL.METERED:                        nieznane
+CAPABILITIES.CARRIER-DETECT:            nie
+CAPABILITIES.SPEED:                     nieznane
+CAPABILITIES.IS-SOFTWARE:               nie
+CAPABILITIES.SRIOV:                     nie
+WIFI-PROPERTIES.WEP:                    tak
+WIFI-PROPERTIES.WPA:                    tak
+WIFI-PROPERTIES.WPA2:                   tak
+WIFI-PROPERTIES.TKIP:                   tak
+WIFI-PROPERTIES.CCMP:                   tak
+WIFI-PROPERTIES.AP:                     tak
+WIFI-PROPERTIES.ADHOC:                  tak
+WIFI-PROPERTIES.2GHZ:                   nieznane
+WIFI-PROPERTIES.5GHZ:                   nieznane
 AP[1].IN-USE:                           [32m [0m
 AP[1].SSID:                             [32mwlan0-ap-2[0m
-AP[1].MODE:                             [32mInfra[0m
+AP[1].MODE:                             [32mInfrastruktura[0m
 AP[1].CHAN:                             [32m1[0m
-AP[1].RATE:                             [32m54 Mbit/s[0m
+AP[1].RATE:                             [32m54 Mb/s[0m
 AP[1].SIGNAL:                           [32m92[0m
 AP[1].BARS:                             [32m****[0m
 AP[1].SECURITY:                         [32mWPA1 WPA2[0m
 AP[2].IN-USE:                           [32m [0m
 AP[2].SSID:                             [32mwlan0-ap-1[0m
-AP[2].MODE:                             [32mInfra[0m
+AP[2].MODE:                             [32mInfrastruktura[0m
 AP[2].CHAN:                             [32m1[0m
-AP[2].RATE:                             [32m54 Mbit/s[0m
+AP[2].RATE:                             [32m54 Mb/s[0m
 AP[2].SIGNAL:                           [32m81[0m
 AP[2].BARS:                             [32m****[0m
 AP[2].SECURITY:                         [32mWPA1 WPA2[0m
 AP[3].IN-USE:                           [35m [0m
 AP[3].SSID:                             [35mwlan0-ap-3[0m
-AP[3].MODE:                             [35mInfra[0m
+AP[3].MODE:                             [35mInfrastruktura[0m
 AP[3].CHAN:                             [35m1[0m
-AP[3].RATE:                             [35m54 Mbit/s[0m
+AP[3].RATE:                             [35m54 Mb/s[0m
 AP[3].SIGNAL:                           [35m55[0m
 AP[3].BARS:                             [35m**  [0m
 AP[3].SECURITY:                         [35mWPA1 WPA2[0m
@@ -4994,14 +5106,6 @@ DHCP6.OPTION[5]:                        dhcp-6-opt-5 = val-5
 CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
-<<<
-size: 21120
-location: clients/tests/test-client.py:1050:test_004()/86
-cmd: $NMCLI --color yes -f all dev show
-lang: pl_PL.UTF-8
-returncode: 0
-stdout: 20961 bytes
->>>
 GENERAL.DEVICE:                         eth0
 GENERAL.TYPE:                           ethernet
 GENERAL.NM-TYPE:                        NMDeviceEthernet
@@ -5288,98 +5392,6 @@ DHCP6.OPTION[2]:                        dhcp-6-opt-6 = val-6
 DHCP6.OPTION[3]:                        dhcp-6-opt-7 = val-7
 DHCP6.OPTION[4]:                        dhcp-6-opt-8 = val-8
 DHCP6.OPTION[5]:                        dhcp-6-opt-9 = val-9
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
-
-GENERAL.DEVICE:                         wlan0
-GENERAL.TYPE:                           wifi
-GENERAL.NM-TYPE:                        NMDeviceWifi
-GENERAL.VENDOR:                         --
-GENERAL.PRODUCT:                        --
-GENERAL.DRIVER:                         virtual
-GENERAL.DRIVER-VERSION:                 --
-GENERAL.FIRMWARE-VERSION:               --
-GENERAL.HWADDR:                         13:E0:74:85:7C:D9
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (niedostępne)
-GENERAL.REASON:                         0 (Nie podano przyczyny)
-GENERAL.IP4-CONNECTIVITY:               0 (nieznane)
-GENERAL.IP6-CONNECTIVITY:               0 (nieznane)
-GENERAL.UDI:                            /sys/devices/virtual/wlan0
-GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    nie
-GENERAL.NM-MANAGED:                     tak
-GENERAL.AUTOCONNECT:                    tak
-GENERAL.FIRMWARE-MISSING:               nie
-GENERAL.NM-PLUGIN-MISSING:              nie
-GENERAL.PHYS-PORT-ID:                   --
-GENERAL.CONNECTION:                     con-vpn-1
-GENERAL.CON-UUID:                       UUID-con-vpn-1-REPLACED-REPLACED-REP
-GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
-GENERAL.METERED:                        nieznane
-CAPABILITIES.CARRIER-DETECT:            nie
-CAPABILITIES.SPEED:                     nieznane
-CAPABILITIES.IS-SOFTWARE:               nie
-CAPABILITIES.SRIOV:                     nie
-WIFI-PROPERTIES.WEP:                    tak
-WIFI-PROPERTIES.WPA:                    tak
-WIFI-PROPERTIES.WPA2:                   tak
-WIFI-PROPERTIES.TKIP:                   tak
-WIFI-PROPERTIES.CCMP:                   tak
-WIFI-PROPERTIES.AP:                     tak
-WIFI-PROPERTIES.ADHOC:                  tak
-WIFI-PROPERTIES.2GHZ:                   nieznane
-WIFI-PROPERTIES.5GHZ:                   nieznane
-AP[1].IN-USE:                           [32m [0m
-AP[1].SSID:                             [32mwlan0-ap-2[0m
-AP[1].MODE:                             [32mInfrastruktura[0m
-AP[1].CHAN:                             [32m1[0m
-AP[1].RATE:                             [32m54 Mb/s[0m
-AP[1].SIGNAL:                           [32m92[0m
-AP[1].BARS:                             [32m****[0m
-AP[1].SECURITY:                         [32mWPA1 WPA2[0m
-AP[2].IN-USE:                           [32m [0m
-AP[2].SSID:                             [32mwlan0-ap-1[0m
-AP[2].MODE:                             [32mInfrastruktura[0m
-AP[2].CHAN:                             [32m1[0m
-AP[2].RATE:                             [32m54 Mb/s[0m
-AP[2].SIGNAL:                           [32m81[0m
-AP[2].BARS:                             [32m****[0m
-AP[2].SECURITY:                         [32mWPA1 WPA2[0m
-AP[3].IN-USE:                           [35m [0m
-AP[3].SSID:                             [35mwlan0-ap-3[0m
-AP[3].MODE:                             [35mInfrastruktura[0m
-AP[3].CHAN:                             [35m1[0m
-AP[3].RATE:                             [35m54 Mb/s[0m
-AP[3].SIGNAL:                           [35m55[0m
-AP[3].BARS:                             [35m**  [0m
-AP[3].SECURITY:                         [35mWPA1 WPA2[0m
-IP4.ADDRESS[1]:                         192.168.228.18/32
-IP4.ADDRESS[2]:                         192.168.209.179/25
-IP4.GATEWAY:                            192.168.41.120
-IP4.DOMAIN[1]:                          sear4.foo2.bar
-IP4.DOMAIN[2]:                          sear4.fo.x.y
-IP4.DOMAIN[3]:                          sear4.foo1.bar
-IP4.DOMAIN[4]:                          sear4.foo4.bar
-IP4.DOMAIN[5]:                          sear4.fo.o.bar
-IP4.WINS[1]:                            192.168.120.79
-DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:                        dhcp-4-opt-2 = val-2
-DHCP4.OPTION[3]:                        dhcp-4-opt-4 = val-4
-DHCP4.OPTION[4]:                        dhcp-4-opt-7 = val-7
-IP6.GATEWAY:                            --
-IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
-IP6.DOMAIN[1]:                          sear6.foo2.bar
-IP6.DOMAIN[2]:                          sear6.foo1.bar
-IP6.DOMAIN[3]:                          sear6.fo.x.y
-IP6.DOMAIN[4]:                          sear6.fo.o.bar
-IP6.DOMAIN[5]:                          sear6.foo3.bar
-IP6.DOMAIN[6]:                          sear6.foo4.bar
-DHCP6.OPTION[1]:                        dhcp-6-opt-1 = val-1
-DHCP6.OPTION[2]:                        dhcp-6-opt-2 = val-2
-DHCP6.OPTION[3]:                        dhcp-6-opt-3 = val-3
-DHCP6.OPTION[4]:                        dhcp-6-opt-4 = val-4
-DHCP6.OPTION[5]:                        dhcp-6-opt-5 = val-5
 CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
@@ -5838,11 +5850,11 @@ returncode: 0
 stdout: 486 bytes
 >>>
 DEVICE  TYPE      DBUS-PATH                                 
+[2mwlan0[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/3[0m 
 [2meth0[0m    [2methernet[0m  [2m/org/freedesktop/NetworkManager/Devices/1[0m 
 [2meth1[0m    [2methernet[0m  [2m/org/freedesktop/NetworkManager/Devices/2[0m 
 [2mwlan1[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/4[0m 
 [2mwlan1[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/5[0m 
-[2mwlan0[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/3[0m 
 
 <<<
 size: 656
@@ -5853,11 +5865,11 @@ returncode: 0
 stdout: 486 bytes
 >>>
 DEVICE  TYPE      DBUS-PATH                                 
+[2mwlan0[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/3[0m 
 [2meth0[0m    [2methernet[0m  [2m/org/freedesktop/NetworkManager/Devices/1[0m 
 [2meth1[0m    [2methernet[0m  [2m/org/freedesktop/NetworkManager/Devices/2[0m 
 [2mwlan1[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/4[0m 
 [2mwlan1[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/5[0m 
-[2mwlan0[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/3[0m 
 
 <<<
 size: 2608
@@ -5868,14 +5880,14 @@ returncode: 0
 stdout: 2452 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
-[35mAP[1][0m  [35mwlan1-ap-4[0m  [35m776C616E312D61702D34[0m  [35m94:2B:E8:F6:D2:86[0m  [35mInfra[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mbit/s[0m  [35m48[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan1[0m   [35mno[0m      [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m 
-
-NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
-
-NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 [32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
 [32mAP[2][0m  [32mwlan0-ap-1[0m  [32m776C616E302D61702D31[0m  [32m61:95:77:AC:1E:4C[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/1[0m 
 [35mAP[3][0m  [35mwlan0-ap-3[0m  [35m776C616E302D61702D33[0m  [35m9B:F6:B7:EC:97:76[0m  [35mInfra[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mbit/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan0[0m   [35mno[0m      [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m 
+
+NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+[35mAP[1][0m  [35mwlan1-ap-4[0m  [35m776C616E312D61702D34[0m  [35m94:2B:E8:F6:D2:86[0m  [35mInfra[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mbit/s[0m  [35m48[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan1[0m   [35mno[0m      [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m 
+
+NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 
 <<<
 size: 2676
@@ -5886,14 +5898,14 @@ returncode: 0
 stdout: 2510 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
-[35mAP[1][0m  [35mwlan1-ap-4[0m  [35m776C616E312D61702D34[0m  [35m94:2B:E8:F6:D2:86[0m  [35mInfrastruktura[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mb/s[0m  [35m48[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan1[0m   [35mnie[0m     [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m 
-
-NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
-
-NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 [32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
 [32mAP[2][0m  [32mwlan0-ap-1[0m  [32m776C616E302D61702D31[0m  [32m61:95:77:AC:1E:4C[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/1[0m 
 [35mAP[3][0m  [35mwlan0-ap-3[0m  [35m776C616E302D61702D33[0m  [35m9B:F6:B7:EC:97:76[0m  [35mInfrastruktura[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mb/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan0[0m   [35mnie[0m     [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m 
+
+NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+[35mAP[1][0m  [35mwlan1-ap-4[0m  [35m776C616E312D61702D34[0m  [35m94:2B:E8:F6:D2:86[0m  [35mInfrastruktura[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mb/s[0m  [35m48[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan1[0m   [35mnie[0m     [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m 
+
+NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 
 <<<
 size: 918
@@ -5904,14 +5916,14 @@ returncode: 0
 stdout: 760 bytes
 >>>
 IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
-[35m [0m       [35mwlan1-ap-4[0m  [35mInfra[0m  [35m1[0m     [35m54 Mbit/s[0m  [35m48[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
-
-IN-USE  SSID  MODE  CHAN  RATE  SIGNAL  BARS  SECURITY 
-
-IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
 [32m [0m       [32mwlan0-ap-2[0m  [32mInfra[0m  [32m1[0m     [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
 [32m [0m       [32mwlan0-ap-1[0m  [32mInfra[0m  [32m1[0m     [32m54 Mbit/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m 
 [35m [0m       [35mwlan0-ap-3[0m  [35mInfra[0m  [35m1[0m     [35m54 Mbit/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
+
+IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
+[35m [0m       [35mwlan1-ap-4[0m  [35mInfra[0m  [35m1[0m     [35m54 Mbit/s[0m  [35m48[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
+
+IN-USE  SSID  MODE  CHAN  RATE  SIGNAL  BARS  SECURITY 
 
 <<<
 size: 979
@@ -5922,14 +5934,14 @@ returncode: 0
 stdout: 810 bytes
 >>>
 IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
-[35m [0m       [35mwlan1-ap-4[0m  [35mInfrastruktura[0m  [35m1[0m     [35m54 Mb/s[0m  [35m48[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
-
-IN-USE  SSID  MODE  CHAN  RATE  SIGNAL  BARS  SECURITY 
-
-IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
 [32m [0m       [32mwlan0-ap-2[0m  [32mInfrastruktura[0m  [32m1[0m     [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
 [32m [0m       [32mwlan0-ap-1[0m  [32mInfrastruktura[0m  [32m1[0m     [32m54 Mb/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m 
 [35m [0m       [35mwlan0-ap-3[0m  [35mInfrastruktura[0m  [35m1[0m     [35m54 Mb/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
+
+IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
+[35m [0m       [35mwlan1-ap-4[0m  [35mInfrastruktura[0m  [35m1[0m     [35m54 Mb/s[0m  [35m48[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
+
+IN-USE  SSID  MODE  CHAN  RATE  SIGNAL  BARS  SECURITY 
 
 <<<
 size: 2722
@@ -5940,14 +5952,14 @@ returncode: 0
 stdout: 2452 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
-[35mAP[1][0m  [35mwlan1-ap-4[0m  [35m776C616E312D61702D34[0m  [35m94:2B:E8:F6:D2:86[0m  [35mInfra[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mbit/s[0m  [35m48[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan1[0m   [35mno[0m      [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m 
-
-NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
-
-NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 [32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
 [32mAP[2][0m  [32mwlan0-ap-1[0m  [32m776C616E302D61702D31[0m  [32m61:95:77:AC:1E:4C[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/1[0m 
 [35mAP[3][0m  [35mwlan0-ap-3[0m  [35m776C616E302D61702D33[0m  [35m9B:F6:B7:EC:97:76[0m  [35mInfra[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mbit/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan0[0m   [35mno[0m      [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m 
+
+NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+[35mAP[1][0m  [35mwlan1-ap-4[0m  [35m776C616E312D61702D34[0m  [35m94:2B:E8:F6:D2:86[0m  [35mInfra[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mbit/s[0m  [35m48[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan1[0m   [35mno[0m      [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m 
+
+NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 
 <<<
 size: 2790
@@ -5958,80 +5970,92 @@ returncode: 0
 stdout: 2510 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
-[35mAP[1][0m  [35mwlan1-ap-4[0m  [35m776C616E312D61702D34[0m  [35m94:2B:E8:F6:D2:86[0m  [35mInfrastruktura[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mb/s[0m  [35m48[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan1[0m   [35mnie[0m     [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m 
-
-NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
-
-NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 [32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
 [32mAP[2][0m  [32mwlan0-ap-1[0m  [32m776C616E302D61702D31[0m  [32m61:95:77:AC:1E:4C[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/1[0m 
 [35mAP[3][0m  [35mwlan0-ap-3[0m  [35m776C616E302D61702D33[0m  [35m9B:F6:B7:EC:97:76[0m  [35mInfrastruktura[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mb/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan0[0m   [35mnie[0m     [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m 
 
+NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+[35mAP[1][0m  [35mwlan1-ap-4[0m  [35m776C616E312D61702D34[0m  [35m94:2B:E8:F6:D2:86[0m  [35mInfrastruktura[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mb/s[0m  [35m48[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan1[0m   [35mnie[0m     [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m 
+
+NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
+
 <<<
-size: 901
+size: 903
 location: clients/tests/test-client.py:1075:test_004()/103
 cmd: $NMCLI --color yes -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 721 bytes
+stdout: 723 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 [32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
 
+
+
 <<<
-size: 929
+size: 931
 location: clients/tests/test-client.py:1075:test_004()/104
 cmd: $NMCLI --color yes -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 739 bytes
+stdout: 741 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 [32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
 
+
+
 <<<
-size: 393
+size: 395
 location: clients/tests/test-client.py:1077:test_004()/105
 cmd: $NMCLI --color yes -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 210 bytes
+stdout: 212 bytes
 >>>
 IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
 [32m [0m       [32mwlan0-ap-2[0m  [32mInfra[0m  [32m1[0m     [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
 
+
+
 <<<
-size: 419
+size: 421
 location: clients/tests/test-client.py:1077:test_004()/106
 cmd: $NMCLI --color yes -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 226 bytes
+stdout: 228 bytes
 >>>
 IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
 [32m [0m       [32mwlan0-ap-2[0m  [32mInfrastruktura[0m  [32m1[0m     [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
 
+
+
 <<<
-size: 1014
+size: 1016
 location: clients/tests/test-client.py:1080:test_004()/107
 cmd: $NMCLI --color yes -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 721 bytes
+stdout: 723 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 [32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
 
+
+
 <<<
-size: 1042
+size: 1044
 location: clients/tests/test-client.py:1080:test_004()/108
 cmd: $NMCLI --color yes -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 739 bytes
+stdout: 741 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 [32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
+
+
 
 <<<
 size: 5089
@@ -7240,11 +7264,11 @@ stdout: 387 bytes
 =====================
 DEVICE  TYPE      STATE        CONNECTION 
 ----------------------------------------------------------------
+wlan0   wifi      unavailable  con-vpn-1  
 eth0    ethernet  unavailable  --         
 eth1    ethernet  unavailable  --         
 wlan1   wifi      unavailable  --         
 wlan1   wifi      unavailable  --         
-wlan0   wifi      unavailable  con-vpn-1  
 
 <<<
 size: 530
@@ -7259,11 +7283,11 @@ stdout: 385 bytes
 ===================
 DEVICE  TYPE      STATE        CONNECTION 
 --------------------------------------------------------------
+wlan0   wifi      niedostępne  con-vpn-1  
 eth0    ethernet  niedostępne  --         
 eth1    ethernet  niedostępne  --         
 wlan1   wifi      niedostępne  --         
 wlan1   wifi      niedostępne  --         
-wlan0   wifi      niedostępne  con-vpn-1  
 
 <<<
 size: 1718
@@ -7278,11 +7302,11 @@ stdout: 1570 bytes
 =====================
 DEVICE  TYPE      STATE        IP4-CONNECTIVITY  IP6-CONNECTIVITY  DBUS-PATH                                  CONNECTION  CON-UUID                              CON-PATH                                           
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+wlan0   wifi      unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/3  con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2 
 eth0    ethernet  unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/1  --          --                                    --                                                 
 eth1    ethernet  unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/2  --          --                                    --                                                 
 wlan1   wifi      unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/4  --          --                                    --                                                 
 wlan1   wifi      unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/5  --          --                                    --                                                 
-wlan0   wifi      unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/3  con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2 
 
 <<<
 size: 1726
@@ -7297,11 +7321,11 @@ stdout: 1568 bytes
 ===================
 DEVICE  TYPE      STATE        IP4-CONNECTIVITY  IP6-CONNECTIVITY  DBUS-PATH                                  CONNECTION  CON-UUID                              CON-PATH                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+wlan0   wifi      niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/3  con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2 
 eth0    ethernet  niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/1  --          --                                    --                                                 
 eth1    ethernet  niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/2  --          --                                    --                                                 
 wlan1   wifi      niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/4  --          --                                    --                                                 
 wlan1   wifi      niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/5  --          --                                    --                                                 
-wlan0   wifi      niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/3  con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2 
 
 <<<
 size: 12873
@@ -7311,6 +7335,43 @@ lang: C
 returncode: 0
 stdout: 12733 bytes
 >>>
+===============================================================================
+                            Device details (wlan0)
+===============================================================================
+GENERAL.DEVICE:                         wlan0
+-------------------------------------------------------------------------------
+GENERAL.TYPE:                           wifi
+-------------------------------------------------------------------------------
+GENERAL.HWADDR:                         13:E0:74:85:7C:D9
+-------------------------------------------------------------------------------
+GENERAL.MTU:                            0
+-------------------------------------------------------------------------------
+GENERAL.STATE:                          20 (unavailable)
+-------------------------------------------------------------------------------
+GENERAL.CONNECTION:                     con-vpn-1
+-------------------------------------------------------------------------------
+GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
+-------------------------------------------------------------------------------
+IP4.ADDRESS[1]:                         192.168.228.18/32
+IP4.ADDRESS[2]:                         192.168.209.179/25
+IP4.GATEWAY:                            192.168.41.120
+IP4.DOMAIN[1]:                          sear4.foo2.bar
+IP4.DOMAIN[2]:                          sear4.fo.x.y
+IP4.DOMAIN[3]:                          sear4.foo1.bar
+IP4.DOMAIN[4]:                          sear4.foo4.bar
+IP4.DOMAIN[5]:                          sear4.fo.o.bar
+IP4.WINS[1]:                            192.168.120.79
+-------------------------------------------------------------------------------
+IP6.GATEWAY:                            --
+IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
+IP6.DOMAIN[1]:                          sear6.foo2.bar
+IP6.DOMAIN[2]:                          sear6.foo1.bar
+IP6.DOMAIN[3]:                          sear6.fo.x.y
+IP6.DOMAIN[4]:                          sear6.fo.o.bar
+IP6.DOMAIN[5]:                          sear6.foo3.bar
+IP6.DOMAIN[6]:                          sear6.foo4.bar
+-------------------------------------------------------------------------------
+
 ===============================================================================
                              Device details (eth0)
 ===============================================================================
@@ -7474,8 +7535,16 @@ IP6.DNS[1]:                             2001:a::2934:bd66:550d:ec19
 IP6.DOMAIN[1]:                          sear6.fo.x.y
 -------------------------------------------------------------------------------
 
+<<<
+size: 12937
+location: clients/tests/test-client.py:1047:test_004()/130
+cmd: $NMCLI --pretty dev show
+lang: pl_PL.UTF-8
+returncode: 0
+stdout: 12787 bytes
+>>>
 ===============================================================================
-                            Device details (wlan0)
+                        Informacje o urządzeniu (wlan0)
 ===============================================================================
 GENERAL.DEVICE:                         wlan0
 -------------------------------------------------------------------------------
@@ -7485,7 +7554,7 @@ GENERAL.HWADDR:                         13:E0:74:85:7C:D9
 -------------------------------------------------------------------------------
 GENERAL.MTU:                            0
 -------------------------------------------------------------------------------
-GENERAL.STATE:                          20 (unavailable)
+GENERAL.STATE:                          20 (niedostępne)
 -------------------------------------------------------------------------------
 GENERAL.CONNECTION:                     con-vpn-1
 -------------------------------------------------------------------------------
@@ -7511,14 +7580,6 @@ IP6.DOMAIN[5]:                          sear6.foo3.bar
 IP6.DOMAIN[6]:                          sear6.foo4.bar
 -------------------------------------------------------------------------------
 
-<<<
-size: 12937
-location: clients/tests/test-client.py:1047:test_004()/130
-cmd: $NMCLI --pretty dev show
-lang: pl_PL.UTF-8
-returncode: 0
-stdout: 12787 bytes
->>>
 ===============================================================================
                         Informacje o urządzeniu (eth0)
 ===============================================================================
@@ -7682,43 +7743,6 @@ IP6.DNS[1]:                             2001:a::2934:bd66:550d:ec19
 IP6.DOMAIN[1]:                          sear6.fo.x.y
 -------------------------------------------------------------------------------
 
-===============================================================================
-                        Informacje o urządzeniu (wlan0)
-===============================================================================
-GENERAL.DEVICE:                         wlan0
--------------------------------------------------------------------------------
-GENERAL.TYPE:                           wifi
--------------------------------------------------------------------------------
-GENERAL.HWADDR:                         13:E0:74:85:7C:D9
--------------------------------------------------------------------------------
-GENERAL.MTU:                            0
--------------------------------------------------------------------------------
-GENERAL.STATE:                          20 (niedostępne)
--------------------------------------------------------------------------------
-GENERAL.CONNECTION:                     con-vpn-1
--------------------------------------------------------------------------------
-GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
--------------------------------------------------------------------------------
-IP4.ADDRESS[1]:                         192.168.228.18/32
-IP4.ADDRESS[2]:                         192.168.209.179/25
-IP4.GATEWAY:                            192.168.41.120
-IP4.DOMAIN[1]:                          sear4.foo2.bar
-IP4.DOMAIN[2]:                          sear4.fo.x.y
-IP4.DOMAIN[3]:                          sear4.foo1.bar
-IP4.DOMAIN[4]:                          sear4.foo4.bar
-IP4.DOMAIN[5]:                          sear4.fo.o.bar
-IP4.WINS[1]:                            192.168.120.79
--------------------------------------------------------------------------------
-IP6.GATEWAY:                            --
-IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
-IP6.DOMAIN[1]:                          sear6.foo2.bar
-IP6.DOMAIN[2]:                          sear6.foo1.bar
-IP6.DOMAIN[3]:                          sear6.fo.x.y
-IP6.DOMAIN[4]:                          sear6.fo.o.bar
-IP6.DOMAIN[5]:                          sear6.foo3.bar
-IP6.DOMAIN[6]:                          sear6.foo4.bar
--------------------------------------------------------------------------------
-
 <<<
 size: 25255
 location: clients/tests/test-client.py:1050:test_004()/131
@@ -7727,340 +7751,6 @@ lang: C
 returncode: 0
 stdout: 25108 bytes
 >>>
-===============================================================================
-                             Device details (eth0)
-===============================================================================
-GENERAL.DEVICE:                         eth0
-GENERAL.TYPE:                           ethernet
-GENERAL.NM-TYPE:                        NMDeviceEthernet
-GENERAL.VENDOR:                         --
-GENERAL.PRODUCT:                        --
-GENERAL.DRIVER:                         virtual
-GENERAL.DRIVER-VERSION:                 --
-GENERAL.FIRMWARE-VERSION:               --
-GENERAL.HWADDR:                         AB:B7:BF:E2:48:E8
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (unavailable)
-GENERAL.REASON:                         0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:               0 (unknown)
-GENERAL.IP6-CONNECTIVITY:               0 (unknown)
-GENERAL.UDI:                            /sys/devices/virtual/eth0
-GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    no
-GENERAL.NM-MANAGED:                     yes
-GENERAL.AUTOCONNECT:                    yes
-GENERAL.FIRMWARE-MISSING:               no
-GENERAL.NM-PLUGIN-MISSING:              no
-GENERAL.PHYS-PORT-ID:                   --
-GENERAL.CONNECTION:                     --
-GENERAL.CON-UUID:                       --
-GENERAL.CON-PATH:                       --
-GENERAL.METERED:                        unknown
--------------------------------------------------------------------------------
-CAPABILITIES.CARRIER-DETECT:            no
-CAPABILITIES.SPEED:                     100 Mb/s
-CAPABILITIES.IS-SOFTWARE:               no
-CAPABILITIES.SRIOV:                     no
--------------------------------------------------------------------------------
-WIRED-PROPERTIES.CARRIER:               off
--------------------------------------------------------------------------------
-IP4.ADDRESS[1]:                         192.168.49.34/22
-IP4.ADDRESS[2]:                         192.168.135.86/19
-IP4.GATEWAY:                            --
-IP4.DNS[1]:                             192.168.45.230
-IP4.DNS[2]:                             192.168.180.201
-IP4.DNS[3]:                             192.168.253.2
-IP4.DOMAIN[1]:                          sear4.foo2.bar
-IP4.DOMAIN[2]:                          sear4.foo1.bar
-IP4.WINS[1]:                            192.168.163.23
-IP4.WINS[2]:                            192.168.151.246
--------------------------------------------------------------------------------
-DHCP4.OPTION[1]:                        dhcp-4-opt-8 = val-8
-DHCP4.OPTION[2]:                        dhcp-4-opt-9 = val-9
--------------------------------------------------------------------------------
-IP6.ADDRESS[1]:                         2001:a::ed81:3d7:c2e9:df82/99
-IP6.GATEWAY:                            --
-IP6.DNS[1]:                             2001:a::2703:f06:9619:d89f
-IP6.DNS[2]:                             2001:a::3a75:3682:c683:8541
-IP6.DNS[3]:                             2001:a::584e:912:d5ee:c74f
-IP6.DOMAIN[1]:                          sear6.foo4.bar
-IP6.DOMAIN[2]:                          sear6.fo.o.bar
--------------------------------------------------------------------------------
-DHCP6.OPTION[1]:                        dhcp-6-opt-0 = val-0
-DHCP6.OPTION[2]:                        dhcp-6-opt-1 = val-1
-DHCP6.OPTION[3]:                        dhcp-6-opt-2 = val-2
-DHCP6.OPTION[4]:                        dhcp-6-opt-3 = val-3
-DHCP6.OPTION[5]:                        dhcp-6-opt-4 = val-4
-DHCP6.OPTION[6]:                        dhcp-6-opt-5 = val-5
-DHCP6.OPTION[7]:                        dhcp-6-opt-6 = val-6
-DHCP6.OPTION[8]:                        dhcp-6-opt-7 = val-7
-DHCP6.OPTION[9]:                        dhcp-6-opt-8 = val-8
-DHCP6.OPTION[10]:                       dhcp-6-opt-9 = val-9
--------------------------------------------------------------------------------
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{1}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   5fcfd6d7-1e63-3332-8826-a7eda103792d | con-1
--------------------------------------------------------------------------------
-
-===============================================================================
-                             Device details (eth1)
-===============================================================================
-GENERAL.DEVICE:                         eth1
-GENERAL.TYPE:                           ethernet
-GENERAL.NM-TYPE:                        NMDeviceEthernet
-GENERAL.VENDOR:                         --
-GENERAL.PRODUCT:                        --
-GENERAL.DRIVER:                         virtual
-GENERAL.DRIVER-VERSION:                 --
-GENERAL.FIRMWARE-VERSION:               --
-GENERAL.HWADDR:                         E7:78:B1:93:2B:22
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (unavailable)
-GENERAL.REASON:                         0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:               0 (unknown)
-GENERAL.IP6-CONNECTIVITY:               0 (unknown)
-GENERAL.UDI:                            /sys/devices/virtual/eth1
-GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    no
-GENERAL.NM-MANAGED:                     yes
-GENERAL.AUTOCONNECT:                    yes
-GENERAL.FIRMWARE-MISSING:               no
-GENERAL.NM-PLUGIN-MISSING:              no
-GENERAL.PHYS-PORT-ID:                   --
-GENERAL.CONNECTION:                     --
-GENERAL.CON-UUID:                       --
-GENERAL.CON-PATH:                       --
-GENERAL.METERED:                        unknown
--------------------------------------------------------------------------------
-CAPABILITIES.CARRIER-DETECT:            no
-CAPABILITIES.SPEED:                     100 Mb/s
-CAPABILITIES.IS-SOFTWARE:               no
-CAPABILITIES.SRIOV:                     no
--------------------------------------------------------------------------------
-WIRED-PROPERTIES.CARRIER:               off
--------------------------------------------------------------------------------
-IP4.ADDRESS[1]:                         192.168.127.210/25
-IP4.GATEWAY:                            192.168.88.4
-IP4.ROUTE[1]:                           dst = 192.168.222.35/19, nh = 192.168.170.142, mt = 3609264321
-IP4.ROUTE[2]:                           dst = 192.168.135.81/32, nh = 192.168.32.11, mt = 1316413247
-IP4.ROUTE[3]:                           dst = 192.168.24.65/26, nh = 192.168.23.163, mt = 3855574583
-IP4.DNS[1]:                             192.168.16.144
-IP4.DNS[2]:                             192.168.79.53
-IP4.DNS[3]:                             192.168.237.155
-IP4.DOMAIN[1]:                          sear4.foo4.bar
-IP4.DOMAIN[2]:                          sear4.foo3.bar
-IP4.DOMAIN[3]:                          sear4.foo1.bar
-IP4.WINS[1]:                            192.168.211.91
-IP4.WINS[2]:                            192.168.58.182
-IP4.WINS[3]:                            192.168.114.97
--------------------------------------------------------------------------------
-DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:                        dhcp-4-opt-1 = val-1
-DHCP4.OPTION[3]:                        dhcp-4-opt-2 = val-2
-DHCP4.OPTION[4]:                        dhcp-4-opt-3 = val-3
-DHCP4.OPTION[5]:                        dhcp-4-opt-4 = val-4
-DHCP4.OPTION[6]:                        dhcp-4-opt-5 = val-5
-DHCP4.OPTION[7]:                        dhcp-4-opt-7 = val-7
-DHCP4.OPTION[8]:                        dhcp-4-opt-8 = val-8
-DHCP4.OPTION[9]:                        dhcp-4-opt-9 = val-9
--------------------------------------------------------------------------------
-IP6.ADDRESS[1]:                         2001:a::1c1:c178:169f:2b80/93
-IP6.ADDRESS[2]:                         2001:a::1f79:e0fb:87b9:3cc6/123
-IP6.GATEWAY:                            --
-IP6.ROUTE[1]:                           dst = 2001:a::3166:7ed1:e4ae:7612/123, nh = ::
-IP6.DNS[1]:                             2001:a::edda:955:dcf4:23d4
-IP6.DNS[2]:                             2001:a::109f:aa0f:fb4a:9d5a
-IP6.DNS[3]:                             2001:a::61cf:7c82:e9c0:c952
-IP6.DOMAIN[1]:                          sear6.foo1.bar
--------------------------------------------------------------------------------
-DHCP6.OPTION[1]:                        dhcp-6-opt-2 = val-2
-DHCP6.OPTION[2]:                        dhcp-6-opt-5 = val-5
-DHCP6.OPTION[3]:                        dhcp-6-opt-6 = val-6
-DHCP6.OPTION[4]:                        dhcp-6-opt-8 = val-8
-DHCP6.OPTION[5]:                        dhcp-6-opt-9 = val-9
--------------------------------------------------------------------------------
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{1}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   5fcfd6d7-1e63-3332-8826-a7eda103792d | con-1
--------------------------------------------------------------------------------
-
-===============================================================================
-                            Device details (wlan1)
-===============================================================================
-GENERAL.DEVICE:                         wlan1
-GENERAL.TYPE:                           wifi
-GENERAL.NM-TYPE:                        NMDeviceWifi
-GENERAL.VENDOR:                         --
-GENERAL.PRODUCT:                        --
-GENERAL.DRIVER:                         virtual
-GENERAL.DRIVER-VERSION:                 --
-GENERAL.FIRMWARE-VERSION:               --
-GENERAL.HWADDR:                         21:E9:64:81:8C:A8
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (unavailable)
-GENERAL.REASON:                         0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:               0 (unknown)
-GENERAL.IP6-CONNECTIVITY:               0 (unknown)
-GENERAL.UDI:                            /sys/devices/virtual/wlan1
-GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    no
-GENERAL.NM-MANAGED:                     yes
-GENERAL.AUTOCONNECT:                    yes
-GENERAL.FIRMWARE-MISSING:               no
-GENERAL.NM-PLUGIN-MISSING:              no
-GENERAL.PHYS-PORT-ID:                   --
-GENERAL.CONNECTION:                     --
-GENERAL.CON-UUID:                       --
-GENERAL.CON-PATH:                       --
-GENERAL.METERED:                        unknown
--------------------------------------------------------------------------------
-CAPABILITIES.CARRIER-DETECT:            no
-CAPABILITIES.SPEED:                     unknown
-CAPABILITIES.IS-SOFTWARE:               no
-CAPABILITIES.SRIOV:                     no
--------------------------------------------------------------------------------
-WIFI-PROPERTIES.WEP:                    yes
-WIFI-PROPERTIES.WPA:                    yes
-WIFI-PROPERTIES.WPA2:                   yes
-WIFI-PROPERTIES.TKIP:                   yes
-WIFI-PROPERTIES.CCMP:                   yes
-WIFI-PROPERTIES.AP:                     yes
-WIFI-PROPERTIES.ADHOC:                  yes
-WIFI-PROPERTIES.2GHZ:                   unknown
-WIFI-PROPERTIES.5GHZ:                   unknown
--------------------------------------------------------------------------------
-AP[1].IN-USE:                            
-AP[1].SSID:                             wlan1-ap-4
-AP[1].MODE:                             Infra
-AP[1].CHAN:                             1
-AP[1].RATE:                             54 Mbit/s
-AP[1].SIGNAL:                           48
-AP[1].BARS:                             **  
-AP[1].SECURITY:                         WPA1 WPA2
--------------------------------------------------------------------------------
-IP4.GATEWAY:                            192.168.57.160
-IP4.ROUTE[1]:                           dst = 192.168.36.106/21, nh = 192.168.199.128, mt = 979274165
-IP4.ROUTE[2]:                           dst = 192.168.238.130/19, nh = 0.0.0.0
-IP4.ROUTE[3]:                           dst = 192.168.224.39/32, nh = 192.168.148.69
-IP4.DNS[1]:                             192.168.61.83
-IP4.DOMAIN[1]:                          sear4.foo4.bar
-IP4.DOMAIN[2]:                          sear4.fo.x.y
-IP4.DOMAIN[3]:                          sear4.foo2.bar
-IP4.DOMAIN[4]:                          sear4.foo1.bar
-IP4.DOMAIN[5]:                          sear4.fo.o.bar
-IP4.DOMAIN[6]:                          sear4.foo3.bar
--------------------------------------------------------------------------------
-DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:                        dhcp-4-opt-1 = val-1
-DHCP4.OPTION[3]:                        dhcp-4-opt-2 = val-2
-DHCP4.OPTION[4]:                        dhcp-4-opt-4 = val-4
-DHCP4.OPTION[5]:                        dhcp-4-opt-6 = val-6
-DHCP4.OPTION[6]:                        dhcp-4-opt-7 = val-7
-DHCP4.OPTION[7]:                        dhcp-4-opt-8 = val-8
-DHCP4.OPTION[8]:                        dhcp-4-opt-9 = val-9
--------------------------------------------------------------------------------
-IP6.ADDRESS[1]:                         2001:a::fa05:2ab4:9300:e8fe/116
-IP6.ADDRESS[2]:                         2001:a::e9cf:bd3:caba:99b3/86
-IP6.ADDRESS[3]:                         2001:a::2be6:44fa:2c95:5559/78
-IP6.GATEWAY:                            2001:a::4d70:d91a:770f:2319
-IP6.ROUTE[1]:                           dst = 2001:a::3cb2:719d:bb00:b22f/66, nh = 2001:a::81b1:58b9:7237:3511, mt = 2280277732
-IP6.ROUTE[2]:                           dst = 2001:a::986f:983c:5eb:1c7d/99, nh = ::, mt = 1204008676
-IP6.DNS[1]:                             2001:a::85e7:3d7d:53e8:50ac
-IP6.DNS[2]:                             2001:a::1c5:9cb5:e86d:25a5
-IP6.DOMAIN[1]:                          sear6.foo4.bar
-IP6.DOMAIN[2]:                          sear6.foo2.bar
--------------------------------------------------------------------------------
-DHCP6.OPTION[1]:                        dhcp-6-opt-0 = val-0
-DHCP6.OPTION[2]:                        dhcp-6-opt-1 = val-1
-DHCP6.OPTION[3]:                        dhcp-6-opt-2 = val-2
-DHCP6.OPTION[4]:                        dhcp-6-opt-3 = val-3
-DHCP6.OPTION[5]:                        dhcp-6-opt-4 = val-4
-DHCP6.OPTION[6]:                        dhcp-6-opt-5 = val-5
-DHCP6.OPTION[7]:                        dhcp-6-opt-6 = val-6
-DHCP6.OPTION[8]:                        dhcp-6-opt-7 = val-7
-DHCP6.OPTION[9]:                        dhcp-6-opt-9 = val-9
--------------------------------------------------------------------------------
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
--------------------------------------------------------------------------------
-
-===============================================================================
-                            Device details (wlan1)
-===============================================================================
-GENERAL.DEVICE:                         wlan1
-GENERAL.TYPE:                           wifi
-GENERAL.NM-TYPE:                        NMDeviceWifi
-GENERAL.VENDOR:                         --
-GENERAL.PRODUCT:                        --
-GENERAL.DRIVER:                         virtual
-GENERAL.DRIVER-VERSION:                 --
-GENERAL.FIRMWARE-VERSION:               --
-GENERAL.HWADDR:                         71:52:AD:63:5C:7C
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (unavailable)
-GENERAL.REASON:                         0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:               0 (unknown)
-GENERAL.IP6-CONNECTIVITY:               0 (unknown)
-GENERAL.UDI:                            /sys/devices/virtual/wlan1
-GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    no
-GENERAL.NM-MANAGED:                     yes
-GENERAL.AUTOCONNECT:                    yes
-GENERAL.FIRMWARE-MISSING:               no
-GENERAL.NM-PLUGIN-MISSING:              no
-GENERAL.PHYS-PORT-ID:                   --
-GENERAL.CONNECTION:                     --
-GENERAL.CON-UUID:                       --
-GENERAL.CON-PATH:                       --
-GENERAL.METERED:                        unknown
--------------------------------------------------------------------------------
-CAPABILITIES.CARRIER-DETECT:            no
-CAPABILITIES.SPEED:                     unknown
-CAPABILITIES.IS-SOFTWARE:               no
-CAPABILITIES.SRIOV:                     no
--------------------------------------------------------------------------------
-WIFI-PROPERTIES.WEP:                    yes
-WIFI-PROPERTIES.WPA:                    yes
-WIFI-PROPERTIES.WPA2:                   yes
-WIFI-PROPERTIES.TKIP:                   yes
-WIFI-PROPERTIES.CCMP:                   yes
-WIFI-PROPERTIES.AP:                     yes
-WIFI-PROPERTIES.ADHOC:                  yes
-WIFI-PROPERTIES.2GHZ:                   unknown
-WIFI-PROPERTIES.5GHZ:                   unknown
--------------------------------------------------------------------------------
-IP4.ADDRESS[1]:                         192.168.97.124/29
-IP4.ADDRESS[2]:                         192.168.76.154/18
-IP4.GATEWAY:                            --
-IP4.ROUTE[1]:                           dst = 192.168.33.233/22, nh = 192.168.222.210, mt = 2810496551
-IP4.DNS[1]:                             192.168.107.109
-IP4.DOMAIN[1]:                          sear4.fo.o.bar
-IP4.DOMAIN[2]:                          sear4.fo.x.y
-IP4.DOMAIN[3]:                          sear4.foo2.bar
-IP4.DOMAIN[4]:                          sear4.foo3.bar
-IP4.DOMAIN[5]:                          sear4.foo4.bar
-IP4.WINS[1]:                            192.168.60.60
-IP4.WINS[2]:                            192.168.63.92
--------------------------------------------------------------------------------
-DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:                        dhcp-4-opt-5 = val-5
--------------------------------------------------------------------------------
-IP6.ADDRESS[1]:                         2001:a::88ca:3654:96b:ab44/89
-IP6.GATEWAY:                            --
-IP6.ROUTE[1]:                           dst = 2001:a::cc8b:7c09:4673:bbb0/85, nh = ::, mt = 2821465568
-IP6.ROUTE[2]:                           dst = 2001:a::a976:2488:f49f:b48/106, nh = 2001:a::62ae:c734:fc7b:e931, mt = 2248613879
-IP6.ROUTE[3]:                           dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::
-IP6.DNS[1]:                             2001:a::2934:bd66:550d:ec19
-IP6.DOMAIN[1]:                          sear6.fo.x.y
--------------------------------------------------------------------------------
-DHCP6.OPTION[1]:                        dhcp-6-opt-2 = val-2
-DHCP6.OPTION[2]:                        dhcp-6-opt-6 = val-6
-DHCP6.OPTION[3]:                        dhcp-6-opt-7 = val-7
-DHCP6.OPTION[4]:                        dhcp-6-opt-8 = val-8
-DHCP6.OPTION[5]:                        dhcp-6-opt-9 = val-9
--------------------------------------------------------------------------------
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
--------------------------------------------------------------------------------
-
 ===============================================================================
                             Device details (wlan0)
 ===============================================================================
@@ -8167,6 +7857,340 @@ CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 -------------------------------------------------------------------------------
 
+===============================================================================
+                             Device details (eth0)
+===============================================================================
+GENERAL.DEVICE:                         eth0
+GENERAL.TYPE:                           ethernet
+GENERAL.NM-TYPE:                        NMDeviceEthernet
+GENERAL.VENDOR:                         --
+GENERAL.PRODUCT:                        --
+GENERAL.DRIVER:                         virtual
+GENERAL.DRIVER-VERSION:                 --
+GENERAL.FIRMWARE-VERSION:               --
+GENERAL.HWADDR:                         AB:B7:BF:E2:48:E8
+GENERAL.MTU:                            0
+GENERAL.STATE:                          20 (unavailable)
+GENERAL.REASON:                         0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:               0 (unknown)
+GENERAL.IP6-CONNECTIVITY:               0 (unknown)
+GENERAL.UDI:                            /sys/devices/virtual/eth0
+GENERAL.IP-IFACE:                       --
+GENERAL.IS-SOFTWARE:                    no
+GENERAL.NM-MANAGED:                     yes
+GENERAL.AUTOCONNECT:                    yes
+GENERAL.FIRMWARE-MISSING:               no
+GENERAL.NM-PLUGIN-MISSING:              no
+GENERAL.PHYS-PORT-ID:                   --
+GENERAL.CONNECTION:                     --
+GENERAL.CON-UUID:                       --
+GENERAL.CON-PATH:                       --
+GENERAL.METERED:                        unknown
+-------------------------------------------------------------------------------
+CAPABILITIES.CARRIER-DETECT:            no
+CAPABILITIES.SPEED:                     100 Mb/s
+CAPABILITIES.IS-SOFTWARE:               no
+CAPABILITIES.SRIOV:                     no
+-------------------------------------------------------------------------------
+WIRED-PROPERTIES.CARRIER:               off
+-------------------------------------------------------------------------------
+IP4.ADDRESS[1]:                         192.168.49.34/22
+IP4.ADDRESS[2]:                         192.168.135.86/19
+IP4.GATEWAY:                            --
+IP4.DNS[1]:                             192.168.45.230
+IP4.DNS[2]:                             192.168.180.201
+IP4.DNS[3]:                             192.168.253.2
+IP4.DOMAIN[1]:                          sear4.foo2.bar
+IP4.DOMAIN[2]:                          sear4.foo1.bar
+IP4.WINS[1]:                            192.168.163.23
+IP4.WINS[2]:                            192.168.151.246
+-------------------------------------------------------------------------------
+DHCP4.OPTION[1]:                        dhcp-4-opt-8 = val-8
+DHCP4.OPTION[2]:                        dhcp-4-opt-9 = val-9
+-------------------------------------------------------------------------------
+IP6.ADDRESS[1]:                         2001:a::ed81:3d7:c2e9:df82/99
+IP6.GATEWAY:                            --
+IP6.DNS[1]:                             2001:a::2703:f06:9619:d89f
+IP6.DNS[2]:                             2001:a::3a75:3682:c683:8541
+IP6.DNS[3]:                             2001:a::584e:912:d5ee:c74f
+IP6.DOMAIN[1]:                          sear6.foo4.bar
+IP6.DOMAIN[2]:                          sear6.fo.o.bar
+-------------------------------------------------------------------------------
+DHCP6.OPTION[1]:                        dhcp-6-opt-0 = val-0
+DHCP6.OPTION[2]:                        dhcp-6-opt-1 = val-1
+DHCP6.OPTION[3]:                        dhcp-6-opt-2 = val-2
+DHCP6.OPTION[4]:                        dhcp-6-opt-3 = val-3
+DHCP6.OPTION[5]:                        dhcp-6-opt-4 = val-4
+DHCP6.OPTION[6]:                        dhcp-6-opt-5 = val-5
+DHCP6.OPTION[7]:                        dhcp-6-opt-6 = val-6
+DHCP6.OPTION[8]:                        dhcp-6-opt-7 = val-7
+DHCP6.OPTION[9]:                        dhcp-6-opt-8 = val-8
+DHCP6.OPTION[10]:                       dhcp-6-opt-9 = val-9
+-------------------------------------------------------------------------------
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{1}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   5fcfd6d7-1e63-3332-8826-a7eda103792d | con-1
+-------------------------------------------------------------------------------
+
+===============================================================================
+                             Device details (eth1)
+===============================================================================
+GENERAL.DEVICE:                         eth1
+GENERAL.TYPE:                           ethernet
+GENERAL.NM-TYPE:                        NMDeviceEthernet
+GENERAL.VENDOR:                         --
+GENERAL.PRODUCT:                        --
+GENERAL.DRIVER:                         virtual
+GENERAL.DRIVER-VERSION:                 --
+GENERAL.FIRMWARE-VERSION:               --
+GENERAL.HWADDR:                         E7:78:B1:93:2B:22
+GENERAL.MTU:                            0
+GENERAL.STATE:                          20 (unavailable)
+GENERAL.REASON:                         0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:               0 (unknown)
+GENERAL.IP6-CONNECTIVITY:               0 (unknown)
+GENERAL.UDI:                            /sys/devices/virtual/eth1
+GENERAL.IP-IFACE:                       --
+GENERAL.IS-SOFTWARE:                    no
+GENERAL.NM-MANAGED:                     yes
+GENERAL.AUTOCONNECT:                    yes
+GENERAL.FIRMWARE-MISSING:               no
+GENERAL.NM-PLUGIN-MISSING:              no
+GENERAL.PHYS-PORT-ID:                   --
+GENERAL.CONNECTION:                     --
+GENERAL.CON-UUID:                       --
+GENERAL.CON-PATH:                       --
+GENERAL.METERED:                        unknown
+-------------------------------------------------------------------------------
+CAPABILITIES.CARRIER-DETECT:            no
+CAPABILITIES.SPEED:                     100 Mb/s
+CAPABILITIES.IS-SOFTWARE:               no
+CAPABILITIES.SRIOV:                     no
+-------------------------------------------------------------------------------
+WIRED-PROPERTIES.CARRIER:               off
+-------------------------------------------------------------------------------
+IP4.ADDRESS[1]:                         192.168.127.210/25
+IP4.GATEWAY:                            192.168.88.4
+IP4.ROUTE[1]:                           dst = 192.168.222.35/19, nh = 192.168.170.142, mt = 3609264321
+IP4.ROUTE[2]:                           dst = 192.168.135.81/32, nh = 192.168.32.11, mt = 1316413247
+IP4.ROUTE[3]:                           dst = 192.168.24.65/26, nh = 192.168.23.163, mt = 3855574583
+IP4.DNS[1]:                             192.168.16.144
+IP4.DNS[2]:                             192.168.79.53
+IP4.DNS[3]:                             192.168.237.155
+IP4.DOMAIN[1]:                          sear4.foo4.bar
+IP4.DOMAIN[2]:                          sear4.foo3.bar
+IP4.DOMAIN[3]:                          sear4.foo1.bar
+IP4.WINS[1]:                            192.168.211.91
+IP4.WINS[2]:                            192.168.58.182
+IP4.WINS[3]:                            192.168.114.97
+-------------------------------------------------------------------------------
+DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:                        dhcp-4-opt-1 = val-1
+DHCP4.OPTION[3]:                        dhcp-4-opt-2 = val-2
+DHCP4.OPTION[4]:                        dhcp-4-opt-3 = val-3
+DHCP4.OPTION[5]:                        dhcp-4-opt-4 = val-4
+DHCP4.OPTION[6]:                        dhcp-4-opt-5 = val-5
+DHCP4.OPTION[7]:                        dhcp-4-opt-7 = val-7
+DHCP4.OPTION[8]:                        dhcp-4-opt-8 = val-8
+DHCP4.OPTION[9]:                        dhcp-4-opt-9 = val-9
+-------------------------------------------------------------------------------
+IP6.ADDRESS[1]:                         2001:a::1c1:c178:169f:2b80/93
+IP6.ADDRESS[2]:                         2001:a::1f79:e0fb:87b9:3cc6/123
+IP6.GATEWAY:                            --
+IP6.ROUTE[1]:                           dst = 2001:a::3166:7ed1:e4ae:7612/123, nh = ::
+IP6.DNS[1]:                             2001:a::edda:955:dcf4:23d4
+IP6.DNS[2]:                             2001:a::109f:aa0f:fb4a:9d5a
+IP6.DNS[3]:                             2001:a::61cf:7c82:e9c0:c952
+IP6.DOMAIN[1]:                          sear6.foo1.bar
+-------------------------------------------------------------------------------
+DHCP6.OPTION[1]:                        dhcp-6-opt-2 = val-2
+DHCP6.OPTION[2]:                        dhcp-6-opt-5 = val-5
+DHCP6.OPTION[3]:                        dhcp-6-opt-6 = val-6
+DHCP6.OPTION[4]:                        dhcp-6-opt-8 = val-8
+DHCP6.OPTION[5]:                        dhcp-6-opt-9 = val-9
+-------------------------------------------------------------------------------
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{1}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   5fcfd6d7-1e63-3332-8826-a7eda103792d | con-1
+-------------------------------------------------------------------------------
+
+===============================================================================
+                            Device details (wlan1)
+===============================================================================
+GENERAL.DEVICE:                         wlan1
+GENERAL.TYPE:                           wifi
+GENERAL.NM-TYPE:                        NMDeviceWifi
+GENERAL.VENDOR:                         --
+GENERAL.PRODUCT:                        --
+GENERAL.DRIVER:                         virtual
+GENERAL.DRIVER-VERSION:                 --
+GENERAL.FIRMWARE-VERSION:               --
+GENERAL.HWADDR:                         21:E9:64:81:8C:A8
+GENERAL.MTU:                            0
+GENERAL.STATE:                          20 (unavailable)
+GENERAL.REASON:                         0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:               0 (unknown)
+GENERAL.IP6-CONNECTIVITY:               0 (unknown)
+GENERAL.UDI:                            /sys/devices/virtual/wlan1
+GENERAL.IP-IFACE:                       --
+GENERAL.IS-SOFTWARE:                    no
+GENERAL.NM-MANAGED:                     yes
+GENERAL.AUTOCONNECT:                    yes
+GENERAL.FIRMWARE-MISSING:               no
+GENERAL.NM-PLUGIN-MISSING:              no
+GENERAL.PHYS-PORT-ID:                   --
+GENERAL.CONNECTION:                     --
+GENERAL.CON-UUID:                       --
+GENERAL.CON-PATH:                       --
+GENERAL.METERED:                        unknown
+-------------------------------------------------------------------------------
+CAPABILITIES.CARRIER-DETECT:            no
+CAPABILITIES.SPEED:                     unknown
+CAPABILITIES.IS-SOFTWARE:               no
+CAPABILITIES.SRIOV:                     no
+-------------------------------------------------------------------------------
+WIFI-PROPERTIES.WEP:                    yes
+WIFI-PROPERTIES.WPA:                    yes
+WIFI-PROPERTIES.WPA2:                   yes
+WIFI-PROPERTIES.TKIP:                   yes
+WIFI-PROPERTIES.CCMP:                   yes
+WIFI-PROPERTIES.AP:                     yes
+WIFI-PROPERTIES.ADHOC:                  yes
+WIFI-PROPERTIES.2GHZ:                   unknown
+WIFI-PROPERTIES.5GHZ:                   unknown
+-------------------------------------------------------------------------------
+AP[1].IN-USE:                            
+AP[1].SSID:                             wlan1-ap-4
+AP[1].MODE:                             Infra
+AP[1].CHAN:                             1
+AP[1].RATE:                             54 Mbit/s
+AP[1].SIGNAL:                           48
+AP[1].BARS:                             **  
+AP[1].SECURITY:                         WPA1 WPA2
+-------------------------------------------------------------------------------
+IP4.GATEWAY:                            192.168.57.160
+IP4.ROUTE[1]:                           dst = 192.168.36.106/21, nh = 192.168.199.128, mt = 979274165
+IP4.ROUTE[2]:                           dst = 192.168.238.130/19, nh = 0.0.0.0
+IP4.ROUTE[3]:                           dst = 192.168.224.39/32, nh = 192.168.148.69
+IP4.DNS[1]:                             192.168.61.83
+IP4.DOMAIN[1]:                          sear4.foo4.bar
+IP4.DOMAIN[2]:                          sear4.fo.x.y
+IP4.DOMAIN[3]:                          sear4.foo2.bar
+IP4.DOMAIN[4]:                          sear4.foo1.bar
+IP4.DOMAIN[5]:                          sear4.fo.o.bar
+IP4.DOMAIN[6]:                          sear4.foo3.bar
+-------------------------------------------------------------------------------
+DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:                        dhcp-4-opt-1 = val-1
+DHCP4.OPTION[3]:                        dhcp-4-opt-2 = val-2
+DHCP4.OPTION[4]:                        dhcp-4-opt-4 = val-4
+DHCP4.OPTION[5]:                        dhcp-4-opt-6 = val-6
+DHCP4.OPTION[6]:                        dhcp-4-opt-7 = val-7
+DHCP4.OPTION[7]:                        dhcp-4-opt-8 = val-8
+DHCP4.OPTION[8]:                        dhcp-4-opt-9 = val-9
+-------------------------------------------------------------------------------
+IP6.ADDRESS[1]:                         2001:a::fa05:2ab4:9300:e8fe/116
+IP6.ADDRESS[2]:                         2001:a::e9cf:bd3:caba:99b3/86
+IP6.ADDRESS[3]:                         2001:a::2be6:44fa:2c95:5559/78
+IP6.GATEWAY:                            2001:a::4d70:d91a:770f:2319
+IP6.ROUTE[1]:                           dst = 2001:a::3cb2:719d:bb00:b22f/66, nh = 2001:a::81b1:58b9:7237:3511, mt = 2280277732
+IP6.ROUTE[2]:                           dst = 2001:a::986f:983c:5eb:1c7d/99, nh = ::, mt = 1204008676
+IP6.DNS[1]:                             2001:a::85e7:3d7d:53e8:50ac
+IP6.DNS[2]:                             2001:a::1c5:9cb5:e86d:25a5
+IP6.DOMAIN[1]:                          sear6.foo4.bar
+IP6.DOMAIN[2]:                          sear6.foo2.bar
+-------------------------------------------------------------------------------
+DHCP6.OPTION[1]:                        dhcp-6-opt-0 = val-0
+DHCP6.OPTION[2]:                        dhcp-6-opt-1 = val-1
+DHCP6.OPTION[3]:                        dhcp-6-opt-2 = val-2
+DHCP6.OPTION[4]:                        dhcp-6-opt-3 = val-3
+DHCP6.OPTION[5]:                        dhcp-6-opt-4 = val-4
+DHCP6.OPTION[6]:                        dhcp-6-opt-5 = val-5
+DHCP6.OPTION[7]:                        dhcp-6-opt-6 = val-6
+DHCP6.OPTION[8]:                        dhcp-6-opt-7 = val-7
+DHCP6.OPTION[9]:                        dhcp-6-opt-9 = val-9
+-------------------------------------------------------------------------------
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
+-------------------------------------------------------------------------------
+
+===============================================================================
+                            Device details (wlan1)
+===============================================================================
+GENERAL.DEVICE:                         wlan1
+GENERAL.TYPE:                           wifi
+GENERAL.NM-TYPE:                        NMDeviceWifi
+GENERAL.VENDOR:                         --
+GENERAL.PRODUCT:                        --
+GENERAL.DRIVER:                         virtual
+GENERAL.DRIVER-VERSION:                 --
+GENERAL.FIRMWARE-VERSION:               --
+GENERAL.HWADDR:                         71:52:AD:63:5C:7C
+GENERAL.MTU:                            0
+GENERAL.STATE:                          20 (unavailable)
+GENERAL.REASON:                         0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:               0 (unknown)
+GENERAL.IP6-CONNECTIVITY:               0 (unknown)
+GENERAL.UDI:                            /sys/devices/virtual/wlan1
+GENERAL.IP-IFACE:                       --
+GENERAL.IS-SOFTWARE:                    no
+GENERAL.NM-MANAGED:                     yes
+GENERAL.AUTOCONNECT:                    yes
+GENERAL.FIRMWARE-MISSING:               no
+GENERAL.NM-PLUGIN-MISSING:              no
+GENERAL.PHYS-PORT-ID:                   --
+GENERAL.CONNECTION:                     --
+GENERAL.CON-UUID:                       --
+GENERAL.CON-PATH:                       --
+GENERAL.METERED:                        unknown
+-------------------------------------------------------------------------------
+CAPABILITIES.CARRIER-DETECT:            no
+CAPABILITIES.SPEED:                     unknown
+CAPABILITIES.IS-SOFTWARE:               no
+CAPABILITIES.SRIOV:                     no
+-------------------------------------------------------------------------------
+WIFI-PROPERTIES.WEP:                    yes
+WIFI-PROPERTIES.WPA:                    yes
+WIFI-PROPERTIES.WPA2:                   yes
+WIFI-PROPERTIES.TKIP:                   yes
+WIFI-PROPERTIES.CCMP:                   yes
+WIFI-PROPERTIES.AP:                     yes
+WIFI-PROPERTIES.ADHOC:                  yes
+WIFI-PROPERTIES.2GHZ:                   unknown
+WIFI-PROPERTIES.5GHZ:                   unknown
+-------------------------------------------------------------------------------
+IP4.ADDRESS[1]:                         192.168.97.124/29
+IP4.ADDRESS[2]:                         192.168.76.154/18
+IP4.GATEWAY:                            --
+IP4.ROUTE[1]:                           dst = 192.168.33.233/22, nh = 192.168.222.210, mt = 2810496551
+IP4.DNS[1]:                             192.168.107.109
+IP4.DOMAIN[1]:                          sear4.fo.o.bar
+IP4.DOMAIN[2]:                          sear4.fo.x.y
+IP4.DOMAIN[3]:                          sear4.foo2.bar
+IP4.DOMAIN[4]:                          sear4.foo3.bar
+IP4.DOMAIN[5]:                          sear4.foo4.bar
+IP4.WINS[1]:                            192.168.60.60
+IP4.WINS[2]:                            192.168.63.92
+-------------------------------------------------------------------------------
+DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:                        dhcp-4-opt-5 = val-5
+-------------------------------------------------------------------------------
+IP6.ADDRESS[1]:                         2001:a::88ca:3654:96b:ab44/89
+IP6.GATEWAY:                            --
+IP6.ROUTE[1]:                           dst = 2001:a::cc8b:7c09:4673:bbb0/85, nh = ::, mt = 2821465568
+IP6.ROUTE[2]:                           dst = 2001:a::a976:2488:f49f:b48/106, nh = 2001:a::62ae:c734:fc7b:e931, mt = 2248613879
+IP6.ROUTE[3]:                           dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::
+IP6.DNS[1]:                             2001:a::2934:bd66:550d:ec19
+IP6.DOMAIN[1]:                          sear6.fo.x.y
+-------------------------------------------------------------------------------
+DHCP6.OPTION[1]:                        dhcp-6-opt-2 = val-2
+DHCP6.OPTION[2]:                        dhcp-6-opt-6 = val-6
+DHCP6.OPTION[3]:                        dhcp-6-opt-7 = val-7
+DHCP6.OPTION[4]:                        dhcp-6-opt-8 = val-8
+DHCP6.OPTION[5]:                        dhcp-6-opt-9 = val-9
+-------------------------------------------------------------------------------
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
+-------------------------------------------------------------------------------
+
 <<<
 size: 25438
 location: clients/tests/test-client.py:1050:test_004()/132
@@ -8175,6 +8199,112 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 25281 bytes
 >>>
+===============================================================================
+                        Informacje o urządzeniu (wlan0)
+===============================================================================
+GENERAL.DEVICE:                         wlan0
+GENERAL.TYPE:                           wifi
+GENERAL.NM-TYPE:                        NMDeviceWifi
+GENERAL.VENDOR:                         --
+GENERAL.PRODUCT:                        --
+GENERAL.DRIVER:                         virtual
+GENERAL.DRIVER-VERSION:                 --
+GENERAL.FIRMWARE-VERSION:               --
+GENERAL.HWADDR:                         13:E0:74:85:7C:D9
+GENERAL.MTU:                            0
+GENERAL.STATE:                          20 (niedostępne)
+GENERAL.REASON:                         0 (Nie podano przyczyny)
+GENERAL.IP4-CONNECTIVITY:               0 (nieznane)
+GENERAL.IP6-CONNECTIVITY:               0 (nieznane)
+GENERAL.UDI:                            /sys/devices/virtual/wlan0
+GENERAL.IP-IFACE:                       --
+GENERAL.IS-SOFTWARE:                    nie
+GENERAL.NM-MANAGED:                     tak
+GENERAL.AUTOCONNECT:                    tak
+GENERAL.FIRMWARE-MISSING:               nie
+GENERAL.NM-PLUGIN-MISSING:              nie
+GENERAL.PHYS-PORT-ID:                   --
+GENERAL.CONNECTION:                     con-vpn-1
+GENERAL.CON-UUID:                       UUID-con-vpn-1-REPLACED-REPLACED-REP
+GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
+GENERAL.METERED:                        nieznane
+-------------------------------------------------------------------------------
+CAPABILITIES.CARRIER-DETECT:            nie
+CAPABILITIES.SPEED:                     nieznane
+CAPABILITIES.IS-SOFTWARE:               nie
+CAPABILITIES.SRIOV:                     nie
+-------------------------------------------------------------------------------
+WIFI-PROPERTIES.WEP:                    tak
+WIFI-PROPERTIES.WPA:                    tak
+WIFI-PROPERTIES.WPA2:                   tak
+WIFI-PROPERTIES.TKIP:                   tak
+WIFI-PROPERTIES.CCMP:                   tak
+WIFI-PROPERTIES.AP:                     tak
+WIFI-PROPERTIES.ADHOC:                  tak
+WIFI-PROPERTIES.2GHZ:                   nieznane
+WIFI-PROPERTIES.5GHZ:                   nieznane
+-------------------------------------------------------------------------------
+AP[1].IN-USE:                            
+AP[1].SSID:                             wlan0-ap-2
+AP[1].MODE:                             Infrastruktura
+AP[1].CHAN:                             1
+AP[1].RATE:                             54 Mb/s
+AP[1].SIGNAL:                           92
+AP[1].BARS:                             ****
+AP[1].SECURITY:                         WPA1 WPA2
+-------------------------------------------------------------------------------
+AP[2].IN-USE:                            
+AP[2].SSID:                             wlan0-ap-1
+AP[2].MODE:                             Infrastruktura
+AP[2].CHAN:                             1
+AP[2].RATE:                             54 Mb/s
+AP[2].SIGNAL:                           81
+AP[2].BARS:                             ****
+AP[2].SECURITY:                         WPA1 WPA2
+-------------------------------------------------------------------------------
+AP[3].IN-USE:                            
+AP[3].SSID:                             wlan0-ap-3
+AP[3].MODE:                             Infrastruktura
+AP[3].CHAN:                             1
+AP[3].RATE:                             54 Mb/s
+AP[3].SIGNAL:                           55
+AP[3].BARS:                             **  
+AP[3].SECURITY:                         WPA1 WPA2
+-------------------------------------------------------------------------------
+IP4.ADDRESS[1]:                         192.168.228.18/32
+IP4.ADDRESS[2]:                         192.168.209.179/25
+IP4.GATEWAY:                            192.168.41.120
+IP4.DOMAIN[1]:                          sear4.foo2.bar
+IP4.DOMAIN[2]:                          sear4.fo.x.y
+IP4.DOMAIN[3]:                          sear4.foo1.bar
+IP4.DOMAIN[4]:                          sear4.foo4.bar
+IP4.DOMAIN[5]:                          sear4.fo.o.bar
+IP4.WINS[1]:                            192.168.120.79
+-------------------------------------------------------------------------------
+DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:                        dhcp-4-opt-2 = val-2
+DHCP4.OPTION[3]:                        dhcp-4-opt-4 = val-4
+DHCP4.OPTION[4]:                        dhcp-4-opt-7 = val-7
+-------------------------------------------------------------------------------
+IP6.GATEWAY:                            --
+IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
+IP6.DOMAIN[1]:                          sear6.foo2.bar
+IP6.DOMAIN[2]:                          sear6.foo1.bar
+IP6.DOMAIN[3]:                          sear6.fo.x.y
+IP6.DOMAIN[4]:                          sear6.fo.o.bar
+IP6.DOMAIN[5]:                          sear6.foo3.bar
+IP6.DOMAIN[6]:                          sear6.foo4.bar
+-------------------------------------------------------------------------------
+DHCP6.OPTION[1]:                        dhcp-6-opt-1 = val-1
+DHCP6.OPTION[2]:                        dhcp-6-opt-2 = val-2
+DHCP6.OPTION[3]:                        dhcp-6-opt-3 = val-3
+DHCP6.OPTION[4]:                        dhcp-6-opt-4 = val-4
+DHCP6.OPTION[5]:                        dhcp-6-opt-5 = val-5
+-------------------------------------------------------------------------------
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
+-------------------------------------------------------------------------------
+
 ===============================================================================
                         Informacje o urządzeniu (eth0)
 ===============================================================================
@@ -8504,112 +8634,6 @@ DHCP6.OPTION[2]:                        dhcp-6-opt-6 = val-6
 DHCP6.OPTION[3]:                        dhcp-6-opt-7 = val-7
 DHCP6.OPTION[4]:                        dhcp-6-opt-8 = val-8
 DHCP6.OPTION[5]:                        dhcp-6-opt-9 = val-9
--------------------------------------------------------------------------------
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
--------------------------------------------------------------------------------
-
-===============================================================================
-                        Informacje o urządzeniu (wlan0)
-===============================================================================
-GENERAL.DEVICE:                         wlan0
-GENERAL.TYPE:                           wifi
-GENERAL.NM-TYPE:                        NMDeviceWifi
-GENERAL.VENDOR:                         --
-GENERAL.PRODUCT:                        --
-GENERAL.DRIVER:                         virtual
-GENERAL.DRIVER-VERSION:                 --
-GENERAL.FIRMWARE-VERSION:               --
-GENERAL.HWADDR:                         13:E0:74:85:7C:D9
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (niedostępne)
-GENERAL.REASON:                         0 (Nie podano przyczyny)
-GENERAL.IP4-CONNECTIVITY:               0 (nieznane)
-GENERAL.IP6-CONNECTIVITY:               0 (nieznane)
-GENERAL.UDI:                            /sys/devices/virtual/wlan0
-GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    nie
-GENERAL.NM-MANAGED:                     tak
-GENERAL.AUTOCONNECT:                    tak
-GENERAL.FIRMWARE-MISSING:               nie
-GENERAL.NM-PLUGIN-MISSING:              nie
-GENERAL.PHYS-PORT-ID:                   --
-GENERAL.CONNECTION:                     con-vpn-1
-GENERAL.CON-UUID:                       UUID-con-vpn-1-REPLACED-REPLACED-REP
-GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
-GENERAL.METERED:                        nieznane
--------------------------------------------------------------------------------
-CAPABILITIES.CARRIER-DETECT:            nie
-CAPABILITIES.SPEED:                     nieznane
-CAPABILITIES.IS-SOFTWARE:               nie
-CAPABILITIES.SRIOV:                     nie
--------------------------------------------------------------------------------
-WIFI-PROPERTIES.WEP:                    tak
-WIFI-PROPERTIES.WPA:                    tak
-WIFI-PROPERTIES.WPA2:                   tak
-WIFI-PROPERTIES.TKIP:                   tak
-WIFI-PROPERTIES.CCMP:                   tak
-WIFI-PROPERTIES.AP:                     tak
-WIFI-PROPERTIES.ADHOC:                  tak
-WIFI-PROPERTIES.2GHZ:                   nieznane
-WIFI-PROPERTIES.5GHZ:                   nieznane
--------------------------------------------------------------------------------
-AP[1].IN-USE:                            
-AP[1].SSID:                             wlan0-ap-2
-AP[1].MODE:                             Infrastruktura
-AP[1].CHAN:                             1
-AP[1].RATE:                             54 Mb/s
-AP[1].SIGNAL:                           92
-AP[1].BARS:                             ****
-AP[1].SECURITY:                         WPA1 WPA2
--------------------------------------------------------------------------------
-AP[2].IN-USE:                            
-AP[2].SSID:                             wlan0-ap-1
-AP[2].MODE:                             Infrastruktura
-AP[2].CHAN:                             1
-AP[2].RATE:                             54 Mb/s
-AP[2].SIGNAL:                           81
-AP[2].BARS:                             ****
-AP[2].SECURITY:                         WPA1 WPA2
--------------------------------------------------------------------------------
-AP[3].IN-USE:                            
-AP[3].SSID:                             wlan0-ap-3
-AP[3].MODE:                             Infrastruktura
-AP[3].CHAN:                             1
-AP[3].RATE:                             54 Mb/s
-AP[3].SIGNAL:                           55
-AP[3].BARS:                             **  
-AP[3].SECURITY:                         WPA1 WPA2
--------------------------------------------------------------------------------
-IP4.ADDRESS[1]:                         192.168.228.18/32
-IP4.ADDRESS[2]:                         192.168.209.179/25
-IP4.GATEWAY:                            192.168.41.120
-IP4.DOMAIN[1]:                          sear4.foo2.bar
-IP4.DOMAIN[2]:                          sear4.fo.x.y
-IP4.DOMAIN[3]:                          sear4.foo1.bar
-IP4.DOMAIN[4]:                          sear4.foo4.bar
-IP4.DOMAIN[5]:                          sear4.fo.o.bar
-IP4.WINS[1]:                            192.168.120.79
--------------------------------------------------------------------------------
-DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:                        dhcp-4-opt-2 = val-2
-DHCP4.OPTION[3]:                        dhcp-4-opt-4 = val-4
-DHCP4.OPTION[4]:                        dhcp-4-opt-7 = val-7
--------------------------------------------------------------------------------
-IP6.GATEWAY:                            --
-IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
-IP6.DOMAIN[1]:                          sear6.foo2.bar
-IP6.DOMAIN[2]:                          sear6.foo1.bar
-IP6.DOMAIN[3]:                          sear6.fo.x.y
-IP6.DOMAIN[4]:                          sear6.fo.o.bar
-IP6.DOMAIN[5]:                          sear6.foo3.bar
-IP6.DOMAIN[6]:                          sear6.foo4.bar
--------------------------------------------------------------------------------
-DHCP6.OPTION[1]:                        dhcp-6-opt-1 = val-1
-DHCP6.OPTION[2]:                        dhcp-6-opt-2 = val-2
-DHCP6.OPTION[3]:                        dhcp-6-opt-3 = val-3
-DHCP6.OPTION[4]:                        dhcp-6-opt-4 = val-4
-DHCP6.OPTION[5]:                        dhcp-6-opt-5 = val-5
 -------------------------------------------------------------------------------
 CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
@@ -9150,11 +9174,11 @@ stdout: 513 bytes
 =====================
 DEVICE  TYPE      DBUS-PATH                                 
 ----------------------------------------------------------------------------------
+wlan0   wifi      /org/freedesktop/NetworkManager/Devices/3 
 eth0    ethernet  /org/freedesktop/NetworkManager/Devices/1 
 eth1    ethernet  /org/freedesktop/NetworkManager/Devices/2 
 wlan1   wifi      /org/freedesktop/NetworkManager/Devices/4 
 wlan1   wifi      /org/freedesktop/NetworkManager/Devices/5 
-wlan0   wifi      /org/freedesktop/NetworkManager/Devices/3 
 
 <<<
 size: 674
@@ -9169,11 +9193,11 @@ stdout: 506 bytes
 ===================
 DEVICE  TYPE      DBUS-PATH                                 
 --------------------------------------------------------------------------------
+wlan0   wifi      /org/freedesktop/NetworkManager/Devices/3 
 eth0    ethernet  /org/freedesktop/NetworkManager/Devices/1 
 eth1    ethernet  /org/freedesktop/NetworkManager/Devices/2 
 wlan1   wifi      /org/freedesktop/NetworkManager/Devices/4 
 wlan1   wifi      /org/freedesktop/NetworkManager/Devices/5 
-wlan0   wifi      /org/freedesktop/NetworkManager/Devices/3 
 
 <<<
 size: 3026
@@ -9183,6 +9207,15 @@ lang: C
 returncode: 0
 stdout: 2872 bytes
 >>>
+===========================
+  Wi-Fi scan list (wlan0)
+===========================
+NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infra  1     2412 MHz  54 Mbit/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/2 
+AP[2]  wlan0-ap-1  776C616E302D61702D31  61:95:77:AC:1E:4C  Infra  1     2412 MHz  54 Mbit/s  81      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/1 
+AP[3]  wlan0-ap-3  776C616E302D61702D33  9B:F6:B7:EC:97:76  Infra  1     2412 MHz  54 Mbit/s  55      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/3 
+
 ===========================
   Wi-Fi scan list (wlan1)
 ===========================
@@ -9196,15 +9229,6 @@ AP[1]  wlan1-ap-4  776C616E312D61702D34  94:2B:E8:F6:D2:86  Infra  1     2412 MH
 NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-===========================
-  Wi-Fi scan list (wlan0)
-===========================
-NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infra  1     2412 MHz  54 Mbit/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/2 
-AP[2]  wlan0-ap-1  776C616E302D61702D31  61:95:77:AC:1E:4C  Infra  1     2412 MHz  54 Mbit/s  81      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/1 
-AP[3]  wlan0-ap-3  776C616E302D61702D33  9B:F6:B7:EC:97:76  Infra  1     2412 MHz  54 Mbit/s  55      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/3 
-
 <<<
 size: 3264
 location: clients/tests/test-client.py:1068:test_004()/144
@@ -9213,6 +9237,15 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 3100 bytes
 >>>
+========================================
+  Lista skanowania sieci Wi-Fi (wlan0)
+========================================
+NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infrastruktura  1     2412 MHz  54 Mb/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/2 
+AP[2]  wlan0-ap-1  776C616E302D61702D31  61:95:77:AC:1E:4C  Infrastruktura  1     2412 MHz  54 Mb/s  81      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/1 
+AP[3]  wlan0-ap-3  776C616E302D61702D33  9B:F6:B7:EC:97:76  Infrastruktura  1     2412 MHz  54 Mb/s  55      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/3 
+
 ========================================
   Lista skanowania sieci Wi-Fi (wlan1)
 ========================================
@@ -9226,15 +9259,6 @@ AP[1]  wlan1-ap-4  776C616E312D61702D34  94:2B:E8:F6:D2:86  Infrastruktura  1   
 NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-========================================
-  Lista skanowania sieci Wi-Fi (wlan0)
-========================================
-NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infrastruktura  1     2412 MHz  54 Mb/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/2 
-AP[2]  wlan0-ap-1  776C616E302D61702D31  61:95:77:AC:1E:4C  Infrastruktura  1     2412 MHz  54 Mb/s  81      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/1 
-AP[3]  wlan0-ap-3  776C616E302D61702D33  9B:F6:B7:EC:97:76  Infrastruktura  1     2412 MHz  54 Mb/s  55      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/3 
-
 <<<
 size: 1152
 location: clients/tests/test-client.py:1070:test_004()/145
@@ -9243,6 +9267,15 @@ lang: C
 returncode: 0
 stdout: 996 bytes
 >>>
+===========================
+  Wi-Fi scan list (wlan0)
+===========================
+IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
+------------------------------------------------------------------------------------------------
+        wlan0-ap-2  Infra  1     54 Mbit/s  92      ****  WPA1 WPA2 
+        wlan0-ap-1  Infra  1     54 Mbit/s  81      ****  WPA1 WPA2 
+        wlan0-ap-3  Infra  1     54 Mbit/s  55      **    WPA1 WPA2 
+
 ===========================
   Wi-Fi scan list (wlan1)
 ===========================
@@ -9256,15 +9289,6 @@ IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY
 IN-USE  SSID  MODE  CHAN  RATE  SIGNAL  BARS  SECURITY 
 -----------------------------------------------------------------------------------
 
-===========================
-  Wi-Fi scan list (wlan0)
-===========================
-IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
-------------------------------------------------------------------------------------------------
-        wlan0-ap-2  Infra  1     54 Mbit/s  92      ****  WPA1 WPA2 
-        wlan0-ap-1  Infra  1     54 Mbit/s  81      ****  WPA1 WPA2 
-        wlan0-ap-3  Infra  1     54 Mbit/s  55      **    WPA1 WPA2 
-
 <<<
 size: 1383
 location: clients/tests/test-client.py:1070:test_004()/146
@@ -9273,6 +9297,15 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 1216 bytes
 >>>
+========================================
+  Lista skanowania sieci Wi-Fi (wlan0)
+========================================
+IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
+--------------------------------------------------------------------------------------------------------------------
+        wlan0-ap-2  Infrastruktura  1     54 Mb/s  92      ****  WPA1 WPA2 
+        wlan0-ap-1  Infrastruktura  1     54 Mb/s  81      ****  WPA1 WPA2 
+        wlan0-ap-3  Infrastruktura  1     54 Mb/s  55      **    WPA1 WPA2 
+
 ========================================
   Lista skanowania sieci Wi-Fi (wlan1)
 ========================================
@@ -9286,15 +9319,6 @@ IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY
 IN-USE  SSID  MODE  CHAN  RATE  SIGNAL  BARS  SECURITY 
 ------------------------------------------------------------------------------------------------
 
-========================================
-  Lista skanowania sieci Wi-Fi (wlan0)
-========================================
-IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
---------------------------------------------------------------------------------------------------------------------
-        wlan0-ap-2  Infrastruktura  1     54 Mb/s  92      ****  WPA1 WPA2 
-        wlan0-ap-1  Infrastruktura  1     54 Mb/s  81      ****  WPA1 WPA2 
-        wlan0-ap-3  Infrastruktura  1     54 Mb/s  55      **    WPA1 WPA2 
-
 <<<
 size: 3139
 location: clients/tests/test-client.py:1073:test_004()/147
@@ -9303,6 +9327,15 @@ lang: C
 returncode: 0
 stdout: 2872 bytes
 >>>
+===========================
+  Wi-Fi scan list (wlan0)
+===========================
+NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infra  1     2412 MHz  54 Mbit/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/2 
+AP[2]  wlan0-ap-1  776C616E302D61702D31  61:95:77:AC:1E:4C  Infra  1     2412 MHz  54 Mbit/s  81      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/1 
+AP[3]  wlan0-ap-3  776C616E302D61702D33  9B:F6:B7:EC:97:76  Infra  1     2412 MHz  54 Mbit/s  55      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/3 
+
 ===========================
   Wi-Fi scan list (wlan1)
 ===========================
@@ -9316,15 +9349,6 @@ AP[1]  wlan1-ap-4  776C616E312D61702D34  94:2B:E8:F6:D2:86  Infra  1     2412 MH
 NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-===========================
-  Wi-Fi scan list (wlan0)
-===========================
-NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infra  1     2412 MHz  54 Mbit/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/2 
-AP[2]  wlan0-ap-1  776C616E302D61702D31  61:95:77:AC:1E:4C  Infra  1     2412 MHz  54 Mbit/s  81      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/1 
-AP[3]  wlan0-ap-3  776C616E302D61702D33  9B:F6:B7:EC:97:76  Infra  1     2412 MHz  54 Mbit/s  55      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/3 
-
 <<<
 size: 3377
 location: clients/tests/test-client.py:1073:test_004()/148
@@ -9333,6 +9357,15 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 3100 bytes
 >>>
+========================================
+  Lista skanowania sieci Wi-Fi (wlan0)
+========================================
+NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infrastruktura  1     2412 MHz  54 Mb/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/2 
+AP[2]  wlan0-ap-1  776C616E302D61702D31  61:95:77:AC:1E:4C  Infrastruktura  1     2412 MHz  54 Mb/s  81      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/1 
+AP[3]  wlan0-ap-3  776C616E302D61702D33  9B:F6:B7:EC:97:76  Infrastruktura  1     2412 MHz  54 Mb/s  55      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/3 
+
 ========================================
   Lista skanowania sieci Wi-Fi (wlan1)
 ========================================
@@ -9346,22 +9379,13 @@ AP[1]  wlan1-ap-4  776C616E312D61702D34  94:2B:E8:F6:D2:86  Infrastruktura  1   
 NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-========================================
-  Lista skanowania sieci Wi-Fi (wlan0)
-========================================
-NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infrastruktura  1     2412 MHz  54 Mb/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/2 
-AP[2]  wlan0-ap-1  776C616E302D61702D31  61:95:77:AC:1E:4C  Infrastruktura  1     2412 MHz  54 Mb/s  81      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/1 
-AP[3]  wlan0-ap-3  776C616E302D61702D33  9B:F6:B7:EC:97:76  Infrastruktura  1     2412 MHz  54 Mb/s  55      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/3 
-
 <<<
-size: 1139
+size: 1141
 location: clients/tests/test-client.py:1075:test_004()/149
 cmd: $NMCLI --pretty -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 962 bytes
+stdout: 964 bytes
 >>>
 ===========================
   Wi-Fi scan list (wlan0)
@@ -9370,13 +9394,15 @@ NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ   
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infra  1     2412 MHz  54 Mbit/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/2 
 
+
+
 <<<
-size: 1227
+size: 1229
 location: clients/tests/test-client.py:1075:test_004()/150
 cmd: $NMCLI --pretty -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 1039 bytes
+stdout: 1041 bytes
 >>>
 ========================================
   Lista skanowania sieci Wi-Fi (wlan0)
@@ -9385,13 +9411,15 @@ NAME   SSID        SSID-HEX              BSSID              MODE            CHAN
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infrastruktura  1     2412 MHz  54 Mb/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/2 
 
+
+
 <<<
-size: 497
+size: 499
 location: clients/tests/test-client.py:1077:test_004()/151
 cmd: $NMCLI --pretty -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 317 bytes
+stdout: 319 bytes
 >>>
 ===========================
   Wi-Fi scan list (wlan0)
@@ -9400,13 +9428,15 @@ IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY
 ------------------------------------------------------------------------------------------------
         wlan0-ap-2  Infra  1     54 Mbit/s  92      ****  WPA1 WPA2 
 
+
+
 <<<
-size: 582
+size: 584
 location: clients/tests/test-client.py:1077:test_004()/152
 cmd: $NMCLI --pretty -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 392 bytes
+stdout: 394 bytes
 >>>
 ========================================
   Lista skanowania sieci Wi-Fi (wlan0)
@@ -9415,13 +9445,15 @@ IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY
 --------------------------------------------------------------------------------------------------------------------
         wlan0-ap-2  Infrastruktura  1     54 Mb/s  92      ****  WPA1 WPA2 
 
+
+
 <<<
-size: 1252
+size: 1254
 location: clients/tests/test-client.py:1080:test_004()/153
 cmd: $NMCLI --pretty -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 962 bytes
+stdout: 964 bytes
 >>>
 ===========================
   Wi-Fi scan list (wlan0)
@@ -9430,13 +9462,15 @@ NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ   
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infra  1     2412 MHz  54 Mbit/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/2 
 
+
+
 <<<
-size: 1340
+size: 1342
 location: clients/tests/test-client.py:1080:test_004()/154
 cmd: $NMCLI --pretty -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 1039 bytes
+stdout: 1041 bytes
 >>>
 ========================================
   Lista skanowania sieci Wi-Fi (wlan0)
@@ -9444,6 +9478,8 @@ stdout: 1039 bytes
 NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infrastruktura  1     2412 MHz  54 Mb/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/2 
+
+
 
 <<<
 size: 5961
@@ -10732,11 +10768,11 @@ stdout: 547 bytes
 =====================
 DEVICE  TYPE      STATE        CONNECTION 
 ----------------------------------------------------------------
+[2mwlan0[0m   [2mwifi[0m      [2munavailable[0m  [2mcon-vpn-1[0m  
 [2meth0[0m    [2methernet[0m  [2munavailable[0m  [2m--[0m         
 [2meth1[0m    [2methernet[0m  [2munavailable[0m  [2m--[0m         
 [2mwlan1[0m   [2mwifi[0m      [2munavailable[0m  [2m--[0m         
 [2mwlan1[0m   [2mwifi[0m      [2munavailable[0m  [2m--[0m         
-[2mwlan0[0m   [2mwifi[0m      [2munavailable[0m  [2mcon-vpn-1[0m  
 
 <<<
 size: 702
@@ -10751,11 +10787,11 @@ stdout: 545 bytes
 ===================
 DEVICE  TYPE      STATE        CONNECTION 
 --------------------------------------------------------------
+[2mwlan0[0m   [2mwifi[0m      [2mniedostępne[0m  [2mcon-vpn-1[0m  
 [2meth0[0m    [2methernet[0m  [2mniedostępne[0m  [2m--[0m         
 [2meth1[0m    [2methernet[0m  [2mniedostępne[0m  [2m--[0m         
 [2mwlan1[0m   [2mwifi[0m      [2mniedostępne[0m  [2m--[0m         
 [2mwlan1[0m   [2mwifi[0m      [2mniedostępne[0m  [2m--[0m         
-[2mwlan0[0m   [2mwifi[0m      [2mniedostępne[0m  [2mcon-vpn-1[0m  
 
 <<<
 size: 2090
@@ -10770,11 +10806,11 @@ stdout: 1930 bytes
 =====================
 DEVICE  TYPE      STATE        IP4-CONNECTIVITY  IP6-CONNECTIVITY  DBUS-PATH                                  CONNECTION  CON-UUID                              CON-PATH                                           
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+[2mwlan0[0m   [2mwifi[0m      [2munavailable[0m  [2munknown[0m           [2munknown[0m           [2m/org/freedesktop/NetworkManager/Devices/3[0m  [2mcon-vpn-1[0m   [2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m  [2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m 
 [2meth0[0m    [2methernet[0m  [2munavailable[0m  [2munknown[0m           [2munknown[0m           [2m/org/freedesktop/NetworkManager/Devices/1[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
 [2meth1[0m    [2methernet[0m  [2munavailable[0m  [2munknown[0m           [2munknown[0m           [2m/org/freedesktop/NetworkManager/Devices/2[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
 [2mwlan1[0m   [2mwifi[0m      [2munavailable[0m  [2munknown[0m           [2munknown[0m           [2m/org/freedesktop/NetworkManager/Devices/4[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
 [2mwlan1[0m   [2mwifi[0m      [2munavailable[0m  [2munknown[0m           [2munknown[0m           [2m/org/freedesktop/NetworkManager/Devices/5[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
-[2mwlan0[0m   [2mwifi[0m      [2munavailable[0m  [2munknown[0m           [2munknown[0m           [2m/org/freedesktop/NetworkManager/Devices/3[0m  [2mcon-vpn-1[0m   [2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m  [2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m 
 
 <<<
 size: 2098
@@ -10789,11 +10825,11 @@ stdout: 1928 bytes
 ===================
 DEVICE  TYPE      STATE        IP4-CONNECTIVITY  IP6-CONNECTIVITY  DBUS-PATH                                  CONNECTION  CON-UUID                              CON-PATH                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+[2mwlan0[0m   [2mwifi[0m      [2mniedostępne[0m  [2mnieznane[0m          [2mnieznane[0m          [2m/org/freedesktop/NetworkManager/Devices/3[0m  [2mcon-vpn-1[0m   [2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m  [2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m 
 [2meth0[0m    [2methernet[0m  [2mniedostępne[0m  [2mnieznane[0m          [2mnieznane[0m          [2m/org/freedesktop/NetworkManager/Devices/1[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
 [2meth1[0m    [2methernet[0m  [2mniedostępne[0m  [2mnieznane[0m          [2mnieznane[0m          [2m/org/freedesktop/NetworkManager/Devices/2[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
 [2mwlan1[0m   [2mwifi[0m      [2mniedostępne[0m  [2mnieznane[0m          [2mnieznane[0m          [2m/org/freedesktop/NetworkManager/Devices/4[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
 [2mwlan1[0m   [2mwifi[0m      [2mniedostępne[0m  [2mnieznane[0m          [2mnieznane[0m          [2m/org/freedesktop/NetworkManager/Devices/5[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
-[2mwlan0[0m   [2mwifi[0m      [2mniedostępne[0m  [2mnieznane[0m          [2mnieznane[0m          [2m/org/freedesktop/NetworkManager/Devices/3[0m  [2mcon-vpn-1[0m   [2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m  [2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m 
 
 <<<
 size: 12885
@@ -10803,6 +10839,43 @@ lang: C
 returncode: 0
 stdout: 12733 bytes
 >>>
+===============================================================================
+                            Device details (wlan0)
+===============================================================================
+GENERAL.DEVICE:                         wlan0
+-------------------------------------------------------------------------------
+GENERAL.TYPE:                           wifi
+-------------------------------------------------------------------------------
+GENERAL.HWADDR:                         13:E0:74:85:7C:D9
+-------------------------------------------------------------------------------
+GENERAL.MTU:                            0
+-------------------------------------------------------------------------------
+GENERAL.STATE:                          20 (unavailable)
+-------------------------------------------------------------------------------
+GENERAL.CONNECTION:                     con-vpn-1
+-------------------------------------------------------------------------------
+GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
+-------------------------------------------------------------------------------
+IP4.ADDRESS[1]:                         192.168.228.18/32
+IP4.ADDRESS[2]:                         192.168.209.179/25
+IP4.GATEWAY:                            192.168.41.120
+IP4.DOMAIN[1]:                          sear4.foo2.bar
+IP4.DOMAIN[2]:                          sear4.fo.x.y
+IP4.DOMAIN[3]:                          sear4.foo1.bar
+IP4.DOMAIN[4]:                          sear4.foo4.bar
+IP4.DOMAIN[5]:                          sear4.fo.o.bar
+IP4.WINS[1]:                            192.168.120.79
+-------------------------------------------------------------------------------
+IP6.GATEWAY:                            --
+IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
+IP6.DOMAIN[1]:                          sear6.foo2.bar
+IP6.DOMAIN[2]:                          sear6.foo1.bar
+IP6.DOMAIN[3]:                          sear6.fo.x.y
+IP6.DOMAIN[4]:                          sear6.fo.o.bar
+IP6.DOMAIN[5]:                          sear6.foo3.bar
+IP6.DOMAIN[6]:                          sear6.foo4.bar
+-------------------------------------------------------------------------------
+
 ===============================================================================
                              Device details (eth0)
 ===============================================================================
@@ -10966,8 +11039,16 @@ IP6.DNS[1]:                             2001:a::2934:bd66:550d:ec19
 IP6.DOMAIN[1]:                          sear6.fo.x.y
 -------------------------------------------------------------------------------
 
+<<<
+size: 12949
+location: clients/tests/test-client.py:1047:test_004()/176
+cmd: $NMCLI --pretty --color yes dev show
+lang: pl_PL.UTF-8
+returncode: 0
+stdout: 12787 bytes
+>>>
 ===============================================================================
-                            Device details (wlan0)
+                        Informacje o urządzeniu (wlan0)
 ===============================================================================
 GENERAL.DEVICE:                         wlan0
 -------------------------------------------------------------------------------
@@ -10977,7 +11058,7 @@ GENERAL.HWADDR:                         13:E0:74:85:7C:D9
 -------------------------------------------------------------------------------
 GENERAL.MTU:                            0
 -------------------------------------------------------------------------------
-GENERAL.STATE:                          20 (unavailable)
+GENERAL.STATE:                          20 (niedostępne)
 -------------------------------------------------------------------------------
 GENERAL.CONNECTION:                     con-vpn-1
 -------------------------------------------------------------------------------
@@ -11003,14 +11084,6 @@ IP6.DOMAIN[5]:                          sear6.foo3.bar
 IP6.DOMAIN[6]:                          sear6.foo4.bar
 -------------------------------------------------------------------------------
 
-<<<
-size: 12949
-location: clients/tests/test-client.py:1047:test_004()/176
-cmd: $NMCLI --pretty --color yes dev show
-lang: pl_PL.UTF-8
-returncode: 0
-stdout: 12787 bytes
->>>
 ===============================================================================
                         Informacje o urządzeniu (eth0)
 ===============================================================================
@@ -11174,22 +11247,85 @@ IP6.DNS[1]:                             2001:a::2934:bd66:550d:ec19
 IP6.DOMAIN[1]:                          sear6.fo.x.y
 -------------------------------------------------------------------------------
 
+<<<
+size: 25555
+location: clients/tests/test-client.py:1050:test_004()/177
+cmd: $NMCLI --pretty --color yes -f all dev show
+lang: C
+returncode: 0
+stdout: 25396 bytes
+>>>
 ===============================================================================
-                        Informacje o urządzeniu (wlan0)
+                            Device details (wlan0)
 ===============================================================================
 GENERAL.DEVICE:                         wlan0
--------------------------------------------------------------------------------
 GENERAL.TYPE:                           wifi
--------------------------------------------------------------------------------
+GENERAL.NM-TYPE:                        NMDeviceWifi
+GENERAL.VENDOR:                         --
+GENERAL.PRODUCT:                        --
+GENERAL.DRIVER:                         virtual
+GENERAL.DRIVER-VERSION:                 --
+GENERAL.FIRMWARE-VERSION:               --
 GENERAL.HWADDR:                         13:E0:74:85:7C:D9
--------------------------------------------------------------------------------
 GENERAL.MTU:                            0
--------------------------------------------------------------------------------
-GENERAL.STATE:                          20 (niedostępne)
--------------------------------------------------------------------------------
+GENERAL.STATE:                          20 (unavailable)
+GENERAL.REASON:                         0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:               0 (unknown)
+GENERAL.IP6-CONNECTIVITY:               0 (unknown)
+GENERAL.UDI:                            /sys/devices/virtual/wlan0
+GENERAL.IP-IFACE:                       --
+GENERAL.IS-SOFTWARE:                    no
+GENERAL.NM-MANAGED:                     yes
+GENERAL.AUTOCONNECT:                    yes
+GENERAL.FIRMWARE-MISSING:               no
+GENERAL.NM-PLUGIN-MISSING:              no
+GENERAL.PHYS-PORT-ID:                   --
 GENERAL.CONNECTION:                     con-vpn-1
--------------------------------------------------------------------------------
+GENERAL.CON-UUID:                       UUID-con-vpn-1-REPLACED-REPLACED-REP
 GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
+GENERAL.METERED:                        unknown
+-------------------------------------------------------------------------------
+CAPABILITIES.CARRIER-DETECT:            no
+CAPABILITIES.SPEED:                     unknown
+CAPABILITIES.IS-SOFTWARE:               no
+CAPABILITIES.SRIOV:                     no
+-------------------------------------------------------------------------------
+WIFI-PROPERTIES.WEP:                    yes
+WIFI-PROPERTIES.WPA:                    yes
+WIFI-PROPERTIES.WPA2:                   yes
+WIFI-PROPERTIES.TKIP:                   yes
+WIFI-PROPERTIES.CCMP:                   yes
+WIFI-PROPERTIES.AP:                     yes
+WIFI-PROPERTIES.ADHOC:                  yes
+WIFI-PROPERTIES.2GHZ:                   unknown
+WIFI-PROPERTIES.5GHZ:                   unknown
+-------------------------------------------------------------------------------
+AP[1].IN-USE:                           [32m [0m
+AP[1].SSID:                             [32mwlan0-ap-2[0m
+AP[1].MODE:                             [32mInfra[0m
+AP[1].CHAN:                             [32m1[0m
+AP[1].RATE:                             [32m54 Mbit/s[0m
+AP[1].SIGNAL:                           [32m92[0m
+AP[1].BARS:                             [32m****[0m
+AP[1].SECURITY:                         [32mWPA1 WPA2[0m
+-------------------------------------------------------------------------------
+AP[2].IN-USE:                           [32m [0m
+AP[2].SSID:                             [32mwlan0-ap-1[0m
+AP[2].MODE:                             [32mInfra[0m
+AP[2].CHAN:                             [32m1[0m
+AP[2].RATE:                             [32m54 Mbit/s[0m
+AP[2].SIGNAL:                           [32m81[0m
+AP[2].BARS:                             [32m****[0m
+AP[2].SECURITY:                         [32mWPA1 WPA2[0m
+-------------------------------------------------------------------------------
+AP[3].IN-USE:                           [35m [0m
+AP[3].SSID:                             [35mwlan0-ap-3[0m
+AP[3].MODE:                             [35mInfra[0m
+AP[3].CHAN:                             [35m1[0m
+AP[3].RATE:                             [35m54 Mbit/s[0m
+AP[3].SIGNAL:                           [35m55[0m
+AP[3].BARS:                             [35m**  [0m
+AP[3].SECURITY:                         [35mWPA1 WPA2[0m
 -------------------------------------------------------------------------------
 IP4.ADDRESS[1]:                         192.168.228.18/32
 IP4.ADDRESS[2]:                         192.168.209.179/25
@@ -11201,6 +11337,11 @@ IP4.DOMAIN[4]:                          sear4.foo4.bar
 IP4.DOMAIN[5]:                          sear4.fo.o.bar
 IP4.WINS[1]:                            192.168.120.79
 -------------------------------------------------------------------------------
+DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:                        dhcp-4-opt-2 = val-2
+DHCP4.OPTION[3]:                        dhcp-4-opt-4 = val-4
+DHCP4.OPTION[4]:                        dhcp-4-opt-7 = val-7
+-------------------------------------------------------------------------------
 IP6.GATEWAY:                            --
 IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
 IP6.DOMAIN[1]:                          sear6.foo2.bar
@@ -11210,15 +11351,16 @@ IP6.DOMAIN[4]:                          sear6.fo.o.bar
 IP6.DOMAIN[5]:                          sear6.foo3.bar
 IP6.DOMAIN[6]:                          sear6.foo4.bar
 -------------------------------------------------------------------------------
+DHCP6.OPTION[1]:                        dhcp-6-opt-1 = val-1
+DHCP6.OPTION[2]:                        dhcp-6-opt-2 = val-2
+DHCP6.OPTION[3]:                        dhcp-6-opt-3 = val-3
+DHCP6.OPTION[4]:                        dhcp-6-opt-4 = val-4
+DHCP6.OPTION[5]:                        dhcp-6-opt-5 = val-5
+-------------------------------------------------------------------------------
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
+-------------------------------------------------------------------------------
 
-<<<
-size: 25555
-location: clients/tests/test-client.py:1050:test_004()/177
-cmd: $NMCLI --pretty --color yes -f all dev show
-lang: C
-returncode: 0
-stdout: 25396 bytes
->>>
 ===============================================================================
                              Device details (eth0)
 ===============================================================================
@@ -11553,8 +11695,16 @@ CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 -------------------------------------------------------------------------------
 
+<<<
+size: 25738
+location: clients/tests/test-client.py:1050:test_004()/178
+cmd: $NMCLI --pretty --color yes -f all dev show
+lang: pl_PL.UTF-8
+returncode: 0
+stdout: 25569 bytes
+>>>
 ===============================================================================
-                            Device details (wlan0)
+                        Informacje o urządzeniu (wlan0)
 ===============================================================================
 GENERAL.DEVICE:                         wlan0
 GENERAL.TYPE:                           wifi
@@ -11566,61 +11716,61 @@ GENERAL.DRIVER-VERSION:                 --
 GENERAL.FIRMWARE-VERSION:               --
 GENERAL.HWADDR:                         13:E0:74:85:7C:D9
 GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (unavailable)
-GENERAL.REASON:                         0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:               0 (unknown)
-GENERAL.IP6-CONNECTIVITY:               0 (unknown)
+GENERAL.STATE:                          20 (niedostępne)
+GENERAL.REASON:                         0 (Nie podano przyczyny)
+GENERAL.IP4-CONNECTIVITY:               0 (nieznane)
+GENERAL.IP6-CONNECTIVITY:               0 (nieznane)
 GENERAL.UDI:                            /sys/devices/virtual/wlan0
 GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    no
-GENERAL.NM-MANAGED:                     yes
-GENERAL.AUTOCONNECT:                    yes
-GENERAL.FIRMWARE-MISSING:               no
-GENERAL.NM-PLUGIN-MISSING:              no
+GENERAL.IS-SOFTWARE:                    nie
+GENERAL.NM-MANAGED:                     tak
+GENERAL.AUTOCONNECT:                    tak
+GENERAL.FIRMWARE-MISSING:               nie
+GENERAL.NM-PLUGIN-MISSING:              nie
 GENERAL.PHYS-PORT-ID:                   --
 GENERAL.CONNECTION:                     con-vpn-1
 GENERAL.CON-UUID:                       UUID-con-vpn-1-REPLACED-REPLACED-REP
 GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
-GENERAL.METERED:                        unknown
+GENERAL.METERED:                        nieznane
 -------------------------------------------------------------------------------
-CAPABILITIES.CARRIER-DETECT:            no
-CAPABILITIES.SPEED:                     unknown
-CAPABILITIES.IS-SOFTWARE:               no
-CAPABILITIES.SRIOV:                     no
+CAPABILITIES.CARRIER-DETECT:            nie
+CAPABILITIES.SPEED:                     nieznane
+CAPABILITIES.IS-SOFTWARE:               nie
+CAPABILITIES.SRIOV:                     nie
 -------------------------------------------------------------------------------
-WIFI-PROPERTIES.WEP:                    yes
-WIFI-PROPERTIES.WPA:                    yes
-WIFI-PROPERTIES.WPA2:                   yes
-WIFI-PROPERTIES.TKIP:                   yes
-WIFI-PROPERTIES.CCMP:                   yes
-WIFI-PROPERTIES.AP:                     yes
-WIFI-PROPERTIES.ADHOC:                  yes
-WIFI-PROPERTIES.2GHZ:                   unknown
-WIFI-PROPERTIES.5GHZ:                   unknown
+WIFI-PROPERTIES.WEP:                    tak
+WIFI-PROPERTIES.WPA:                    tak
+WIFI-PROPERTIES.WPA2:                   tak
+WIFI-PROPERTIES.TKIP:                   tak
+WIFI-PROPERTIES.CCMP:                   tak
+WIFI-PROPERTIES.AP:                     tak
+WIFI-PROPERTIES.ADHOC:                  tak
+WIFI-PROPERTIES.2GHZ:                   nieznane
+WIFI-PROPERTIES.5GHZ:                   nieznane
 -------------------------------------------------------------------------------
 AP[1].IN-USE:                           [32m [0m
 AP[1].SSID:                             [32mwlan0-ap-2[0m
-AP[1].MODE:                             [32mInfra[0m
+AP[1].MODE:                             [32mInfrastruktura[0m
 AP[1].CHAN:                             [32m1[0m
-AP[1].RATE:                             [32m54 Mbit/s[0m
+AP[1].RATE:                             [32m54 Mb/s[0m
 AP[1].SIGNAL:                           [32m92[0m
 AP[1].BARS:                             [32m****[0m
 AP[1].SECURITY:                         [32mWPA1 WPA2[0m
 -------------------------------------------------------------------------------
 AP[2].IN-USE:                           [32m [0m
 AP[2].SSID:                             [32mwlan0-ap-1[0m
-AP[2].MODE:                             [32mInfra[0m
+AP[2].MODE:                             [32mInfrastruktura[0m
 AP[2].CHAN:                             [32m1[0m
-AP[2].RATE:                             [32m54 Mbit/s[0m
+AP[2].RATE:                             [32m54 Mb/s[0m
 AP[2].SIGNAL:                           [32m81[0m
 AP[2].BARS:                             [32m****[0m
 AP[2].SECURITY:                         [32mWPA1 WPA2[0m
 -------------------------------------------------------------------------------
 AP[3].IN-USE:                           [35m [0m
 AP[3].SSID:                             [35mwlan0-ap-3[0m
-AP[3].MODE:                             [35mInfra[0m
+AP[3].MODE:                             [35mInfrastruktura[0m
 AP[3].CHAN:                             [35m1[0m
-AP[3].RATE:                             [35m54 Mbit/s[0m
+AP[3].RATE:                             [35m54 Mb/s[0m
 AP[3].SIGNAL:                           [35m55[0m
 AP[3].BARS:                             [35m**  [0m
 AP[3].SECURITY:                         [35mWPA1 WPA2[0m
@@ -11659,14 +11809,6 @@ CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 -------------------------------------------------------------------------------
 
-<<<
-size: 25738
-location: clients/tests/test-client.py:1050:test_004()/178
-cmd: $NMCLI --pretty --color yes -f all dev show
-lang: pl_PL.UTF-8
-returncode: 0
-stdout: 25569 bytes
->>>
 ===============================================================================
                         Informacje o urządzeniu (eth0)
 ===============================================================================
@@ -11996,112 +12138,6 @@ DHCP6.OPTION[2]:                        dhcp-6-opt-6 = val-6
 DHCP6.OPTION[3]:                        dhcp-6-opt-7 = val-7
 DHCP6.OPTION[4]:                        dhcp-6-opt-8 = val-8
 DHCP6.OPTION[5]:                        dhcp-6-opt-9 = val-9
--------------------------------------------------------------------------------
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
--------------------------------------------------------------------------------
-
-===============================================================================
-                        Informacje o urządzeniu (wlan0)
-===============================================================================
-GENERAL.DEVICE:                         wlan0
-GENERAL.TYPE:                           wifi
-GENERAL.NM-TYPE:                        NMDeviceWifi
-GENERAL.VENDOR:                         --
-GENERAL.PRODUCT:                        --
-GENERAL.DRIVER:                         virtual
-GENERAL.DRIVER-VERSION:                 --
-GENERAL.FIRMWARE-VERSION:               --
-GENERAL.HWADDR:                         13:E0:74:85:7C:D9
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (niedostępne)
-GENERAL.REASON:                         0 (Nie podano przyczyny)
-GENERAL.IP4-CONNECTIVITY:               0 (nieznane)
-GENERAL.IP6-CONNECTIVITY:               0 (nieznane)
-GENERAL.UDI:                            /sys/devices/virtual/wlan0
-GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    nie
-GENERAL.NM-MANAGED:                     tak
-GENERAL.AUTOCONNECT:                    tak
-GENERAL.FIRMWARE-MISSING:               nie
-GENERAL.NM-PLUGIN-MISSING:              nie
-GENERAL.PHYS-PORT-ID:                   --
-GENERAL.CONNECTION:                     con-vpn-1
-GENERAL.CON-UUID:                       UUID-con-vpn-1-REPLACED-REPLACED-REP
-GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
-GENERAL.METERED:                        nieznane
--------------------------------------------------------------------------------
-CAPABILITIES.CARRIER-DETECT:            nie
-CAPABILITIES.SPEED:                     nieznane
-CAPABILITIES.IS-SOFTWARE:               nie
-CAPABILITIES.SRIOV:                     nie
--------------------------------------------------------------------------------
-WIFI-PROPERTIES.WEP:                    tak
-WIFI-PROPERTIES.WPA:                    tak
-WIFI-PROPERTIES.WPA2:                   tak
-WIFI-PROPERTIES.TKIP:                   tak
-WIFI-PROPERTIES.CCMP:                   tak
-WIFI-PROPERTIES.AP:                     tak
-WIFI-PROPERTIES.ADHOC:                  tak
-WIFI-PROPERTIES.2GHZ:                   nieznane
-WIFI-PROPERTIES.5GHZ:                   nieznane
--------------------------------------------------------------------------------
-AP[1].IN-USE:                           [32m [0m
-AP[1].SSID:                             [32mwlan0-ap-2[0m
-AP[1].MODE:                             [32mInfrastruktura[0m
-AP[1].CHAN:                             [32m1[0m
-AP[1].RATE:                             [32m54 Mb/s[0m
-AP[1].SIGNAL:                           [32m92[0m
-AP[1].BARS:                             [32m****[0m
-AP[1].SECURITY:                         [32mWPA1 WPA2[0m
--------------------------------------------------------------------------------
-AP[2].IN-USE:                           [32m [0m
-AP[2].SSID:                             [32mwlan0-ap-1[0m
-AP[2].MODE:                             [32mInfrastruktura[0m
-AP[2].CHAN:                             [32m1[0m
-AP[2].RATE:                             [32m54 Mb/s[0m
-AP[2].SIGNAL:                           [32m81[0m
-AP[2].BARS:                             [32m****[0m
-AP[2].SECURITY:                         [32mWPA1 WPA2[0m
--------------------------------------------------------------------------------
-AP[3].IN-USE:                           [35m [0m
-AP[3].SSID:                             [35mwlan0-ap-3[0m
-AP[3].MODE:                             [35mInfrastruktura[0m
-AP[3].CHAN:                             [35m1[0m
-AP[3].RATE:                             [35m54 Mb/s[0m
-AP[3].SIGNAL:                           [35m55[0m
-AP[3].BARS:                             [35m**  [0m
-AP[3].SECURITY:                         [35mWPA1 WPA2[0m
--------------------------------------------------------------------------------
-IP4.ADDRESS[1]:                         192.168.228.18/32
-IP4.ADDRESS[2]:                         192.168.209.179/25
-IP4.GATEWAY:                            192.168.41.120
-IP4.DOMAIN[1]:                          sear4.foo2.bar
-IP4.DOMAIN[2]:                          sear4.fo.x.y
-IP4.DOMAIN[3]:                          sear4.foo1.bar
-IP4.DOMAIN[4]:                          sear4.foo4.bar
-IP4.DOMAIN[5]:                          sear4.fo.o.bar
-IP4.WINS[1]:                            192.168.120.79
--------------------------------------------------------------------------------
-DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:                        dhcp-4-opt-2 = val-2
-DHCP4.OPTION[3]:                        dhcp-4-opt-4 = val-4
-DHCP4.OPTION[4]:                        dhcp-4-opt-7 = val-7
--------------------------------------------------------------------------------
-IP6.GATEWAY:                            --
-IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
-IP6.DOMAIN[1]:                          sear6.foo2.bar
-IP6.DOMAIN[2]:                          sear6.foo1.bar
-IP6.DOMAIN[3]:                          sear6.fo.x.y
-IP6.DOMAIN[4]:                          sear6.fo.o.bar
-IP6.DOMAIN[5]:                          sear6.foo3.bar
-IP6.DOMAIN[6]:                          sear6.foo4.bar
--------------------------------------------------------------------------------
-DHCP6.OPTION[1]:                        dhcp-6-opt-1 = val-1
-DHCP6.OPTION[2]:                        dhcp-6-opt-2 = val-2
-DHCP6.OPTION[3]:                        dhcp-6-opt-3 = val-3
-DHCP6.OPTION[4]:                        dhcp-6-opt-4 = val-4
-DHCP6.OPTION[5]:                        dhcp-6-opt-5 = val-5
 -------------------------------------------------------------------------------
 CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
@@ -12642,11 +12678,11 @@ stdout: 633 bytes
 =====================
 DEVICE  TYPE      DBUS-PATH                                 
 ----------------------------------------------------------------------------------
+[2mwlan0[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/3[0m 
 [2meth0[0m    [2methernet[0m  [2m/org/freedesktop/NetworkManager/Devices/1[0m 
 [2meth1[0m    [2methernet[0m  [2m/org/freedesktop/NetworkManager/Devices/2[0m 
 [2mwlan1[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/4[0m 
 [2mwlan1[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/5[0m 
-[2mwlan0[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/3[0m 
 
 <<<
 size: 806
@@ -12661,11 +12697,11 @@ stdout: 626 bytes
 ===================
 DEVICE  TYPE      DBUS-PATH                                 
 --------------------------------------------------------------------------------
+[2mwlan0[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/3[0m 
 [2meth0[0m    [2methernet[0m  [2m/org/freedesktop/NetworkManager/Devices/1[0m 
 [2meth1[0m    [2methernet[0m  [2m/org/freedesktop/NetworkManager/Devices/2[0m 
 [2mwlan1[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/4[0m 
 [2mwlan1[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/5[0m 
-[2mwlan0[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/3[0m 
 
 <<<
 size: 3650
@@ -12675,6 +12711,15 @@ lang: C
 returncode: 0
 stdout: 3484 bytes
 >>>
+===========================
+  Wi-Fi scan list (wlan0)
+===========================
+NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+[32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
+[32mAP[2][0m  [32mwlan0-ap-1[0m  [32m776C616E302D61702D31[0m  [32m61:95:77:AC:1E:4C[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/1[0m 
+[35mAP[3][0m  [35mwlan0-ap-3[0m  [35m776C616E302D61702D33[0m  [35m9B:F6:B7:EC:97:76[0m  [35mInfra[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mbit/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan0[0m   [35mno[0m      [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m 
+
 ===========================
   Wi-Fi scan list (wlan1)
 ===========================
@@ -12688,15 +12733,6 @@ NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ   
 NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-===========================
-  Wi-Fi scan list (wlan0)
-===========================
-NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-[32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
-[32mAP[2][0m  [32mwlan0-ap-1[0m  [32m776C616E302D61702D31[0m  [32m61:95:77:AC:1E:4C[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/1[0m 
-[35mAP[3][0m  [35mwlan0-ap-3[0m  [35m776C616E302D61702D33[0m  [35m9B:F6:B7:EC:97:76[0m  [35mInfra[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mbit/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan0[0m   [35mno[0m      [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m 
-
 <<<
 size: 3888
 location: clients/tests/test-client.py:1068:test_004()/190
@@ -12705,6 +12741,15 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 3712 bytes
 >>>
+========================================
+  Lista skanowania sieci Wi-Fi (wlan0)
+========================================
+NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+[32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
+[32mAP[2][0m  [32mwlan0-ap-1[0m  [32m776C616E302D61702D31[0m  [32m61:95:77:AC:1E:4C[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/1[0m 
+[35mAP[3][0m  [35mwlan0-ap-3[0m  [35m776C616E302D61702D33[0m  [35m9B:F6:B7:EC:97:76[0m  [35mInfrastruktura[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mb/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan0[0m   [35mnie[0m     [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m 
+
 ========================================
   Lista skanowania sieci Wi-Fi (wlan1)
 ========================================
@@ -12718,15 +12763,6 @@ NAME   SSID        SSID-HEX              BSSID              MODE            CHAN
 NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-========================================
-  Lista skanowania sieci Wi-Fi (wlan0)
-========================================
-NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-[32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
-[32mAP[2][0m  [32mwlan0-ap-1[0m  [32m776C616E302D61702D31[0m  [32m61:95:77:AC:1E:4C[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/1[0m 
-[35mAP[3][0m  [35mwlan0-ap-3[0m  [35m776C616E302D61702D33[0m  [35m9B:F6:B7:EC:97:76[0m  [35mInfrastruktura[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mb/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan0[0m   [35mnie[0m     [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m 
-
 <<<
 size: 1453
 location: clients/tests/test-client.py:1070:test_004()/191
@@ -12735,6 +12771,15 @@ lang: C
 returncode: 0
 stdout: 1284 bytes
 >>>
+===========================
+  Wi-Fi scan list (wlan0)
+===========================
+IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
+------------------------------------------------------------------------------------------------
+[32m [0m       [32mwlan0-ap-2[0m  [32mInfra[0m  [32m1[0m     [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
+[32m [0m       [32mwlan0-ap-1[0m  [32mInfra[0m  [32m1[0m     [32m54 Mbit/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m 
+[35m [0m       [35mwlan0-ap-3[0m  [35mInfra[0m  [35m1[0m     [35m54 Mbit/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
+
 ===========================
   Wi-Fi scan list (wlan1)
 ===========================
@@ -12748,15 +12793,6 @@ IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY
 IN-USE  SSID  MODE  CHAN  RATE  SIGNAL  BARS  SECURITY 
 -----------------------------------------------------------------------------------
 
-===========================
-  Wi-Fi scan list (wlan0)
-===========================
-IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
-------------------------------------------------------------------------------------------------
-[32m [0m       [32mwlan0-ap-2[0m  [32mInfra[0m  [32m1[0m     [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
-[32m [0m       [32mwlan0-ap-1[0m  [32mInfra[0m  [32m1[0m     [32m54 Mbit/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m 
-[35m [0m       [35mwlan0-ap-3[0m  [35mInfra[0m  [35m1[0m     [35m54 Mbit/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
-
 <<<
 size: 1683
 location: clients/tests/test-client.py:1070:test_004()/192
@@ -12765,6 +12801,15 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 1504 bytes
 >>>
+========================================
+  Lista skanowania sieci Wi-Fi (wlan0)
+========================================
+IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
+--------------------------------------------------------------------------------------------------------------------
+[32m [0m       [32mwlan0-ap-2[0m  [32mInfrastruktura[0m  [32m1[0m     [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
+[32m [0m       [32mwlan0-ap-1[0m  [32mInfrastruktura[0m  [32m1[0m     [32m54 Mb/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m 
+[35m [0m       [35mwlan0-ap-3[0m  [35mInfrastruktura[0m  [35m1[0m     [35m54 Mb/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
+
 ========================================
   Lista skanowania sieci Wi-Fi (wlan1)
 ========================================
@@ -12778,15 +12823,6 @@ IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY
 IN-USE  SSID  MODE  CHAN  RATE  SIGNAL  BARS  SECURITY 
 ------------------------------------------------------------------------------------------------
 
-========================================
-  Lista skanowania sieci Wi-Fi (wlan0)
-========================================
-IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
---------------------------------------------------------------------------------------------------------------------
-[32m [0m       [32mwlan0-ap-2[0m  [32mInfrastruktura[0m  [32m1[0m     [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
-[32m [0m       [32mwlan0-ap-1[0m  [32mInfrastruktura[0m  [32m1[0m     [32m54 Mb/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m 
-[35m [0m       [35mwlan0-ap-3[0m  [35mInfrastruktura[0m  [35m1[0m     [35m54 Mb/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
-
 <<<
 size: 3763
 location: clients/tests/test-client.py:1073:test_004()/193
@@ -12795,6 +12831,15 @@ lang: C
 returncode: 0
 stdout: 3484 bytes
 >>>
+===========================
+  Wi-Fi scan list (wlan0)
+===========================
+NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+[32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
+[32mAP[2][0m  [32mwlan0-ap-1[0m  [32m776C616E302D61702D31[0m  [32m61:95:77:AC:1E:4C[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/1[0m 
+[35mAP[3][0m  [35mwlan0-ap-3[0m  [35m776C616E302D61702D33[0m  [35m9B:F6:B7:EC:97:76[0m  [35mInfra[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mbit/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan0[0m   [35mno[0m      [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m 
+
 ===========================
   Wi-Fi scan list (wlan1)
 ===========================
@@ -12808,15 +12853,6 @@ NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ   
 NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-===========================
-  Wi-Fi scan list (wlan0)
-===========================
-NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-[32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
-[32mAP[2][0m  [32mwlan0-ap-1[0m  [32m776C616E302D61702D31[0m  [32m61:95:77:AC:1E:4C[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/1[0m 
-[35mAP[3][0m  [35mwlan0-ap-3[0m  [35m776C616E302D61702D33[0m  [35m9B:F6:B7:EC:97:76[0m  [35mInfra[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mbit/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan0[0m   [35mno[0m      [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m 
-
 <<<
 size: 4001
 location: clients/tests/test-client.py:1073:test_004()/194
@@ -12825,6 +12861,15 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 3712 bytes
 >>>
+========================================
+  Lista skanowania sieci Wi-Fi (wlan0)
+========================================
+NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+[32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
+[32mAP[2][0m  [32mwlan0-ap-1[0m  [32m776C616E302D61702D31[0m  [32m61:95:77:AC:1E:4C[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/1[0m 
+[35mAP[3][0m  [35mwlan0-ap-3[0m  [35m776C616E302D61702D33[0m  [35m9B:F6:B7:EC:97:76[0m  [35mInfrastruktura[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mb/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan0[0m   [35mnie[0m     [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m 
+
 ========================================
   Lista skanowania sieci Wi-Fi (wlan1)
 ========================================
@@ -12838,22 +12883,13 @@ NAME   SSID        SSID-HEX              BSSID              MODE            CHAN
 NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-========================================
-  Lista skanowania sieci Wi-Fi (wlan0)
-========================================
-NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-[32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
-[32mAP[2][0m  [32mwlan0-ap-1[0m  [32m776C616E302D61702D31[0m  [32m61:95:77:AC:1E:4C[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/1[0m 
-[35mAP[3][0m  [35mwlan0-ap-3[0m  [35m776C616E302D61702D33[0m  [35m9B:F6:B7:EC:97:76[0m  [35mInfrastruktura[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mb/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan0[0m   [35mnie[0m     [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m 
-
 <<<
-size: 1305
+size: 1307
 location: clients/tests/test-client.py:1075:test_004()/195
 cmd: $NMCLI --pretty --color yes -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 1115 bytes
+stdout: 1117 bytes
 >>>
 ===========================
   Wi-Fi scan list (wlan0)
@@ -12862,13 +12898,15 @@ NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ   
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 [32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
 
+
+
 <<<
-size: 1392
+size: 1394
 location: clients/tests/test-client.py:1075:test_004()/196
 cmd: $NMCLI --pretty --color yes -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 1192 bytes
+stdout: 1194 bytes
 >>>
 ========================================
   Lista skanowania sieci Wi-Fi (wlan0)
@@ -12877,13 +12915,15 @@ NAME   SSID        SSID-HEX              BSSID              MODE            CHAN
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 [32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
 
+
+
 <<<
-size: 581
+size: 583
 location: clients/tests/test-client.py:1077:test_004()/197
 cmd: $NMCLI --pretty --color yes -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 389 bytes
+stdout: 391 bytes
 >>>
 ===========================
   Wi-Fi scan list (wlan0)
@@ -12892,13 +12932,15 @@ IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY
 ------------------------------------------------------------------------------------------------
 [32m [0m       [32mwlan0-ap-2[0m  [32mInfra[0m  [32m1[0m     [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
 
+
+
 <<<
-size: 666
+size: 668
 location: clients/tests/test-client.py:1077:test_004()/198
 cmd: $NMCLI --pretty --color yes -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 464 bytes
+stdout: 466 bytes
 >>>
 ========================================
   Lista skanowania sieci Wi-Fi (wlan0)
@@ -12907,13 +12949,15 @@ IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY
 --------------------------------------------------------------------------------------------------------------------
 [32m [0m       [32mwlan0-ap-2[0m  [32mInfrastruktura[0m  [32m1[0m     [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
 
+
+
 <<<
-size: 1418
+size: 1420
 location: clients/tests/test-client.py:1080:test_004()/199
 cmd: $NMCLI --pretty --color yes -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 1115 bytes
+stdout: 1117 bytes
 >>>
 ===========================
   Wi-Fi scan list (wlan0)
@@ -12922,13 +12966,15 @@ NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ   
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 [32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
 
+
+
 <<<
-size: 1505
+size: 1507
 location: clients/tests/test-client.py:1080:test_004()/200
 cmd: $NMCLI --pretty --color yes -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 1192 bytes
+stdout: 1194 bytes
 >>>
 ========================================
   Lista skanowania sieci Wi-Fi (wlan0)
@@ -12936,6 +12982,8 @@ stdout: 1192 bytes
 NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 [32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
+
+
 
 <<<
 size: 6189
@@ -14135,11 +14183,11 @@ lang: C
 returncode: 0
 stdout: 135 bytes
 >>>
+wlan0:wifi:unavailable:con-vpn-1
 eth0:ethernet:unavailable:
 eth1:ethernet:unavailable:
 wlan1:wifi:unavailable:
 wlan1:wifi:unavailable:
-wlan0:wifi:unavailable:con-vpn-1
 
 <<<
 size: 279
@@ -14149,11 +14197,11 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 135 bytes
 >>>
+wlan0:wifi:unavailable:con-vpn-1
 eth0:ethernet:unavailable:
 eth1:ethernet:unavailable:
 wlan1:wifi:unavailable:
 wlan1:wifi:unavailable:
-wlan0:wifi:unavailable:con-vpn-1
 
 <<<
 size: 667
@@ -14163,11 +14211,11 @@ lang: C
 returncode: 0
 stdout: 521 bytes
 >>>
+wlan0:wifi:unavailable:unknown:unknown:/org/freedesktop/NetworkManager/Devices/3:con-vpn-1:UUID-con-vpn-1-REPLACED-REPLACED-REP:/org/freedesktop/NetworkManager/ActiveConnection/2
 eth0:ethernet:unavailable:unknown:unknown:/org/freedesktop/NetworkManager/Devices/1:::
 eth1:ethernet:unavailable:unknown:unknown:/org/freedesktop/NetworkManager/Devices/2:::
 wlan1:wifi:unavailable:unknown:unknown:/org/freedesktop/NetworkManager/Devices/4:::
 wlan1:wifi:unavailable:unknown:unknown:/org/freedesktop/NetworkManager/Devices/5:::
-wlan0:wifi:unavailable:unknown:unknown:/org/freedesktop/NetworkManager/Devices/3:con-vpn-1:UUID-con-vpn-1-REPLACED-REPLACED-REP:/org/freedesktop/NetworkManager/ActiveConnection/2
 
 <<<
 size: 687
@@ -14177,11 +14225,11 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 531 bytes
 >>>
+wlan0:wifi:unavailable:nieznane:nieznane:/org/freedesktop/NetworkManager/Devices/3:con-vpn-1:UUID-con-vpn-1-REPLACED-REPLACED-REP:/org/freedesktop/NetworkManager/ActiveConnection/2
 eth0:ethernet:unavailable:nieznane:nieznane:/org/freedesktop/NetworkManager/Devices/1:::
 eth1:ethernet:unavailable:nieznane:nieznane:/org/freedesktop/NetworkManager/Devices/2:::
 wlan1:wifi:unavailable:nieznane:nieznane:/org/freedesktop/NetworkManager/Devices/4:::
 wlan1:wifi:unavailable:nieznane:nieznane:/org/freedesktop/NetworkManager/Devices/5:::
-wlan0:wifi:unavailable:nieznane:nieznane:/org/freedesktop/NetworkManager/Devices/3:con-vpn-1:UUID-con-vpn-1-REPLACED-REPLACED-REP:/org/freedesktop/NetworkManager/ActiveConnection/2
 
 <<<
 size: 4540
@@ -14191,6 +14239,31 @@ lang: C
 returncode: 0
 stdout: 4402 bytes
 >>>
+GENERAL.DEVICE:wlan0
+GENERAL.TYPE:wifi
+GENERAL.HWADDR:13:E0:74:85:7C:D9
+GENERAL.MTU:0
+GENERAL.STATE:20 (unavailable)
+GENERAL.CONNECTION:con-vpn-1
+GENERAL.CON-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
+IP4.ADDRESS[1]:192.168.228.18/32
+IP4.ADDRESS[2]:192.168.209.179/25
+IP4.GATEWAY:192.168.41.120
+IP4.DOMAIN[1]:sear4.foo2.bar
+IP4.DOMAIN[2]:sear4.fo.x.y
+IP4.DOMAIN[3]:sear4.foo1.bar
+IP4.DOMAIN[4]:sear4.foo4.bar
+IP4.DOMAIN[5]:sear4.fo.o.bar
+IP4.WINS[1]:192.168.120.79
+IP6.GATEWAY:
+IP6.ROUTE[1]:dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
+IP6.DOMAIN[1]:sear6.foo2.bar
+IP6.DOMAIN[2]:sear6.foo1.bar
+IP6.DOMAIN[3]:sear6.fo.x.y
+IP6.DOMAIN[4]:sear6.fo.o.bar
+IP6.DOMAIN[5]:sear6.foo3.bar
+IP6.DOMAIN[6]:sear6.foo4.bar
+
 GENERAL.DEVICE:eth0
 GENERAL.TYPE:ethernet
 GENERAL.HWADDR:AB:B7:BF:E2:48:E8
@@ -14303,31 +14376,6 @@ IP6.ROUTE[2]:dst = 2001:a::a976:2488:f49f:b48/106, nh = 2001:a::62ae:c734:fc7b:e
 IP6.ROUTE[3]:dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::
 IP6.DNS[1]:2001:a::2934:bd66:550d:ec19
 IP6.DOMAIN[1]:sear6.fo.x.y
-
-GENERAL.DEVICE:wlan0
-GENERAL.TYPE:wifi
-GENERAL.HWADDR:13:E0:74:85:7C:D9
-GENERAL.MTU:0
-GENERAL.STATE:20 (unavailable)
-GENERAL.CONNECTION:con-vpn-1
-GENERAL.CON-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
-IP4.ADDRESS[1]:192.168.228.18/32
-IP4.ADDRESS[2]:192.168.209.179/25
-IP4.GATEWAY:192.168.41.120
-IP4.DOMAIN[1]:sear4.foo2.bar
-IP4.DOMAIN[2]:sear4.fo.x.y
-IP4.DOMAIN[3]:sear4.foo1.bar
-IP4.DOMAIN[4]:sear4.foo4.bar
-IP4.DOMAIN[5]:sear4.fo.o.bar
-IP4.WINS[1]:192.168.120.79
-IP6.GATEWAY:
-IP6.ROUTE[1]:dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
-IP6.DOMAIN[1]:sear6.foo2.bar
-IP6.DOMAIN[2]:sear6.foo1.bar
-IP6.DOMAIN[3]:sear6.fo.x.y
-IP6.DOMAIN[4]:sear6.fo.o.bar
-IP6.DOMAIN[5]:sear6.foo3.bar
-IP6.DOMAIN[6]:sear6.foo4.bar
 
 <<<
 size: 4550
@@ -14337,119 +14385,6 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 4402 bytes
 >>>
-GENERAL.DEVICE:eth0
-GENERAL.TYPE:ethernet
-GENERAL.HWADDR:AB:B7:BF:E2:48:E8
-GENERAL.MTU:0
-GENERAL.STATE:20 (unavailable)
-GENERAL.CONNECTION:
-GENERAL.CON-PATH:
-WIRED-PROPERTIES.CARRIER:off
-IP4.ADDRESS[1]:192.168.49.34/22
-IP4.ADDRESS[2]:192.168.135.86/19
-IP4.GATEWAY:
-IP4.DNS[1]:192.168.45.230
-IP4.DNS[2]:192.168.180.201
-IP4.DNS[3]:192.168.253.2
-IP4.DOMAIN[1]:sear4.foo2.bar
-IP4.DOMAIN[2]:sear4.foo1.bar
-IP4.WINS[1]:192.168.163.23
-IP4.WINS[2]:192.168.151.246
-IP6.ADDRESS[1]:2001:a::ed81:3d7:c2e9:df82/99
-IP6.GATEWAY:
-IP6.DNS[1]:2001:a::2703:f06:9619:d89f
-IP6.DNS[2]:2001:a::3a75:3682:c683:8541
-IP6.DNS[3]:2001:a::584e:912:d5ee:c74f
-IP6.DOMAIN[1]:sear6.foo4.bar
-IP6.DOMAIN[2]:sear6.fo.o.bar
-
-GENERAL.DEVICE:eth1
-GENERAL.TYPE:ethernet
-GENERAL.HWADDR:E7:78:B1:93:2B:22
-GENERAL.MTU:0
-GENERAL.STATE:20 (unavailable)
-GENERAL.CONNECTION:
-GENERAL.CON-PATH:
-WIRED-PROPERTIES.CARRIER:off
-IP4.ADDRESS[1]:192.168.127.210/25
-IP4.GATEWAY:192.168.88.4
-IP4.ROUTE[1]:dst = 192.168.222.35/19, nh = 192.168.170.142, mt = 3609264321
-IP4.ROUTE[2]:dst = 192.168.135.81/32, nh = 192.168.32.11, mt = 1316413247
-IP4.ROUTE[3]:dst = 192.168.24.65/26, nh = 192.168.23.163, mt = 3855574583
-IP4.DNS[1]:192.168.16.144
-IP4.DNS[2]:192.168.79.53
-IP4.DNS[3]:192.168.237.155
-IP4.DOMAIN[1]:sear4.foo4.bar
-IP4.DOMAIN[2]:sear4.foo3.bar
-IP4.DOMAIN[3]:sear4.foo1.bar
-IP4.WINS[1]:192.168.211.91
-IP4.WINS[2]:192.168.58.182
-IP4.WINS[3]:192.168.114.97
-IP6.ADDRESS[1]:2001:a::1c1:c178:169f:2b80/93
-IP6.ADDRESS[2]:2001:a::1f79:e0fb:87b9:3cc6/123
-IP6.GATEWAY:
-IP6.ROUTE[1]:dst = 2001:a::3166:7ed1:e4ae:7612/123, nh = ::
-IP6.DNS[1]:2001:a::edda:955:dcf4:23d4
-IP6.DNS[2]:2001:a::109f:aa0f:fb4a:9d5a
-IP6.DNS[3]:2001:a::61cf:7c82:e9c0:c952
-IP6.DOMAIN[1]:sear6.foo1.bar
-
-GENERAL.DEVICE:wlan1
-GENERAL.TYPE:wifi
-GENERAL.HWADDR:21:E9:64:81:8C:A8
-GENERAL.MTU:0
-GENERAL.STATE:20 (unavailable)
-GENERAL.CONNECTION:
-GENERAL.CON-PATH:
-IP4.GATEWAY:192.168.57.160
-IP4.ROUTE[1]:dst = 192.168.36.106/21, nh = 192.168.199.128, mt = 979274165
-IP4.ROUTE[2]:dst = 192.168.238.130/19, nh = 0.0.0.0
-IP4.ROUTE[3]:dst = 192.168.224.39/32, nh = 192.168.148.69
-IP4.DNS[1]:192.168.61.83
-IP4.DOMAIN[1]:sear4.foo4.bar
-IP4.DOMAIN[2]:sear4.fo.x.y
-IP4.DOMAIN[3]:sear4.foo2.bar
-IP4.DOMAIN[4]:sear4.foo1.bar
-IP4.DOMAIN[5]:sear4.fo.o.bar
-IP4.DOMAIN[6]:sear4.foo3.bar
-IP6.ADDRESS[1]:2001:a::fa05:2ab4:9300:e8fe/116
-IP6.ADDRESS[2]:2001:a::e9cf:bd3:caba:99b3/86
-IP6.ADDRESS[3]:2001:a::2be6:44fa:2c95:5559/78
-IP6.GATEWAY:2001:a::4d70:d91a:770f:2319
-IP6.ROUTE[1]:dst = 2001:a::3cb2:719d:bb00:b22f/66, nh = 2001:a::81b1:58b9:7237:3511, mt = 2280277732
-IP6.ROUTE[2]:dst = 2001:a::986f:983c:5eb:1c7d/99, nh = ::, mt = 1204008676
-IP6.DNS[1]:2001:a::85e7:3d7d:53e8:50ac
-IP6.DNS[2]:2001:a::1c5:9cb5:e86d:25a5
-IP6.DOMAIN[1]:sear6.foo4.bar
-IP6.DOMAIN[2]:sear6.foo2.bar
-
-GENERAL.DEVICE:wlan1
-GENERAL.TYPE:wifi
-GENERAL.HWADDR:71:52:AD:63:5C:7C
-GENERAL.MTU:0
-GENERAL.STATE:20 (unavailable)
-GENERAL.CONNECTION:
-GENERAL.CON-PATH:
-IP4.ADDRESS[1]:192.168.97.124/29
-IP4.ADDRESS[2]:192.168.76.154/18
-IP4.GATEWAY:
-IP4.ROUTE[1]:dst = 192.168.33.233/22, nh = 192.168.222.210, mt = 2810496551
-IP4.DNS[1]:192.168.107.109
-IP4.DOMAIN[1]:sear4.fo.o.bar
-IP4.DOMAIN[2]:sear4.fo.x.y
-IP4.DOMAIN[3]:sear4.foo2.bar
-IP4.DOMAIN[4]:sear4.foo3.bar
-IP4.DOMAIN[5]:sear4.foo4.bar
-IP4.WINS[1]:192.168.60.60
-IP4.WINS[2]:192.168.63.92
-IP6.ADDRESS[1]:2001:a::88ca:3654:96b:ab44/89
-IP6.GATEWAY:
-IP6.ROUTE[1]:dst = 2001:a::cc8b:7c09:4673:bbb0/85, nh = ::, mt = 2821465568
-IP6.ROUTE[2]:dst = 2001:a::a976:2488:f49f:b48/106, nh = 2001:a::62ae:c734:fc7b:e931, mt = 2248613879
-IP6.ROUTE[3]:dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::
-IP6.DNS[1]:2001:a::2934:bd66:550d:ec19
-IP6.DOMAIN[1]:sear6.fo.x.y
-
 GENERAL.DEVICE:wlan0
 GENERAL.TYPE:wifi
 GENERAL.HWADDR:13:E0:74:85:7C:D9
@@ -14475,44 +14410,13 @@ IP6.DOMAIN[4]:sear6.fo.o.bar
 IP6.DOMAIN[5]:sear6.foo3.bar
 IP6.DOMAIN[6]:sear6.foo4.bar
 
-<<<
-size: 11937
-location: clients/tests/test-client.py:1050:test_004()/223
-cmd: $NMCLI --terse -f all dev show
-lang: C
-returncode: 0
-stdout: 11791 bytes
->>>
 GENERAL.DEVICE:eth0
 GENERAL.TYPE:ethernet
-GENERAL.NM-TYPE:NMDeviceEthernet
-GENERAL.VENDOR:
-GENERAL.PRODUCT:
-GENERAL.DRIVER:virtual
-GENERAL.DRIVER-VERSION:
-GENERAL.FIRMWARE-VERSION:
 GENERAL.HWADDR:AB:B7:BF:E2:48:E8
 GENERAL.MTU:0
 GENERAL.STATE:20 (unavailable)
-GENERAL.REASON:0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:0 (unknown)
-GENERAL.IP6-CONNECTIVITY:0 (unknown)
-GENERAL.UDI:/sys/devices/virtual/eth0
-GENERAL.IP-IFACE:
-GENERAL.IS-SOFTWARE:no
-GENERAL.NM-MANAGED:yes
-GENERAL.AUTOCONNECT:yes
-GENERAL.FIRMWARE-MISSING:no
-GENERAL.NM-PLUGIN-MISSING:no
-GENERAL.PHYS-PORT-ID:
 GENERAL.CONNECTION:
-GENERAL.CON-UUID:
 GENERAL.CON-PATH:
-GENERAL.METERED:unknown
-CAPABILITIES.CARRIER-DETECT:no
-CAPABILITIES.SPEED:100 Mb/s
-CAPABILITIES.IS-SOFTWARE:no
-CAPABILITIES.SRIOV:no
 WIRED-PROPERTIES.CARRIER:off
 IP4.ADDRESS[1]:192.168.49.34/22
 IP4.ADDRESS[2]:192.168.135.86/19
@@ -14524,8 +14428,6 @@ IP4.DOMAIN[1]:sear4.foo2.bar
 IP4.DOMAIN[2]:sear4.foo1.bar
 IP4.WINS[1]:192.168.163.23
 IP4.WINS[2]:192.168.151.246
-DHCP4.OPTION[1]:dhcp-4-opt-8 = val-8
-DHCP4.OPTION[2]:dhcp-4-opt-9 = val-9
 IP6.ADDRESS[1]:2001:a::ed81:3d7:c2e9:df82/99
 IP6.GATEWAY:
 IP6.DNS[1]:2001:a::2703:f06:9619:d89f
@@ -14533,49 +14435,14 @@ IP6.DNS[2]:2001:a::3a75:3682:c683:8541
 IP6.DNS[3]:2001:a::584e:912:d5ee:c74f
 IP6.DOMAIN[1]:sear6.foo4.bar
 IP6.DOMAIN[2]:sear6.fo.o.bar
-DHCP6.OPTION[1]:dhcp-6-opt-0 = val-0
-DHCP6.OPTION[2]:dhcp-6-opt-1 = val-1
-DHCP6.OPTION[3]:dhcp-6-opt-2 = val-2
-DHCP6.OPTION[4]:dhcp-6-opt-3 = val-3
-DHCP6.OPTION[5]:dhcp-6-opt-4 = val-4
-DHCP6.OPTION[6]:dhcp-6-opt-5 = val-5
-DHCP6.OPTION[7]:dhcp-6-opt-6 = val-6
-DHCP6.OPTION[8]:dhcp-6-opt-7 = val-7
-DHCP6.OPTION[9]:dhcp-6-opt-8 = val-8
-DHCP6.OPTION[10]:dhcp-6-opt-9 = val-9
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{1}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:5fcfd6d7-1e63-3332-8826-a7eda103792d | con-1
 
 GENERAL.DEVICE:eth1
 GENERAL.TYPE:ethernet
-GENERAL.NM-TYPE:NMDeviceEthernet
-GENERAL.VENDOR:
-GENERAL.PRODUCT:
-GENERAL.DRIVER:virtual
-GENERAL.DRIVER-VERSION:
-GENERAL.FIRMWARE-VERSION:
 GENERAL.HWADDR:E7:78:B1:93:2B:22
 GENERAL.MTU:0
 GENERAL.STATE:20 (unavailable)
-GENERAL.REASON:0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:0 (unknown)
-GENERAL.IP6-CONNECTIVITY:0 (unknown)
-GENERAL.UDI:/sys/devices/virtual/eth1
-GENERAL.IP-IFACE:
-GENERAL.IS-SOFTWARE:no
-GENERAL.NM-MANAGED:yes
-GENERAL.AUTOCONNECT:yes
-GENERAL.FIRMWARE-MISSING:no
-GENERAL.NM-PLUGIN-MISSING:no
-GENERAL.PHYS-PORT-ID:
 GENERAL.CONNECTION:
-GENERAL.CON-UUID:
 GENERAL.CON-PATH:
-GENERAL.METERED:unknown
-CAPABILITIES.CARRIER-DETECT:no
-CAPABILITIES.SPEED:100 Mb/s
-CAPABILITIES.IS-SOFTWARE:no
-CAPABILITIES.SRIOV:no
 WIRED-PROPERTIES.CARRIER:off
 IP4.ADDRESS[1]:192.168.127.210/25
 IP4.GATEWAY:192.168.88.4
@@ -14591,15 +14458,6 @@ IP4.DOMAIN[3]:sear4.foo1.bar
 IP4.WINS[1]:192.168.211.91
 IP4.WINS[2]:192.168.58.182
 IP4.WINS[3]:192.168.114.97
-DHCP4.OPTION[1]:dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:dhcp-4-opt-1 = val-1
-DHCP4.OPTION[3]:dhcp-4-opt-2 = val-2
-DHCP4.OPTION[4]:dhcp-4-opt-3 = val-3
-DHCP4.OPTION[5]:dhcp-4-opt-4 = val-4
-DHCP4.OPTION[6]:dhcp-4-opt-5 = val-5
-DHCP4.OPTION[7]:dhcp-4-opt-7 = val-7
-DHCP4.OPTION[8]:dhcp-4-opt-8 = val-8
-DHCP4.OPTION[9]:dhcp-4-opt-9 = val-9
 IP6.ADDRESS[1]:2001:a::1c1:c178:169f:2b80/93
 IP6.ADDRESS[2]:2001:a::1f79:e0fb:87b9:3cc6/123
 IP6.GATEWAY:
@@ -14608,61 +14466,14 @@ IP6.DNS[1]:2001:a::edda:955:dcf4:23d4
 IP6.DNS[2]:2001:a::109f:aa0f:fb4a:9d5a
 IP6.DNS[3]:2001:a::61cf:7c82:e9c0:c952
 IP6.DOMAIN[1]:sear6.foo1.bar
-DHCP6.OPTION[1]:dhcp-6-opt-2 = val-2
-DHCP6.OPTION[2]:dhcp-6-opt-5 = val-5
-DHCP6.OPTION[3]:dhcp-6-opt-6 = val-6
-DHCP6.OPTION[4]:dhcp-6-opt-8 = val-8
-DHCP6.OPTION[5]:dhcp-6-opt-9 = val-9
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{1}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:5fcfd6d7-1e63-3332-8826-a7eda103792d | con-1
 
 GENERAL.DEVICE:wlan1
 GENERAL.TYPE:wifi
-GENERAL.NM-TYPE:NMDeviceWifi
-GENERAL.VENDOR:
-GENERAL.PRODUCT:
-GENERAL.DRIVER:virtual
-GENERAL.DRIVER-VERSION:
-GENERAL.FIRMWARE-VERSION:
 GENERAL.HWADDR:21:E9:64:81:8C:A8
 GENERAL.MTU:0
 GENERAL.STATE:20 (unavailable)
-GENERAL.REASON:0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:0 (unknown)
-GENERAL.IP6-CONNECTIVITY:0 (unknown)
-GENERAL.UDI:/sys/devices/virtual/wlan1
-GENERAL.IP-IFACE:
-GENERAL.IS-SOFTWARE:no
-GENERAL.NM-MANAGED:yes
-GENERAL.AUTOCONNECT:yes
-GENERAL.FIRMWARE-MISSING:no
-GENERAL.NM-PLUGIN-MISSING:no
-GENERAL.PHYS-PORT-ID:
 GENERAL.CONNECTION:
-GENERAL.CON-UUID:
 GENERAL.CON-PATH:
-GENERAL.METERED:unknown
-CAPABILITIES.CARRIER-DETECT:no
-CAPABILITIES.SPEED:unknown
-CAPABILITIES.IS-SOFTWARE:no
-CAPABILITIES.SRIOV:no
-WIFI-PROPERTIES.WEP:yes
-WIFI-PROPERTIES.WPA:yes
-WIFI-PROPERTIES.WPA2:yes
-WIFI-PROPERTIES.TKIP:yes
-WIFI-PROPERTIES.CCMP:yes
-WIFI-PROPERTIES.AP:yes
-WIFI-PROPERTIES.ADHOC:yes
-WIFI-PROPERTIES.2GHZ:unknown
-WIFI-PROPERTIES.5GHZ:unknown
-AP[1].IN-USE: 
-AP[1].SSID:wlan1-ap-4
-AP[1].MODE:Infra
-AP[1].CHAN:1
-AP[1].RATE:54 Mbit/s
-AP[1].SIGNAL:48
-AP[1].BARS:**  
-AP[1].SECURITY:WPA1 WPA2
 IP4.GATEWAY:192.168.57.160
 IP4.ROUTE[1]:dst = 192.168.36.106/21, nh = 192.168.199.128, mt = 979274165
 IP4.ROUTE[2]:dst = 192.168.238.130/19, nh = 0.0.0.0
@@ -14674,14 +14485,6 @@ IP4.DOMAIN[3]:sear4.foo2.bar
 IP4.DOMAIN[4]:sear4.foo1.bar
 IP4.DOMAIN[5]:sear4.fo.o.bar
 IP4.DOMAIN[6]:sear4.foo3.bar
-DHCP4.OPTION[1]:dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:dhcp-4-opt-1 = val-1
-DHCP4.OPTION[3]:dhcp-4-opt-2 = val-2
-DHCP4.OPTION[4]:dhcp-4-opt-4 = val-4
-DHCP4.OPTION[5]:dhcp-4-opt-6 = val-6
-DHCP4.OPTION[6]:dhcp-4-opt-7 = val-7
-DHCP4.OPTION[7]:dhcp-4-opt-8 = val-8
-DHCP4.OPTION[8]:dhcp-4-opt-9 = val-9
 IP6.ADDRESS[1]:2001:a::fa05:2ab4:9300:e8fe/116
 IP6.ADDRESS[2]:2001:a::e9cf:bd3:caba:99b3/86
 IP6.ADDRESS[3]:2001:a::2be6:44fa:2c95:5559/78
@@ -14692,57 +14495,14 @@ IP6.DNS[1]:2001:a::85e7:3d7d:53e8:50ac
 IP6.DNS[2]:2001:a::1c5:9cb5:e86d:25a5
 IP6.DOMAIN[1]:sear6.foo4.bar
 IP6.DOMAIN[2]:sear6.foo2.bar
-DHCP6.OPTION[1]:dhcp-6-opt-0 = val-0
-DHCP6.OPTION[2]:dhcp-6-opt-1 = val-1
-DHCP6.OPTION[3]:dhcp-6-opt-2 = val-2
-DHCP6.OPTION[4]:dhcp-6-opt-3 = val-3
-DHCP6.OPTION[5]:dhcp-6-opt-4 = val-4
-DHCP6.OPTION[6]:dhcp-6-opt-5 = val-5
-DHCP6.OPTION[7]:dhcp-6-opt-6 = val-6
-DHCP6.OPTION[8]:dhcp-6-opt-7 = val-7
-DHCP6.OPTION[9]:dhcp-6-opt-9 = val-9
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{2}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
 GENERAL.DEVICE:wlan1
 GENERAL.TYPE:wifi
-GENERAL.NM-TYPE:NMDeviceWifi
-GENERAL.VENDOR:
-GENERAL.PRODUCT:
-GENERAL.DRIVER:virtual
-GENERAL.DRIVER-VERSION:
-GENERAL.FIRMWARE-VERSION:
 GENERAL.HWADDR:71:52:AD:63:5C:7C
 GENERAL.MTU:0
 GENERAL.STATE:20 (unavailable)
-GENERAL.REASON:0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:0 (unknown)
-GENERAL.IP6-CONNECTIVITY:0 (unknown)
-GENERAL.UDI:/sys/devices/virtual/wlan1
-GENERAL.IP-IFACE:
-GENERAL.IS-SOFTWARE:no
-GENERAL.NM-MANAGED:yes
-GENERAL.AUTOCONNECT:yes
-GENERAL.FIRMWARE-MISSING:no
-GENERAL.NM-PLUGIN-MISSING:no
-GENERAL.PHYS-PORT-ID:
 GENERAL.CONNECTION:
-GENERAL.CON-UUID:
 GENERAL.CON-PATH:
-GENERAL.METERED:unknown
-CAPABILITIES.CARRIER-DETECT:no
-CAPABILITIES.SPEED:unknown
-CAPABILITIES.IS-SOFTWARE:no
-CAPABILITIES.SRIOV:no
-WIFI-PROPERTIES.WEP:yes
-WIFI-PROPERTIES.WPA:yes
-WIFI-PROPERTIES.WPA2:yes
-WIFI-PROPERTIES.TKIP:yes
-WIFI-PROPERTIES.CCMP:yes
-WIFI-PROPERTIES.AP:yes
-WIFI-PROPERTIES.ADHOC:yes
-WIFI-PROPERTIES.2GHZ:unknown
-WIFI-PROPERTIES.5GHZ:unknown
 IP4.ADDRESS[1]:192.168.97.124/29
 IP4.ADDRESS[2]:192.168.76.154/18
 IP4.GATEWAY:
@@ -14755,8 +14515,6 @@ IP4.DOMAIN[4]:sear4.foo3.bar
 IP4.DOMAIN[5]:sear4.foo4.bar
 IP4.WINS[1]:192.168.60.60
 IP4.WINS[2]:192.168.63.92
-DHCP4.OPTION[1]:dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:dhcp-4-opt-5 = val-5
 IP6.ADDRESS[1]:2001:a::88ca:3654:96b:ab44/89
 IP6.GATEWAY:
 IP6.ROUTE[1]:dst = 2001:a::cc8b:7c09:4673:bbb0/85, nh = ::, mt = 2821465568
@@ -14764,14 +14522,15 @@ IP6.ROUTE[2]:dst = 2001:a::a976:2488:f49f:b48/106, nh = 2001:a::62ae:c734:fc7b:e
 IP6.ROUTE[3]:dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::
 IP6.DNS[1]:2001:a::2934:bd66:550d:ec19
 IP6.DOMAIN[1]:sear6.fo.x.y
-DHCP6.OPTION[1]:dhcp-6-opt-2 = val-2
-DHCP6.OPTION[2]:dhcp-6-opt-6 = val-6
-DHCP6.OPTION[3]:dhcp-6-opt-7 = val-7
-DHCP6.OPTION[4]:dhcp-6-opt-8 = val-8
-DHCP6.OPTION[5]:dhcp-6-opt-9 = val-9
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{2}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
+<<<
+size: 11937
+location: clients/tests/test-client.py:1050:test_004()/223
+cmd: $NMCLI --terse -f all dev show
+lang: C
+returncode: 0
+stdout: 11791 bytes
+>>>
 GENERAL.DEVICE:wlan0
 GENERAL.TYPE:wifi
 GENERAL.NM-TYPE:NMDeviceWifi
@@ -14864,6 +14623,295 @@ DHCP6.OPTION[5]:dhcp-6-opt-5 = val-5
 CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{2}
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
+GENERAL.DEVICE:eth0
+GENERAL.TYPE:ethernet
+GENERAL.NM-TYPE:NMDeviceEthernet
+GENERAL.VENDOR:
+GENERAL.PRODUCT:
+GENERAL.DRIVER:virtual
+GENERAL.DRIVER-VERSION:
+GENERAL.FIRMWARE-VERSION:
+GENERAL.HWADDR:AB:B7:BF:E2:48:E8
+GENERAL.MTU:0
+GENERAL.STATE:20 (unavailable)
+GENERAL.REASON:0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:0 (unknown)
+GENERAL.IP6-CONNECTIVITY:0 (unknown)
+GENERAL.UDI:/sys/devices/virtual/eth0
+GENERAL.IP-IFACE:
+GENERAL.IS-SOFTWARE:no
+GENERAL.NM-MANAGED:yes
+GENERAL.AUTOCONNECT:yes
+GENERAL.FIRMWARE-MISSING:no
+GENERAL.NM-PLUGIN-MISSING:no
+GENERAL.PHYS-PORT-ID:
+GENERAL.CONNECTION:
+GENERAL.CON-UUID:
+GENERAL.CON-PATH:
+GENERAL.METERED:unknown
+CAPABILITIES.CARRIER-DETECT:no
+CAPABILITIES.SPEED:100 Mb/s
+CAPABILITIES.IS-SOFTWARE:no
+CAPABILITIES.SRIOV:no
+WIRED-PROPERTIES.CARRIER:off
+IP4.ADDRESS[1]:192.168.49.34/22
+IP4.ADDRESS[2]:192.168.135.86/19
+IP4.GATEWAY:
+IP4.DNS[1]:192.168.45.230
+IP4.DNS[2]:192.168.180.201
+IP4.DNS[3]:192.168.253.2
+IP4.DOMAIN[1]:sear4.foo2.bar
+IP4.DOMAIN[2]:sear4.foo1.bar
+IP4.WINS[1]:192.168.163.23
+IP4.WINS[2]:192.168.151.246
+DHCP4.OPTION[1]:dhcp-4-opt-8 = val-8
+DHCP4.OPTION[2]:dhcp-4-opt-9 = val-9
+IP6.ADDRESS[1]:2001:a::ed81:3d7:c2e9:df82/99
+IP6.GATEWAY:
+IP6.DNS[1]:2001:a::2703:f06:9619:d89f
+IP6.DNS[2]:2001:a::3a75:3682:c683:8541
+IP6.DNS[3]:2001:a::584e:912:d5ee:c74f
+IP6.DOMAIN[1]:sear6.foo4.bar
+IP6.DOMAIN[2]:sear6.fo.o.bar
+DHCP6.OPTION[1]:dhcp-6-opt-0 = val-0
+DHCP6.OPTION[2]:dhcp-6-opt-1 = val-1
+DHCP6.OPTION[3]:dhcp-6-opt-2 = val-2
+DHCP6.OPTION[4]:dhcp-6-opt-3 = val-3
+DHCP6.OPTION[5]:dhcp-6-opt-4 = val-4
+DHCP6.OPTION[6]:dhcp-6-opt-5 = val-5
+DHCP6.OPTION[7]:dhcp-6-opt-6 = val-6
+DHCP6.OPTION[8]:dhcp-6-opt-7 = val-7
+DHCP6.OPTION[9]:dhcp-6-opt-8 = val-8
+DHCP6.OPTION[10]:dhcp-6-opt-9 = val-9
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{1}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:5fcfd6d7-1e63-3332-8826-a7eda103792d | con-1
+
+GENERAL.DEVICE:eth1
+GENERAL.TYPE:ethernet
+GENERAL.NM-TYPE:NMDeviceEthernet
+GENERAL.VENDOR:
+GENERAL.PRODUCT:
+GENERAL.DRIVER:virtual
+GENERAL.DRIVER-VERSION:
+GENERAL.FIRMWARE-VERSION:
+GENERAL.HWADDR:E7:78:B1:93:2B:22
+GENERAL.MTU:0
+GENERAL.STATE:20 (unavailable)
+GENERAL.REASON:0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:0 (unknown)
+GENERAL.IP6-CONNECTIVITY:0 (unknown)
+GENERAL.UDI:/sys/devices/virtual/eth1
+GENERAL.IP-IFACE:
+GENERAL.IS-SOFTWARE:no
+GENERAL.NM-MANAGED:yes
+GENERAL.AUTOCONNECT:yes
+GENERAL.FIRMWARE-MISSING:no
+GENERAL.NM-PLUGIN-MISSING:no
+GENERAL.PHYS-PORT-ID:
+GENERAL.CONNECTION:
+GENERAL.CON-UUID:
+GENERAL.CON-PATH:
+GENERAL.METERED:unknown
+CAPABILITIES.CARRIER-DETECT:no
+CAPABILITIES.SPEED:100 Mb/s
+CAPABILITIES.IS-SOFTWARE:no
+CAPABILITIES.SRIOV:no
+WIRED-PROPERTIES.CARRIER:off
+IP4.ADDRESS[1]:192.168.127.210/25
+IP4.GATEWAY:192.168.88.4
+IP4.ROUTE[1]:dst = 192.168.222.35/19, nh = 192.168.170.142, mt = 3609264321
+IP4.ROUTE[2]:dst = 192.168.135.81/32, nh = 192.168.32.11, mt = 1316413247
+IP4.ROUTE[3]:dst = 192.168.24.65/26, nh = 192.168.23.163, mt = 3855574583
+IP4.DNS[1]:192.168.16.144
+IP4.DNS[2]:192.168.79.53
+IP4.DNS[3]:192.168.237.155
+IP4.DOMAIN[1]:sear4.foo4.bar
+IP4.DOMAIN[2]:sear4.foo3.bar
+IP4.DOMAIN[3]:sear4.foo1.bar
+IP4.WINS[1]:192.168.211.91
+IP4.WINS[2]:192.168.58.182
+IP4.WINS[3]:192.168.114.97
+DHCP4.OPTION[1]:dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:dhcp-4-opt-1 = val-1
+DHCP4.OPTION[3]:dhcp-4-opt-2 = val-2
+DHCP4.OPTION[4]:dhcp-4-opt-3 = val-3
+DHCP4.OPTION[5]:dhcp-4-opt-4 = val-4
+DHCP4.OPTION[6]:dhcp-4-opt-5 = val-5
+DHCP4.OPTION[7]:dhcp-4-opt-7 = val-7
+DHCP4.OPTION[8]:dhcp-4-opt-8 = val-8
+DHCP4.OPTION[9]:dhcp-4-opt-9 = val-9
+IP6.ADDRESS[1]:2001:a::1c1:c178:169f:2b80/93
+IP6.ADDRESS[2]:2001:a::1f79:e0fb:87b9:3cc6/123
+IP6.GATEWAY:
+IP6.ROUTE[1]:dst = 2001:a::3166:7ed1:e4ae:7612/123, nh = ::
+IP6.DNS[1]:2001:a::edda:955:dcf4:23d4
+IP6.DNS[2]:2001:a::109f:aa0f:fb4a:9d5a
+IP6.DNS[3]:2001:a::61cf:7c82:e9c0:c952
+IP6.DOMAIN[1]:sear6.foo1.bar
+DHCP6.OPTION[1]:dhcp-6-opt-2 = val-2
+DHCP6.OPTION[2]:dhcp-6-opt-5 = val-5
+DHCP6.OPTION[3]:dhcp-6-opt-6 = val-6
+DHCP6.OPTION[4]:dhcp-6-opt-8 = val-8
+DHCP6.OPTION[5]:dhcp-6-opt-9 = val-9
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{1}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:5fcfd6d7-1e63-3332-8826-a7eda103792d | con-1
+
+GENERAL.DEVICE:wlan1
+GENERAL.TYPE:wifi
+GENERAL.NM-TYPE:NMDeviceWifi
+GENERAL.VENDOR:
+GENERAL.PRODUCT:
+GENERAL.DRIVER:virtual
+GENERAL.DRIVER-VERSION:
+GENERAL.FIRMWARE-VERSION:
+GENERAL.HWADDR:21:E9:64:81:8C:A8
+GENERAL.MTU:0
+GENERAL.STATE:20 (unavailable)
+GENERAL.REASON:0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:0 (unknown)
+GENERAL.IP6-CONNECTIVITY:0 (unknown)
+GENERAL.UDI:/sys/devices/virtual/wlan1
+GENERAL.IP-IFACE:
+GENERAL.IS-SOFTWARE:no
+GENERAL.NM-MANAGED:yes
+GENERAL.AUTOCONNECT:yes
+GENERAL.FIRMWARE-MISSING:no
+GENERAL.NM-PLUGIN-MISSING:no
+GENERAL.PHYS-PORT-ID:
+GENERAL.CONNECTION:
+GENERAL.CON-UUID:
+GENERAL.CON-PATH:
+GENERAL.METERED:unknown
+CAPABILITIES.CARRIER-DETECT:no
+CAPABILITIES.SPEED:unknown
+CAPABILITIES.IS-SOFTWARE:no
+CAPABILITIES.SRIOV:no
+WIFI-PROPERTIES.WEP:yes
+WIFI-PROPERTIES.WPA:yes
+WIFI-PROPERTIES.WPA2:yes
+WIFI-PROPERTIES.TKIP:yes
+WIFI-PROPERTIES.CCMP:yes
+WIFI-PROPERTIES.AP:yes
+WIFI-PROPERTIES.ADHOC:yes
+WIFI-PROPERTIES.2GHZ:unknown
+WIFI-PROPERTIES.5GHZ:unknown
+AP[1].IN-USE: 
+AP[1].SSID:wlan1-ap-4
+AP[1].MODE:Infra
+AP[1].CHAN:1
+AP[1].RATE:54 Mbit/s
+AP[1].SIGNAL:48
+AP[1].BARS:**  
+AP[1].SECURITY:WPA1 WPA2
+IP4.GATEWAY:192.168.57.160
+IP4.ROUTE[1]:dst = 192.168.36.106/21, nh = 192.168.199.128, mt = 979274165
+IP4.ROUTE[2]:dst = 192.168.238.130/19, nh = 0.0.0.0
+IP4.ROUTE[3]:dst = 192.168.224.39/32, nh = 192.168.148.69
+IP4.DNS[1]:192.168.61.83
+IP4.DOMAIN[1]:sear4.foo4.bar
+IP4.DOMAIN[2]:sear4.fo.x.y
+IP4.DOMAIN[3]:sear4.foo2.bar
+IP4.DOMAIN[4]:sear4.foo1.bar
+IP4.DOMAIN[5]:sear4.fo.o.bar
+IP4.DOMAIN[6]:sear4.foo3.bar
+DHCP4.OPTION[1]:dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:dhcp-4-opt-1 = val-1
+DHCP4.OPTION[3]:dhcp-4-opt-2 = val-2
+DHCP4.OPTION[4]:dhcp-4-opt-4 = val-4
+DHCP4.OPTION[5]:dhcp-4-opt-6 = val-6
+DHCP4.OPTION[6]:dhcp-4-opt-7 = val-7
+DHCP4.OPTION[7]:dhcp-4-opt-8 = val-8
+DHCP4.OPTION[8]:dhcp-4-opt-9 = val-9
+IP6.ADDRESS[1]:2001:a::fa05:2ab4:9300:e8fe/116
+IP6.ADDRESS[2]:2001:a::e9cf:bd3:caba:99b3/86
+IP6.ADDRESS[3]:2001:a::2be6:44fa:2c95:5559/78
+IP6.GATEWAY:2001:a::4d70:d91a:770f:2319
+IP6.ROUTE[1]:dst = 2001:a::3cb2:719d:bb00:b22f/66, nh = 2001:a::81b1:58b9:7237:3511, mt = 2280277732
+IP6.ROUTE[2]:dst = 2001:a::986f:983c:5eb:1c7d/99, nh = ::, mt = 1204008676
+IP6.DNS[1]:2001:a::85e7:3d7d:53e8:50ac
+IP6.DNS[2]:2001:a::1c5:9cb5:e86d:25a5
+IP6.DOMAIN[1]:sear6.foo4.bar
+IP6.DOMAIN[2]:sear6.foo2.bar
+DHCP6.OPTION[1]:dhcp-6-opt-0 = val-0
+DHCP6.OPTION[2]:dhcp-6-opt-1 = val-1
+DHCP6.OPTION[3]:dhcp-6-opt-2 = val-2
+DHCP6.OPTION[4]:dhcp-6-opt-3 = val-3
+DHCP6.OPTION[5]:dhcp-6-opt-4 = val-4
+DHCP6.OPTION[6]:dhcp-6-opt-5 = val-5
+DHCP6.OPTION[7]:dhcp-6-opt-6 = val-6
+DHCP6.OPTION[8]:dhcp-6-opt-7 = val-7
+DHCP6.OPTION[9]:dhcp-6-opt-9 = val-9
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{2}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
+
+GENERAL.DEVICE:wlan1
+GENERAL.TYPE:wifi
+GENERAL.NM-TYPE:NMDeviceWifi
+GENERAL.VENDOR:
+GENERAL.PRODUCT:
+GENERAL.DRIVER:virtual
+GENERAL.DRIVER-VERSION:
+GENERAL.FIRMWARE-VERSION:
+GENERAL.HWADDR:71:52:AD:63:5C:7C
+GENERAL.MTU:0
+GENERAL.STATE:20 (unavailable)
+GENERAL.REASON:0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:0 (unknown)
+GENERAL.IP6-CONNECTIVITY:0 (unknown)
+GENERAL.UDI:/sys/devices/virtual/wlan1
+GENERAL.IP-IFACE:
+GENERAL.IS-SOFTWARE:no
+GENERAL.NM-MANAGED:yes
+GENERAL.AUTOCONNECT:yes
+GENERAL.FIRMWARE-MISSING:no
+GENERAL.NM-PLUGIN-MISSING:no
+GENERAL.PHYS-PORT-ID:
+GENERAL.CONNECTION:
+GENERAL.CON-UUID:
+GENERAL.CON-PATH:
+GENERAL.METERED:unknown
+CAPABILITIES.CARRIER-DETECT:no
+CAPABILITIES.SPEED:unknown
+CAPABILITIES.IS-SOFTWARE:no
+CAPABILITIES.SRIOV:no
+WIFI-PROPERTIES.WEP:yes
+WIFI-PROPERTIES.WPA:yes
+WIFI-PROPERTIES.WPA2:yes
+WIFI-PROPERTIES.TKIP:yes
+WIFI-PROPERTIES.CCMP:yes
+WIFI-PROPERTIES.AP:yes
+WIFI-PROPERTIES.ADHOC:yes
+WIFI-PROPERTIES.2GHZ:unknown
+WIFI-PROPERTIES.5GHZ:unknown
+IP4.ADDRESS[1]:192.168.97.124/29
+IP4.ADDRESS[2]:192.168.76.154/18
+IP4.GATEWAY:
+IP4.ROUTE[1]:dst = 192.168.33.233/22, nh = 192.168.222.210, mt = 2810496551
+IP4.DNS[1]:192.168.107.109
+IP4.DOMAIN[1]:sear4.fo.o.bar
+IP4.DOMAIN[2]:sear4.fo.x.y
+IP4.DOMAIN[3]:sear4.foo2.bar
+IP4.DOMAIN[4]:sear4.foo3.bar
+IP4.DOMAIN[5]:sear4.foo4.bar
+IP4.WINS[1]:192.168.60.60
+IP4.WINS[2]:192.168.63.92
+DHCP4.OPTION[1]:dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:dhcp-4-opt-5 = val-5
+IP6.ADDRESS[1]:2001:a::88ca:3654:96b:ab44/89
+IP6.GATEWAY:
+IP6.ROUTE[1]:dst = 2001:a::cc8b:7c09:4673:bbb0/85, nh = ::, mt = 2821465568
+IP6.ROUTE[2]:dst = 2001:a::a976:2488:f49f:b48/106, nh = 2001:a::62ae:c734:fc7b:e931, mt = 2248613879
+IP6.ROUTE[3]:dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::
+IP6.DNS[1]:2001:a::2934:bd66:550d:ec19
+IP6.DOMAIN[1]:sear6.fo.x.y
+DHCP6.OPTION[1]:dhcp-6-opt-2 = val-2
+DHCP6.OPTION[2]:dhcp-6-opt-6 = val-6
+DHCP6.OPTION[3]:dhcp-6-opt-7 = val-7
+DHCP6.OPTION[4]:dhcp-6-opt-8 = val-8
+DHCP6.OPTION[5]:dhcp-6-opt-9 = val-9
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{2}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
+
 <<<
 size: 11993
 location: clients/tests/test-client.py:1050:test_004()/224
@@ -14872,6 +14920,98 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 11837 bytes
 >>>
+GENERAL.DEVICE:wlan0
+GENERAL.TYPE:wifi
+GENERAL.NM-TYPE:NMDeviceWifi
+GENERAL.VENDOR:
+GENERAL.PRODUCT:
+GENERAL.DRIVER:virtual
+GENERAL.DRIVER-VERSION:
+GENERAL.FIRMWARE-VERSION:
+GENERAL.HWADDR:13:E0:74:85:7C:D9
+GENERAL.MTU:0
+GENERAL.STATE:20 (unavailable)
+GENERAL.REASON:0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:0 (nieznane)
+GENERAL.IP6-CONNECTIVITY:0 (nieznane)
+GENERAL.UDI:/sys/devices/virtual/wlan0
+GENERAL.IP-IFACE:
+GENERAL.IS-SOFTWARE:no
+GENERAL.NM-MANAGED:yes
+GENERAL.AUTOCONNECT:yes
+GENERAL.FIRMWARE-MISSING:no
+GENERAL.NM-PLUGIN-MISSING:no
+GENERAL.PHYS-PORT-ID:
+GENERAL.CONNECTION:con-vpn-1
+GENERAL.CON-UUID:UUID-con-vpn-1-REPLACED-REPLACED-REP
+GENERAL.CON-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
+GENERAL.METERED:unknown
+CAPABILITIES.CARRIER-DETECT:no
+CAPABILITIES.SPEED:unknown
+CAPABILITIES.IS-SOFTWARE:no
+CAPABILITIES.SRIOV:no
+WIFI-PROPERTIES.WEP:yes
+WIFI-PROPERTIES.WPA:yes
+WIFI-PROPERTIES.WPA2:yes
+WIFI-PROPERTIES.TKIP:yes
+WIFI-PROPERTIES.CCMP:yes
+WIFI-PROPERTIES.AP:yes
+WIFI-PROPERTIES.ADHOC:yes
+WIFI-PROPERTIES.2GHZ:unknown
+WIFI-PROPERTIES.5GHZ:unknown
+AP[1].IN-USE: 
+AP[1].SSID:wlan0-ap-2
+AP[1].MODE:Infrastruktura
+AP[1].CHAN:1
+AP[1].RATE:54 Mb/s
+AP[1].SIGNAL:92
+AP[1].BARS:****
+AP[1].SECURITY:WPA1 WPA2
+AP[2].IN-USE: 
+AP[2].SSID:wlan0-ap-1
+AP[2].MODE:Infrastruktura
+AP[2].CHAN:1
+AP[2].RATE:54 Mb/s
+AP[2].SIGNAL:81
+AP[2].BARS:****
+AP[2].SECURITY:WPA1 WPA2
+AP[3].IN-USE: 
+AP[3].SSID:wlan0-ap-3
+AP[3].MODE:Infrastruktura
+AP[3].CHAN:1
+AP[3].RATE:54 Mb/s
+AP[3].SIGNAL:55
+AP[3].BARS:**  
+AP[3].SECURITY:WPA1 WPA2
+IP4.ADDRESS[1]:192.168.228.18/32
+IP4.ADDRESS[2]:192.168.209.179/25
+IP4.GATEWAY:192.168.41.120
+IP4.DOMAIN[1]:sear4.foo2.bar
+IP4.DOMAIN[2]:sear4.fo.x.y
+IP4.DOMAIN[3]:sear4.foo1.bar
+IP4.DOMAIN[4]:sear4.foo4.bar
+IP4.DOMAIN[5]:sear4.fo.o.bar
+IP4.WINS[1]:192.168.120.79
+DHCP4.OPTION[1]:dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:dhcp-4-opt-2 = val-2
+DHCP4.OPTION[3]:dhcp-4-opt-4 = val-4
+DHCP4.OPTION[4]:dhcp-4-opt-7 = val-7
+IP6.GATEWAY:
+IP6.ROUTE[1]:dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
+IP6.DOMAIN[1]:sear6.foo2.bar
+IP6.DOMAIN[2]:sear6.foo1.bar
+IP6.DOMAIN[3]:sear6.fo.x.y
+IP6.DOMAIN[4]:sear6.fo.o.bar
+IP6.DOMAIN[5]:sear6.foo3.bar
+IP6.DOMAIN[6]:sear6.foo4.bar
+DHCP6.OPTION[1]:dhcp-6-opt-1 = val-1
+DHCP6.OPTION[2]:dhcp-6-opt-2 = val-2
+DHCP6.OPTION[3]:dhcp-6-opt-3 = val-3
+DHCP6.OPTION[4]:dhcp-6-opt-4 = val-4
+DHCP6.OPTION[5]:dhcp-6-opt-5 = val-5
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{2}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
+
 GENERAL.DEVICE:eth0
 GENERAL.TYPE:ethernet
 GENERAL.NM-TYPE:NMDeviceEthernet
@@ -15158,98 +15298,6 @@ DHCP6.OPTION[2]:dhcp-6-opt-6 = val-6
 DHCP6.OPTION[3]:dhcp-6-opt-7 = val-7
 DHCP6.OPTION[4]:dhcp-6-opt-8 = val-8
 DHCP6.OPTION[5]:dhcp-6-opt-9 = val-9
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{2}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
-
-GENERAL.DEVICE:wlan0
-GENERAL.TYPE:wifi
-GENERAL.NM-TYPE:NMDeviceWifi
-GENERAL.VENDOR:
-GENERAL.PRODUCT:
-GENERAL.DRIVER:virtual
-GENERAL.DRIVER-VERSION:
-GENERAL.FIRMWARE-VERSION:
-GENERAL.HWADDR:13:E0:74:85:7C:D9
-GENERAL.MTU:0
-GENERAL.STATE:20 (unavailable)
-GENERAL.REASON:0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:0 (nieznane)
-GENERAL.IP6-CONNECTIVITY:0 (nieznane)
-GENERAL.UDI:/sys/devices/virtual/wlan0
-GENERAL.IP-IFACE:
-GENERAL.IS-SOFTWARE:no
-GENERAL.NM-MANAGED:yes
-GENERAL.AUTOCONNECT:yes
-GENERAL.FIRMWARE-MISSING:no
-GENERAL.NM-PLUGIN-MISSING:no
-GENERAL.PHYS-PORT-ID:
-GENERAL.CONNECTION:con-vpn-1
-GENERAL.CON-UUID:UUID-con-vpn-1-REPLACED-REPLACED-REP
-GENERAL.CON-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
-GENERAL.METERED:unknown
-CAPABILITIES.CARRIER-DETECT:no
-CAPABILITIES.SPEED:unknown
-CAPABILITIES.IS-SOFTWARE:no
-CAPABILITIES.SRIOV:no
-WIFI-PROPERTIES.WEP:yes
-WIFI-PROPERTIES.WPA:yes
-WIFI-PROPERTIES.WPA2:yes
-WIFI-PROPERTIES.TKIP:yes
-WIFI-PROPERTIES.CCMP:yes
-WIFI-PROPERTIES.AP:yes
-WIFI-PROPERTIES.ADHOC:yes
-WIFI-PROPERTIES.2GHZ:unknown
-WIFI-PROPERTIES.5GHZ:unknown
-AP[1].IN-USE: 
-AP[1].SSID:wlan0-ap-2
-AP[1].MODE:Infrastruktura
-AP[1].CHAN:1
-AP[1].RATE:54 Mb/s
-AP[1].SIGNAL:92
-AP[1].BARS:****
-AP[1].SECURITY:WPA1 WPA2
-AP[2].IN-USE: 
-AP[2].SSID:wlan0-ap-1
-AP[2].MODE:Infrastruktura
-AP[2].CHAN:1
-AP[2].RATE:54 Mb/s
-AP[2].SIGNAL:81
-AP[2].BARS:****
-AP[2].SECURITY:WPA1 WPA2
-AP[3].IN-USE: 
-AP[3].SSID:wlan0-ap-3
-AP[3].MODE:Infrastruktura
-AP[3].CHAN:1
-AP[3].RATE:54 Mb/s
-AP[3].SIGNAL:55
-AP[3].BARS:**  
-AP[3].SECURITY:WPA1 WPA2
-IP4.ADDRESS[1]:192.168.228.18/32
-IP4.ADDRESS[2]:192.168.209.179/25
-IP4.GATEWAY:192.168.41.120
-IP4.DOMAIN[1]:sear4.foo2.bar
-IP4.DOMAIN[2]:sear4.fo.x.y
-IP4.DOMAIN[3]:sear4.foo1.bar
-IP4.DOMAIN[4]:sear4.foo4.bar
-IP4.DOMAIN[5]:sear4.fo.o.bar
-IP4.WINS[1]:192.168.120.79
-DHCP4.OPTION[1]:dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:dhcp-4-opt-2 = val-2
-DHCP4.OPTION[3]:dhcp-4-opt-4 = val-4
-DHCP4.OPTION[4]:dhcp-4-opt-7 = val-7
-IP6.GATEWAY:
-IP6.ROUTE[1]:dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
-IP6.DOMAIN[1]:sear6.foo2.bar
-IP6.DOMAIN[2]:sear6.foo1.bar
-IP6.DOMAIN[3]:sear6.fo.x.y
-IP6.DOMAIN[4]:sear6.fo.o.bar
-IP6.DOMAIN[5]:sear6.foo3.bar
-IP6.DOMAIN[6]:sear6.foo4.bar
-DHCP6.OPTION[1]:dhcp-6-opt-1 = val-1
-DHCP6.OPTION[2]:dhcp-6-opt-2 = val-2
-DHCP6.OPTION[3]:dhcp-6-opt-3 = val-3
-DHCP6.OPTION[4]:dhcp-6-opt-4 = val-4
-DHCP6.OPTION[5]:dhcp-6-opt-5 = val-5
 CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{2}
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
@@ -15707,11 +15755,11 @@ lang: C
 returncode: 0
 stdout: 271 bytes
 >>>
+wlan0:wifi:/org/freedesktop/NetworkManager/Devices/3
 eth0:ethernet:/org/freedesktop/NetworkManager/Devices/1
 eth1:ethernet:/org/freedesktop/NetworkManager/Devices/2
 wlan1:wifi:/org/freedesktop/NetworkManager/Devices/4
 wlan1:wifi:/org/freedesktop/NetworkManager/Devices/5
-wlan0:wifi:/org/freedesktop/NetworkManager/Devices/3
 
 <<<
 size: 438
@@ -15721,11 +15769,11 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 271 bytes
 >>>
+wlan0:wifi:/org/freedesktop/NetworkManager/Devices/3
 eth0:ethernet:/org/freedesktop/NetworkManager/Devices/1
 eth1:ethernet:/org/freedesktop/NetworkManager/Devices/2
 wlan1:wifi:/org/freedesktop/NetworkManager/Devices/4
 wlan1:wifi:/org/freedesktop/NetworkManager/Devices/5
-wlan0:wifi:/org/freedesktop/NetworkManager/Devices/3
 
 <<<
 size: 1175
@@ -15735,12 +15783,12 @@ lang: C
 returncode: 0
 stdout: 1022 bytes
 >>>
-AP[1]:wlan1-ap-4:776C616E312D61702D34:94\:2B\:E8\:F6\:D2\:86:Infra:1:2412 MHz:54 Mbit/s:48:**  :WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan1:no: :/org/freedesktop/NetworkManager/AccessPoint/4
-
-
 AP[1]:wlan0-ap-2:776C616E302D61702D32:C0\:E2\:BE\:E8\:EF\:B6:Infra:1:2412 MHz:54 Mbit/s:92:****:WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:no: :/org/freedesktop/NetworkManager/AccessPoint/2
 AP[2]:wlan0-ap-1:776C616E302D61702D31:61\:95\:77\:AC\:1E\:4C:Infra:1:2412 MHz:54 Mbit/s:81:****:WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:no: :/org/freedesktop/NetworkManager/AccessPoint/1
 AP[3]:wlan0-ap-3:776C616E302D61702D33:9B\:F6\:B7\:EC\:97\:76:Infra:1:2412 MHz:54 Mbit/s:55:**  :WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:no: :/org/freedesktop/NetworkManager/AccessPoint/3
+
+AP[1]:wlan1-ap-4:776C616E312D61702D34:94\:2B\:E8\:F6\:D2\:86:Infra:1:2412 MHz:54 Mbit/s:48:**  :WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan1:no: :/org/freedesktop/NetworkManager/AccessPoint/4
+
 
 <<<
 size: 1233
@@ -15750,12 +15798,12 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 1070 bytes
 >>>
-AP[1]:wlan1-ap-4:776C616E312D61702D34:94\:2B\:E8\:F6\:D2\:86:Infrastruktura:1:2412 MHz:54 Mb/s:48:**  :WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan1:nie: :/org/freedesktop/NetworkManager/AccessPoint/4
-
-
 AP[1]:wlan0-ap-2:776C616E302D61702D32:C0\:E2\:BE\:E8\:EF\:B6:Infrastruktura:1:2412 MHz:54 Mb/s:92:****:WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:nie: :/org/freedesktop/NetworkManager/AccessPoint/2
 AP[2]:wlan0-ap-1:776C616E302D61702D31:61\:95\:77\:AC\:1E\:4C:Infrastruktura:1:2412 MHz:54 Mb/s:81:****:WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:nie: :/org/freedesktop/NetworkManager/AccessPoint/1
 AP[3]:wlan0-ap-3:776C616E302D61702D33:9B\:F6\:B7\:EC\:97\:76:Infrastruktura:1:2412 MHz:54 Mb/s:55:**  :WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:nie: :/org/freedesktop/NetworkManager/AccessPoint/3
+
+AP[1]:wlan1-ap-4:776C616E312D61702D34:94\:2B\:E8\:F6\:D2\:86:Infrastruktura:1:2412 MHz:54 Mb/s:48:**  :WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan1:nie: :/org/freedesktop/NetworkManager/AccessPoint/4
+
 
 <<<
 size: 353
@@ -15765,12 +15813,12 @@ lang: C
 returncode: 0
 stdout: 198 bytes
 >>>
- :wlan1-ap-4:Infra:1:54 Mbit/s:48:**  :WPA1 WPA2
-
-
  :wlan0-ap-2:Infra:1:54 Mbit/s:92:****:WPA1 WPA2
  :wlan0-ap-1:Infra:1:54 Mbit/s:81:****:WPA1 WPA2
  :wlan0-ap-3:Infra:1:54 Mbit/s:55:**  :WPA1 WPA2
+
+ :wlan1-ap-4:Infra:1:54 Mbit/s:48:**  :WPA1 WPA2
+
 
 <<<
 size: 399
@@ -15780,12 +15828,12 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 234 bytes
 >>>
- :wlan1-ap-4:Infrastruktura:1:54 Mb/s:48:**  :WPA1 WPA2
-
-
  :wlan0-ap-2:Infrastruktura:1:54 Mb/s:92:****:WPA1 WPA2
  :wlan0-ap-1:Infrastruktura:1:54 Mb/s:81:****:WPA1 WPA2
  :wlan0-ap-3:Infrastruktura:1:54 Mb/s:55:**  :WPA1 WPA2
+
+ :wlan1-ap-4:Infrastruktura:1:54 Mb/s:48:**  :WPA1 WPA2
+
 
 <<<
 size: 1288
@@ -15795,12 +15843,12 @@ lang: C
 returncode: 0
 stdout: 1022 bytes
 >>>
-AP[1]:wlan1-ap-4:776C616E312D61702D34:94\:2B\:E8\:F6\:D2\:86:Infra:1:2412 MHz:54 Mbit/s:48:**  :WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan1:no: :/org/freedesktop/NetworkManager/AccessPoint/4
-
-
 AP[1]:wlan0-ap-2:776C616E302D61702D32:C0\:E2\:BE\:E8\:EF\:B6:Infra:1:2412 MHz:54 Mbit/s:92:****:WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:no: :/org/freedesktop/NetworkManager/AccessPoint/2
 AP[2]:wlan0-ap-1:776C616E302D61702D31:61\:95\:77\:AC\:1E\:4C:Infra:1:2412 MHz:54 Mbit/s:81:****:WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:no: :/org/freedesktop/NetworkManager/AccessPoint/1
 AP[3]:wlan0-ap-3:776C616E302D61702D33:9B\:F6\:B7\:EC\:97\:76:Infra:1:2412 MHz:54 Mbit/s:55:**  :WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:no: :/org/freedesktop/NetworkManager/AccessPoint/3
+
+AP[1]:wlan1-ap-4:776C616E312D61702D34:94\:2B\:E8\:F6\:D2\:86:Infra:1:2412 MHz:54 Mbit/s:48:**  :WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan1:no: :/org/freedesktop/NetworkManager/AccessPoint/4
+
 
 <<<
 size: 1346
@@ -15810,72 +15858,84 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 1070 bytes
 >>>
-AP[1]:wlan1-ap-4:776C616E312D61702D34:94\:2B\:E8\:F6\:D2\:86:Infrastruktura:1:2412 MHz:54 Mb/s:48:**  :WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan1:nie: :/org/freedesktop/NetworkManager/AccessPoint/4
-
-
 AP[1]:wlan0-ap-2:776C616E302D61702D32:C0\:E2\:BE\:E8\:EF\:B6:Infrastruktura:1:2412 MHz:54 Mb/s:92:****:WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:nie: :/org/freedesktop/NetworkManager/AccessPoint/2
 AP[2]:wlan0-ap-1:776C616E302D61702D31:61\:95\:77\:AC\:1E\:4C:Infrastruktura:1:2412 MHz:54 Mb/s:81:****:WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:nie: :/org/freedesktop/NetworkManager/AccessPoint/1
 AP[3]:wlan0-ap-3:776C616E302D61702D33:9B\:F6\:B7\:EC\:97\:76:Infrastruktura:1:2412 MHz:54 Mb/s:55:**  :WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:nie: :/org/freedesktop/NetworkManager/AccessPoint/3
 
+AP[1]:wlan1-ap-4:776C616E312D61702D34:94\:2B\:E8\:F6\:D2\:86:Infrastruktura:1:2412 MHz:54 Mb/s:48:**  :WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan1:nie: :/org/freedesktop/NetworkManager/AccessPoint/4
+
+
 <<<
-size: 431
+size: 433
 location: clients/tests/test-client.py:1075:test_004()/241
 cmd: $NMCLI --terse -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 255 bytes
+stdout: 257 bytes
 >>>
 AP[1]:wlan0-ap-2:776C616E302D61702D32:C0\:E2\:BE\:E8\:EF\:B6:Infra:1:2412 MHz:54 Mbit/s:92:****:WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:no: :/org/freedesktop/NetworkManager/AccessPoint/2
 
+
+
 <<<
-size: 453
+size: 455
 location: clients/tests/test-client.py:1075:test_004()/242
 cmd: $NMCLI --terse -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 267 bytes
+stdout: 269 bytes
 >>>
 AP[1]:wlan0-ap-2:776C616E302D61702D32:C0\:E2\:BE\:E8\:EF\:B6:Infrastruktura:1:2412 MHz:54 Mb/s:92:****:WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:nie: :/org/freedesktop/NetworkManager/AccessPoint/2
 
+
+
 <<<
-size: 227
+size: 229
 location: clients/tests/test-client.py:1077:test_004()/243
 cmd: $NMCLI --terse -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 49 bytes
+stdout: 51 bytes
 >>>
  :wlan0-ap-2:Infra:1:54 Mbit/s:92:****:WPA1 WPA2
 
+
+
 <<<
-size: 246
+size: 248
 location: clients/tests/test-client.py:1077:test_004()/244
 cmd: $NMCLI --terse -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 58 bytes
+stdout: 60 bytes
 >>>
  :wlan0-ap-2:Infrastruktura:1:54 Mb/s:92:****:WPA1 WPA2
 
+
+
 <<<
-size: 544
+size: 546
 location: clients/tests/test-client.py:1080:test_004()/245
 cmd: $NMCLI --terse -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 255 bytes
+stdout: 257 bytes
 >>>
 AP[1]:wlan0-ap-2:776C616E302D61702D32:C0\:E2\:BE\:E8\:EF\:B6:Infra:1:2412 MHz:54 Mbit/s:92:****:WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:no: :/org/freedesktop/NetworkManager/AccessPoint/2
 
+
+
 <<<
-size: 566
+size: 568
 location: clients/tests/test-client.py:1080:test_004()/246
 cmd: $NMCLI --terse -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 267 bytes
+stdout: 269 bytes
 >>>
 AP[1]:wlan0-ap-2:776C616E302D61702D32:C0\:E2\:BE\:E8\:EF\:B6:Infrastruktura:1:2412 MHz:54 Mb/s:92:****:WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:nie: :/org/freedesktop/NetworkManager/AccessPoint/2
+
+
 
 <<<
 size: 2706
@@ -16995,11 +17055,11 @@ lang: C
 returncode: 0
 stdout: 295 bytes
 >>>
+[2mwlan0[0m:[2mwifi[0m:[2munavailable[0m:[2mcon-vpn-1[0m
 [2meth0[0m:[2methernet[0m:[2munavailable[0m:[2m[0m
 [2meth1[0m:[2methernet[0m:[2munavailable[0m:[2m[0m
 [2mwlan1[0m:[2mwifi[0m:[2munavailable[0m:[2m[0m
 [2mwlan1[0m:[2mwifi[0m:[2munavailable[0m:[2m[0m
-[2mwlan0[0m:[2mwifi[0m:[2munavailable[0m:[2mcon-vpn-1[0m
 
 <<<
 size: 451
@@ -17009,11 +17069,11 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 295 bytes
 >>>
+[2mwlan0[0m:[2mwifi[0m:[2munavailable[0m:[2mcon-vpn-1[0m
 [2meth0[0m:[2methernet[0m:[2munavailable[0m:[2m[0m
 [2meth1[0m:[2methernet[0m:[2munavailable[0m:[2m[0m
 [2mwlan1[0m:[2mwifi[0m:[2munavailable[0m:[2m[0m
 [2mwlan1[0m:[2mwifi[0m:[2munavailable[0m:[2m[0m
-[2mwlan0[0m:[2mwifi[0m:[2munavailable[0m:[2mcon-vpn-1[0m
 
 <<<
 size: 1039
@@ -17023,11 +17083,11 @@ lang: C
 returncode: 0
 stdout: 881 bytes
 >>>
+[2mwlan0[0m:[2mwifi[0m:[2munavailable[0m:[2munknown[0m:[2munknown[0m:[2m/org/freedesktop/NetworkManager/Devices/3[0m:[2mcon-vpn-1[0m:[2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m:[2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
 [2meth0[0m:[2methernet[0m:[2munavailable[0m:[2munknown[0m:[2munknown[0m:[2m/org/freedesktop/NetworkManager/Devices/1[0m:[2m[0m:[2m[0m:[2m[0m
 [2meth1[0m:[2methernet[0m:[2munavailable[0m:[2munknown[0m:[2munknown[0m:[2m/org/freedesktop/NetworkManager/Devices/2[0m:[2m[0m:[2m[0m:[2m[0m
 [2mwlan1[0m:[2mwifi[0m:[2munavailable[0m:[2munknown[0m:[2munknown[0m:[2m/org/freedesktop/NetworkManager/Devices/4[0m:[2m[0m:[2m[0m:[2m[0m
 [2mwlan1[0m:[2mwifi[0m:[2munavailable[0m:[2munknown[0m:[2munknown[0m:[2m/org/freedesktop/NetworkManager/Devices/5[0m:[2m[0m:[2m[0m:[2m[0m
-[2mwlan0[0m:[2mwifi[0m:[2munavailable[0m:[2munknown[0m:[2munknown[0m:[2m/org/freedesktop/NetworkManager/Devices/3[0m:[2mcon-vpn-1[0m:[2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m:[2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
 
 <<<
 size: 1059
@@ -17037,11 +17097,11 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 891 bytes
 >>>
+[2mwlan0[0m:[2mwifi[0m:[2munavailable[0m:[2mnieznane[0m:[2mnieznane[0m:[2m/org/freedesktop/NetworkManager/Devices/3[0m:[2mcon-vpn-1[0m:[2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m:[2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
 [2meth0[0m:[2methernet[0m:[2munavailable[0m:[2mnieznane[0m:[2mnieznane[0m:[2m/org/freedesktop/NetworkManager/Devices/1[0m:[2m[0m:[2m[0m:[2m[0m
 [2meth1[0m:[2methernet[0m:[2munavailable[0m:[2mnieznane[0m:[2mnieznane[0m:[2m/org/freedesktop/NetworkManager/Devices/2[0m:[2m[0m:[2m[0m:[2m[0m
 [2mwlan1[0m:[2mwifi[0m:[2munavailable[0m:[2mnieznane[0m:[2mnieznane[0m:[2m/org/freedesktop/NetworkManager/Devices/4[0m:[2m[0m:[2m[0m:[2m[0m
 [2mwlan1[0m:[2mwifi[0m:[2munavailable[0m:[2mnieznane[0m:[2mnieznane[0m:[2m/org/freedesktop/NetworkManager/Devices/5[0m:[2m[0m:[2m[0m:[2m[0m
-[2mwlan0[0m:[2mwifi[0m:[2munavailable[0m:[2mnieznane[0m:[2mnieznane[0m:[2m/org/freedesktop/NetworkManager/Devices/3[0m:[2mcon-vpn-1[0m:[2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m:[2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
 
 <<<
 size: 4552
@@ -17051,6 +17111,31 @@ lang: C
 returncode: 0
 stdout: 4402 bytes
 >>>
+GENERAL.DEVICE:wlan0
+GENERAL.TYPE:wifi
+GENERAL.HWADDR:13:E0:74:85:7C:D9
+GENERAL.MTU:0
+GENERAL.STATE:20 (unavailable)
+GENERAL.CONNECTION:con-vpn-1
+GENERAL.CON-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
+IP4.ADDRESS[1]:192.168.228.18/32
+IP4.ADDRESS[2]:192.168.209.179/25
+IP4.GATEWAY:192.168.41.120
+IP4.DOMAIN[1]:sear4.foo2.bar
+IP4.DOMAIN[2]:sear4.fo.x.y
+IP4.DOMAIN[3]:sear4.foo1.bar
+IP4.DOMAIN[4]:sear4.foo4.bar
+IP4.DOMAIN[5]:sear4.fo.o.bar
+IP4.WINS[1]:192.168.120.79
+IP6.GATEWAY:
+IP6.ROUTE[1]:dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
+IP6.DOMAIN[1]:sear6.foo2.bar
+IP6.DOMAIN[2]:sear6.foo1.bar
+IP6.DOMAIN[3]:sear6.fo.x.y
+IP6.DOMAIN[4]:sear6.fo.o.bar
+IP6.DOMAIN[5]:sear6.foo3.bar
+IP6.DOMAIN[6]:sear6.foo4.bar
+
 GENERAL.DEVICE:eth0
 GENERAL.TYPE:ethernet
 GENERAL.HWADDR:AB:B7:BF:E2:48:E8
@@ -17163,31 +17248,6 @@ IP6.ROUTE[2]:dst = 2001:a::a976:2488:f49f:b48/106, nh = 2001:a::62ae:c734:fc7b:e
 IP6.ROUTE[3]:dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::
 IP6.DNS[1]:2001:a::2934:bd66:550d:ec19
 IP6.DOMAIN[1]:sear6.fo.x.y
-
-GENERAL.DEVICE:wlan0
-GENERAL.TYPE:wifi
-GENERAL.HWADDR:13:E0:74:85:7C:D9
-GENERAL.MTU:0
-GENERAL.STATE:20 (unavailable)
-GENERAL.CONNECTION:con-vpn-1
-GENERAL.CON-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
-IP4.ADDRESS[1]:192.168.228.18/32
-IP4.ADDRESS[2]:192.168.209.179/25
-IP4.GATEWAY:192.168.41.120
-IP4.DOMAIN[1]:sear4.foo2.bar
-IP4.DOMAIN[2]:sear4.fo.x.y
-IP4.DOMAIN[3]:sear4.foo1.bar
-IP4.DOMAIN[4]:sear4.foo4.bar
-IP4.DOMAIN[5]:sear4.fo.o.bar
-IP4.WINS[1]:192.168.120.79
-IP6.GATEWAY:
-IP6.ROUTE[1]:dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
-IP6.DOMAIN[1]:sear6.foo2.bar
-IP6.DOMAIN[2]:sear6.foo1.bar
-IP6.DOMAIN[3]:sear6.fo.x.y
-IP6.DOMAIN[4]:sear6.fo.o.bar
-IP6.DOMAIN[5]:sear6.foo3.bar
-IP6.DOMAIN[6]:sear6.foo4.bar
 
 <<<
 size: 4562
@@ -17197,6 +17257,31 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 4402 bytes
 >>>
+GENERAL.DEVICE:wlan0
+GENERAL.TYPE:wifi
+GENERAL.HWADDR:13:E0:74:85:7C:D9
+GENERAL.MTU:0
+GENERAL.STATE:20 (unavailable)
+GENERAL.CONNECTION:con-vpn-1
+GENERAL.CON-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
+IP4.ADDRESS[1]:192.168.228.18/32
+IP4.ADDRESS[2]:192.168.209.179/25
+IP4.GATEWAY:192.168.41.120
+IP4.DOMAIN[1]:sear4.foo2.bar
+IP4.DOMAIN[2]:sear4.fo.x.y
+IP4.DOMAIN[3]:sear4.foo1.bar
+IP4.DOMAIN[4]:sear4.foo4.bar
+IP4.DOMAIN[5]:sear4.fo.o.bar
+IP4.WINS[1]:192.168.120.79
+IP6.GATEWAY:
+IP6.ROUTE[1]:dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
+IP6.DOMAIN[1]:sear6.foo2.bar
+IP6.DOMAIN[2]:sear6.foo1.bar
+IP6.DOMAIN[3]:sear6.fo.x.y
+IP6.DOMAIN[4]:sear6.fo.o.bar
+IP6.DOMAIN[5]:sear6.foo3.bar
+IP6.DOMAIN[6]:sear6.foo4.bar
+
 GENERAL.DEVICE:eth0
 GENERAL.TYPE:ethernet
 GENERAL.HWADDR:AB:B7:BF:E2:48:E8
@@ -17310,13 +17395,77 @@ IP6.ROUTE[3]:dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::
 IP6.DNS[1]:2001:a::2934:bd66:550d:ec19
 IP6.DOMAIN[1]:sear6.fo.x.y
 
+<<<
+size: 12237
+location: clients/tests/test-client.py:1050:test_004()/269
+cmd: $NMCLI --terse --color yes -f all dev show
+lang: C
+returncode: 0
+stdout: 12079 bytes
+>>>
 GENERAL.DEVICE:wlan0
 GENERAL.TYPE:wifi
+GENERAL.NM-TYPE:NMDeviceWifi
+GENERAL.VENDOR:
+GENERAL.PRODUCT:
+GENERAL.DRIVER:virtual
+GENERAL.DRIVER-VERSION:
+GENERAL.FIRMWARE-VERSION:
 GENERAL.HWADDR:13:E0:74:85:7C:D9
 GENERAL.MTU:0
 GENERAL.STATE:20 (unavailable)
+GENERAL.REASON:0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:0 (unknown)
+GENERAL.IP6-CONNECTIVITY:0 (unknown)
+GENERAL.UDI:/sys/devices/virtual/wlan0
+GENERAL.IP-IFACE:
+GENERAL.IS-SOFTWARE:no
+GENERAL.NM-MANAGED:yes
+GENERAL.AUTOCONNECT:yes
+GENERAL.FIRMWARE-MISSING:no
+GENERAL.NM-PLUGIN-MISSING:no
+GENERAL.PHYS-PORT-ID:
 GENERAL.CONNECTION:con-vpn-1
+GENERAL.CON-UUID:UUID-con-vpn-1-REPLACED-REPLACED-REP
 GENERAL.CON-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
+GENERAL.METERED:unknown
+CAPABILITIES.CARRIER-DETECT:no
+CAPABILITIES.SPEED:unknown
+CAPABILITIES.IS-SOFTWARE:no
+CAPABILITIES.SRIOV:no
+WIFI-PROPERTIES.WEP:yes
+WIFI-PROPERTIES.WPA:yes
+WIFI-PROPERTIES.WPA2:yes
+WIFI-PROPERTIES.TKIP:yes
+WIFI-PROPERTIES.CCMP:yes
+WIFI-PROPERTIES.AP:yes
+WIFI-PROPERTIES.ADHOC:yes
+WIFI-PROPERTIES.2GHZ:unknown
+WIFI-PROPERTIES.5GHZ:unknown
+AP[1].IN-USE:[32m [0m
+AP[1].SSID:[32mwlan0-ap-2[0m
+AP[1].MODE:[32mInfra[0m
+AP[1].CHAN:[32m1[0m
+AP[1].RATE:[32m54 Mbit/s[0m
+AP[1].SIGNAL:[32m92[0m
+AP[1].BARS:[32m****[0m
+AP[1].SECURITY:[32mWPA1 WPA2[0m
+AP[2].IN-USE:[32m [0m
+AP[2].SSID:[32mwlan0-ap-1[0m
+AP[2].MODE:[32mInfra[0m
+AP[2].CHAN:[32m1[0m
+AP[2].RATE:[32m54 Mbit/s[0m
+AP[2].SIGNAL:[32m81[0m
+AP[2].BARS:[32m****[0m
+AP[2].SECURITY:[32mWPA1 WPA2[0m
+AP[3].IN-USE:[35m [0m
+AP[3].SSID:[35mwlan0-ap-3[0m
+AP[3].MODE:[35mInfra[0m
+AP[3].CHAN:[35m1[0m
+AP[3].RATE:[35m54 Mbit/s[0m
+AP[3].SIGNAL:[35m55[0m
+AP[3].BARS:[35m**  [0m
+AP[3].SECURITY:[35mWPA1 WPA2[0m
 IP4.ADDRESS[1]:192.168.228.18/32
 IP4.ADDRESS[2]:192.168.209.179/25
 IP4.GATEWAY:192.168.41.120
@@ -17326,6 +17475,10 @@ IP4.DOMAIN[3]:sear4.foo1.bar
 IP4.DOMAIN[4]:sear4.foo4.bar
 IP4.DOMAIN[5]:sear4.fo.o.bar
 IP4.WINS[1]:192.168.120.79
+DHCP4.OPTION[1]:dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:dhcp-4-opt-2 = val-2
+DHCP4.OPTION[3]:dhcp-4-opt-4 = val-4
+DHCP4.OPTION[4]:dhcp-4-opt-7 = val-7
 IP6.GATEWAY:
 IP6.ROUTE[1]:dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
 IP6.DOMAIN[1]:sear6.foo2.bar
@@ -17334,15 +17487,14 @@ IP6.DOMAIN[3]:sear6.fo.x.y
 IP6.DOMAIN[4]:sear6.fo.o.bar
 IP6.DOMAIN[5]:sear6.foo3.bar
 IP6.DOMAIN[6]:sear6.foo4.bar
+DHCP6.OPTION[1]:dhcp-6-opt-1 = val-1
+DHCP6.OPTION[2]:dhcp-6-opt-2 = val-2
+DHCP6.OPTION[3]:dhcp-6-opt-3 = val-3
+DHCP6.OPTION[4]:dhcp-6-opt-4 = val-4
+DHCP6.OPTION[5]:dhcp-6-opt-5 = val-5
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{2}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
-<<<
-size: 12237
-location: clients/tests/test-client.py:1050:test_004()/269
-cmd: $NMCLI --terse --color yes -f all dev show
-lang: C
-returncode: 0
-stdout: 12079 bytes
->>>
 GENERAL.DEVICE:eth0
 GENERAL.TYPE:ethernet
 GENERAL.NM-TYPE:NMDeviceEthernet
@@ -17632,6 +17784,14 @@ DHCP6.OPTION[5]:dhcp-6-opt-9 = val-9
 CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{2}
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
+<<<
+size: 12293
+location: clients/tests/test-client.py:1050:test_004()/270
+cmd: $NMCLI --terse --color yes -f all dev show
+lang: pl_PL.UTF-8
+returncode: 0
+stdout: 12125 bytes
+>>>
 GENERAL.DEVICE:wlan0
 GENERAL.TYPE:wifi
 GENERAL.NM-TYPE:NMDeviceWifi
@@ -17644,8 +17804,8 @@ GENERAL.HWADDR:13:E0:74:85:7C:D9
 GENERAL.MTU:0
 GENERAL.STATE:20 (unavailable)
 GENERAL.REASON:0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:0 (unknown)
-GENERAL.IP6-CONNECTIVITY:0 (unknown)
+GENERAL.IP4-CONNECTIVITY:0 (nieznane)
+GENERAL.IP6-CONNECTIVITY:0 (nieznane)
 GENERAL.UDI:/sys/devices/virtual/wlan0
 GENERAL.IP-IFACE:
 GENERAL.IS-SOFTWARE:no
@@ -17673,25 +17833,25 @@ WIFI-PROPERTIES.2GHZ:unknown
 WIFI-PROPERTIES.5GHZ:unknown
 AP[1].IN-USE:[32m [0m
 AP[1].SSID:[32mwlan0-ap-2[0m
-AP[1].MODE:[32mInfra[0m
+AP[1].MODE:[32mInfrastruktura[0m
 AP[1].CHAN:[32m1[0m
-AP[1].RATE:[32m54 Mbit/s[0m
+AP[1].RATE:[32m54 Mb/s[0m
 AP[1].SIGNAL:[32m92[0m
 AP[1].BARS:[32m****[0m
 AP[1].SECURITY:[32mWPA1 WPA2[0m
 AP[2].IN-USE:[32m [0m
 AP[2].SSID:[32mwlan0-ap-1[0m
-AP[2].MODE:[32mInfra[0m
+AP[2].MODE:[32mInfrastruktura[0m
 AP[2].CHAN:[32m1[0m
-AP[2].RATE:[32m54 Mbit/s[0m
+AP[2].RATE:[32m54 Mb/s[0m
 AP[2].SIGNAL:[32m81[0m
 AP[2].BARS:[32m****[0m
 AP[2].SECURITY:[32mWPA1 WPA2[0m
 AP[3].IN-USE:[35m [0m
 AP[3].SSID:[35mwlan0-ap-3[0m
-AP[3].MODE:[35mInfra[0m
+AP[3].MODE:[35mInfrastruktura[0m
 AP[3].CHAN:[35m1[0m
-AP[3].RATE:[35m54 Mbit/s[0m
+AP[3].RATE:[35m54 Mb/s[0m
 AP[3].SIGNAL:[35m55[0m
 AP[3].BARS:[35m**  [0m
 AP[3].SECURITY:[35mWPA1 WPA2[0m
@@ -17724,14 +17884,6 @@ DHCP6.OPTION[5]:dhcp-6-opt-5 = val-5
 CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{2}
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
-<<<
-size: 12293
-location: clients/tests/test-client.py:1050:test_004()/270
-cmd: $NMCLI --terse --color yes -f all dev show
-lang: pl_PL.UTF-8
-returncode: 0
-stdout: 12125 bytes
->>>
 GENERAL.DEVICE:eth0
 GENERAL.TYPE:ethernet
 GENERAL.NM-TYPE:NMDeviceEthernet
@@ -18018,98 +18170,6 @@ DHCP6.OPTION[2]:dhcp-6-opt-6 = val-6
 DHCP6.OPTION[3]:dhcp-6-opt-7 = val-7
 DHCP6.OPTION[4]:dhcp-6-opt-8 = val-8
 DHCP6.OPTION[5]:dhcp-6-opt-9 = val-9
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{2}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
-
-GENERAL.DEVICE:wlan0
-GENERAL.TYPE:wifi
-GENERAL.NM-TYPE:NMDeviceWifi
-GENERAL.VENDOR:
-GENERAL.PRODUCT:
-GENERAL.DRIVER:virtual
-GENERAL.DRIVER-VERSION:
-GENERAL.FIRMWARE-VERSION:
-GENERAL.HWADDR:13:E0:74:85:7C:D9
-GENERAL.MTU:0
-GENERAL.STATE:20 (unavailable)
-GENERAL.REASON:0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:0 (nieznane)
-GENERAL.IP6-CONNECTIVITY:0 (nieznane)
-GENERAL.UDI:/sys/devices/virtual/wlan0
-GENERAL.IP-IFACE:
-GENERAL.IS-SOFTWARE:no
-GENERAL.NM-MANAGED:yes
-GENERAL.AUTOCONNECT:yes
-GENERAL.FIRMWARE-MISSING:no
-GENERAL.NM-PLUGIN-MISSING:no
-GENERAL.PHYS-PORT-ID:
-GENERAL.CONNECTION:con-vpn-1
-GENERAL.CON-UUID:UUID-con-vpn-1-REPLACED-REPLACED-REP
-GENERAL.CON-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
-GENERAL.METERED:unknown
-CAPABILITIES.CARRIER-DETECT:no
-CAPABILITIES.SPEED:unknown
-CAPABILITIES.IS-SOFTWARE:no
-CAPABILITIES.SRIOV:no
-WIFI-PROPERTIES.WEP:yes
-WIFI-PROPERTIES.WPA:yes
-WIFI-PROPERTIES.WPA2:yes
-WIFI-PROPERTIES.TKIP:yes
-WIFI-PROPERTIES.CCMP:yes
-WIFI-PROPERTIES.AP:yes
-WIFI-PROPERTIES.ADHOC:yes
-WIFI-PROPERTIES.2GHZ:unknown
-WIFI-PROPERTIES.5GHZ:unknown
-AP[1].IN-USE:[32m [0m
-AP[1].SSID:[32mwlan0-ap-2[0m
-AP[1].MODE:[32mInfrastruktura[0m
-AP[1].CHAN:[32m1[0m
-AP[1].RATE:[32m54 Mb/s[0m
-AP[1].SIGNAL:[32m92[0m
-AP[1].BARS:[32m****[0m
-AP[1].SECURITY:[32mWPA1 WPA2[0m
-AP[2].IN-USE:[32m [0m
-AP[2].SSID:[32mwlan0-ap-1[0m
-AP[2].MODE:[32mInfrastruktura[0m
-AP[2].CHAN:[32m1[0m
-AP[2].RATE:[32m54 Mb/s[0m
-AP[2].SIGNAL:[32m81[0m
-AP[2].BARS:[32m****[0m
-AP[2].SECURITY:[32mWPA1 WPA2[0m
-AP[3].IN-USE:[35m [0m
-AP[3].SSID:[35mwlan0-ap-3[0m
-AP[3].MODE:[35mInfrastruktura[0m
-AP[3].CHAN:[35m1[0m
-AP[3].RATE:[35m54 Mb/s[0m
-AP[3].SIGNAL:[35m55[0m
-AP[3].BARS:[35m**  [0m
-AP[3].SECURITY:[35mWPA1 WPA2[0m
-IP4.ADDRESS[1]:192.168.228.18/32
-IP4.ADDRESS[2]:192.168.209.179/25
-IP4.GATEWAY:192.168.41.120
-IP4.DOMAIN[1]:sear4.foo2.bar
-IP4.DOMAIN[2]:sear4.fo.x.y
-IP4.DOMAIN[3]:sear4.foo1.bar
-IP4.DOMAIN[4]:sear4.foo4.bar
-IP4.DOMAIN[5]:sear4.fo.o.bar
-IP4.WINS[1]:192.168.120.79
-DHCP4.OPTION[1]:dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:dhcp-4-opt-2 = val-2
-DHCP4.OPTION[3]:dhcp-4-opt-4 = val-4
-DHCP4.OPTION[4]:dhcp-4-opt-7 = val-7
-IP6.GATEWAY:
-IP6.ROUTE[1]:dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
-IP6.DOMAIN[1]:sear6.foo2.bar
-IP6.DOMAIN[2]:sear6.foo1.bar
-IP6.DOMAIN[3]:sear6.fo.x.y
-IP6.DOMAIN[4]:sear6.fo.o.bar
-IP6.DOMAIN[5]:sear6.foo3.bar
-IP6.DOMAIN[6]:sear6.foo4.bar
-DHCP6.OPTION[1]:dhcp-6-opt-1 = val-1
-DHCP6.OPTION[2]:dhcp-6-opt-2 = val-2
-DHCP6.OPTION[3]:dhcp-6-opt-3 = val-3
-DHCP6.OPTION[4]:dhcp-6-opt-4 = val-4
-DHCP6.OPTION[5]:dhcp-6-opt-5 = val-5
 CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{2}
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
@@ -18567,11 +18627,11 @@ lang: C
 returncode: 0
 stdout: 391 bytes
 >>>
+[2mwlan0[0m:[2mwifi[0m:[2m/org/freedesktop/NetworkManager/Devices/3[0m
 [2meth0[0m:[2methernet[0m:[2m/org/freedesktop/NetworkManager/Devices/1[0m
 [2meth1[0m:[2methernet[0m:[2m/org/freedesktop/NetworkManager/Devices/2[0m
 [2mwlan1[0m:[2mwifi[0m:[2m/org/freedesktop/NetworkManager/Devices/4[0m
 [2mwlan1[0m:[2mwifi[0m:[2m/org/freedesktop/NetworkManager/Devices/5[0m
-[2mwlan0[0m:[2mwifi[0m:[2m/org/freedesktop/NetworkManager/Devices/3[0m
 
 <<<
 size: 570
@@ -18581,11 +18641,11 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 391 bytes
 >>>
+[2mwlan0[0m:[2mwifi[0m:[2m/org/freedesktop/NetworkManager/Devices/3[0m
 [2meth0[0m:[2methernet[0m:[2m/org/freedesktop/NetworkManager/Devices/1[0m
 [2meth1[0m:[2methernet[0m:[2m/org/freedesktop/NetworkManager/Devices/2[0m
 [2mwlan1[0m:[2mwifi[0m:[2m/org/freedesktop/NetworkManager/Devices/4[0m
 [2mwlan1[0m:[2mwifi[0m:[2m/org/freedesktop/NetworkManager/Devices/5[0m
-[2mwlan0[0m:[2mwifi[0m:[2m/org/freedesktop/NetworkManager/Devices/3[0m
 
 <<<
 size: 1799
@@ -18595,12 +18655,12 @@ lang: C
 returncode: 0
 stdout: 1634 bytes
 >>>
-[35mAP[1][0m:[35mwlan1-ap-4[0m:[35m776C616E312D61702D34[0m:[35m94\:2B\:E8\:F6\:D2\:86[0m:[35mInfra[0m:[35m1[0m:[35m2412 MHz[0m:[35m54 Mbit/s[0m:[35m48[0m:[35m**  [0m:[35mWPA1 WPA2[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mwlan1[0m:[35mno[0m:[35m [0m:[35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
-
-
 [32mAP[1][0m:[32mwlan0-ap-2[0m:[32m776C616E302D61702D32[0m:[32mC0\:E2\:BE\:E8\:EF\:B6[0m:[32mInfra[0m:[32m1[0m:[32m2412 MHz[0m:[32m54 Mbit/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mwlan0[0m:[32mno[0m:[32m [0m:[32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
 [32mAP[2][0m:[32mwlan0-ap-1[0m:[32m776C616E302D61702D31[0m:[32m61\:95\:77\:AC\:1E\:4C[0m:[32mInfra[0m:[32m1[0m:[32m2412 MHz[0m:[32m54 Mbit/s[0m:[32m81[0m:[32m****[0m:[32mWPA1 WPA2[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mwlan0[0m:[32mno[0m:[32m [0m:[32m/org/freedesktop/NetworkManager/AccessPoint/1[0m
 [35mAP[3][0m:[35mwlan0-ap-3[0m:[35m776C616E302D61702D33[0m:[35m9B\:F6\:B7\:EC\:97\:76[0m:[35mInfra[0m:[35m1[0m:[35m2412 MHz[0m:[35m54 Mbit/s[0m:[35m55[0m:[35m**  [0m:[35mWPA1 WPA2[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mwlan0[0m:[35mno[0m:[35m [0m:[35m/org/freedesktop/NetworkManager/AccessPoint/3[0m
+
+[35mAP[1][0m:[35mwlan1-ap-4[0m:[35m776C616E312D61702D34[0m:[35m94\:2B\:E8\:F6\:D2\:86[0m:[35mInfra[0m:[35m1[0m:[35m2412 MHz[0m:[35m54 Mbit/s[0m:[35m48[0m:[35m**  [0m:[35mWPA1 WPA2[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mwlan1[0m:[35mno[0m:[35m [0m:[35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
+
 
 <<<
 size: 1857
@@ -18610,12 +18670,12 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 1682 bytes
 >>>
-[35mAP[1][0m:[35mwlan1-ap-4[0m:[35m776C616E312D61702D34[0m:[35m94\:2B\:E8\:F6\:D2\:86[0m:[35mInfrastruktura[0m:[35m1[0m:[35m2412 MHz[0m:[35m54 Mb/s[0m:[35m48[0m:[35m**  [0m:[35mWPA1 WPA2[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mwlan1[0m:[35mnie[0m:[35m [0m:[35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
-
-
 [32mAP[1][0m:[32mwlan0-ap-2[0m:[32m776C616E302D61702D32[0m:[32mC0\:E2\:BE\:E8\:EF\:B6[0m:[32mInfrastruktura[0m:[32m1[0m:[32m2412 MHz[0m:[32m54 Mb/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mwlan0[0m:[32mnie[0m:[32m [0m:[32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
 [32mAP[2][0m:[32mwlan0-ap-1[0m:[32m776C616E302D61702D31[0m:[32m61\:95\:77\:AC\:1E\:4C[0m:[32mInfrastruktura[0m:[32m1[0m:[32m2412 MHz[0m:[32m54 Mb/s[0m:[32m81[0m:[32m****[0m:[32mWPA1 WPA2[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mwlan0[0m:[32mnie[0m:[32m [0m:[32m/org/freedesktop/NetworkManager/AccessPoint/1[0m
 [35mAP[3][0m:[35mwlan0-ap-3[0m:[35m776C616E302D61702D33[0m:[35m9B\:F6\:B7\:EC\:97\:76[0m:[35mInfrastruktura[0m:[35m1[0m:[35m2412 MHz[0m:[35m54 Mb/s[0m:[35m55[0m:[35m**  [0m:[35mWPA1 WPA2[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mwlan0[0m:[35mnie[0m:[35m [0m:[35m/org/freedesktop/NetworkManager/AccessPoint/3[0m
+
+[35mAP[1][0m:[35mwlan1-ap-4[0m:[35m776C616E312D61702D34[0m:[35m94\:2B\:E8\:F6\:D2\:86[0m:[35mInfrastruktura[0m:[35m1[0m:[35m2412 MHz[0m:[35m54 Mb/s[0m:[35m48[0m:[35m**  [0m:[35mWPA1 WPA2[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mwlan1[0m:[35mnie[0m:[35m [0m:[35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
+
 
 <<<
 size: 653
@@ -18625,12 +18685,12 @@ lang: C
 returncode: 0
 stdout: 486 bytes
 >>>
-[35m [0m:[35mwlan1-ap-4[0m:[35mInfra[0m:[35m1[0m:[35m54 Mbit/s[0m:[35m48[0m:[35m**  [0m:[35mWPA1 WPA2[0m
-
-
 [32m [0m:[32mwlan0-ap-2[0m:[32mInfra[0m:[32m1[0m:[32m54 Mbit/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m
 [32m [0m:[32mwlan0-ap-1[0m:[32mInfra[0m:[32m1[0m:[32m54 Mbit/s[0m:[32m81[0m:[32m****[0m:[32mWPA1 WPA2[0m
 [35m [0m:[35mwlan0-ap-3[0m:[35mInfra[0m:[35m1[0m:[35m54 Mbit/s[0m:[35m55[0m:[35m**  [0m:[35mWPA1 WPA2[0m
+
+[35m [0m:[35mwlan1-ap-4[0m:[35mInfra[0m:[35m1[0m:[35m54 Mbit/s[0m:[35m48[0m:[35m**  [0m:[35mWPA1 WPA2[0m
+
 
 <<<
 size: 699
@@ -18640,12 +18700,12 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 522 bytes
 >>>
-[35m [0m:[35mwlan1-ap-4[0m:[35mInfrastruktura[0m:[35m1[0m:[35m54 Mb/s[0m:[35m48[0m:[35m**  [0m:[35mWPA1 WPA2[0m
-
-
 [32m [0m:[32mwlan0-ap-2[0m:[32mInfrastruktura[0m:[32m1[0m:[32m54 Mb/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m
 [32m [0m:[32mwlan0-ap-1[0m:[32mInfrastruktura[0m:[32m1[0m:[32m54 Mb/s[0m:[32m81[0m:[32m****[0m:[32mWPA1 WPA2[0m
 [35m [0m:[35mwlan0-ap-3[0m:[35mInfrastruktura[0m:[35m1[0m:[35m54 Mb/s[0m:[35m55[0m:[35m**  [0m:[35mWPA1 WPA2[0m
+
+[35m [0m:[35mwlan1-ap-4[0m:[35mInfrastruktura[0m:[35m1[0m:[35m54 Mb/s[0m:[35m48[0m:[35m**  [0m:[35mWPA1 WPA2[0m
+
 
 <<<
 size: 1912
@@ -18655,12 +18715,12 @@ lang: C
 returncode: 0
 stdout: 1634 bytes
 >>>
-[35mAP[1][0m:[35mwlan1-ap-4[0m:[35m776C616E312D61702D34[0m:[35m94\:2B\:E8\:F6\:D2\:86[0m:[35mInfra[0m:[35m1[0m:[35m2412 MHz[0m:[35m54 Mbit/s[0m:[35m48[0m:[35m**  [0m:[35mWPA1 WPA2[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mwlan1[0m:[35mno[0m:[35m [0m:[35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
-
-
 [32mAP[1][0m:[32mwlan0-ap-2[0m:[32m776C616E302D61702D32[0m:[32mC0\:E2\:BE\:E8\:EF\:B6[0m:[32mInfra[0m:[32m1[0m:[32m2412 MHz[0m:[32m54 Mbit/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mwlan0[0m:[32mno[0m:[32m [0m:[32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
 [32mAP[2][0m:[32mwlan0-ap-1[0m:[32m776C616E302D61702D31[0m:[32m61\:95\:77\:AC\:1E\:4C[0m:[32mInfra[0m:[32m1[0m:[32m2412 MHz[0m:[32m54 Mbit/s[0m:[32m81[0m:[32m****[0m:[32mWPA1 WPA2[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mwlan0[0m:[32mno[0m:[32m [0m:[32m/org/freedesktop/NetworkManager/AccessPoint/1[0m
 [35mAP[3][0m:[35mwlan0-ap-3[0m:[35m776C616E302D61702D33[0m:[35m9B\:F6\:B7\:EC\:97\:76[0m:[35mInfra[0m:[35m1[0m:[35m2412 MHz[0m:[35m54 Mbit/s[0m:[35m55[0m:[35m**  [0m:[35mWPA1 WPA2[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mwlan0[0m:[35mno[0m:[35m [0m:[35m/org/freedesktop/NetworkManager/AccessPoint/3[0m
+
+[35mAP[1][0m:[35mwlan1-ap-4[0m:[35m776C616E312D61702D34[0m:[35m94\:2B\:E8\:F6\:D2\:86[0m:[35mInfra[0m:[35m1[0m:[35m2412 MHz[0m:[35m54 Mbit/s[0m:[35m48[0m:[35m**  [0m:[35mWPA1 WPA2[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mwlan1[0m:[35mno[0m:[35m [0m:[35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
+
 
 <<<
 size: 1970
@@ -18670,72 +18730,84 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 1682 bytes
 >>>
-[35mAP[1][0m:[35mwlan1-ap-4[0m:[35m776C616E312D61702D34[0m:[35m94\:2B\:E8\:F6\:D2\:86[0m:[35mInfrastruktura[0m:[35m1[0m:[35m2412 MHz[0m:[35m54 Mb/s[0m:[35m48[0m:[35m**  [0m:[35mWPA1 WPA2[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mwlan1[0m:[35mnie[0m:[35m [0m:[35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
-
-
 [32mAP[1][0m:[32mwlan0-ap-2[0m:[32m776C616E302D61702D32[0m:[32mC0\:E2\:BE\:E8\:EF\:B6[0m:[32mInfrastruktura[0m:[32m1[0m:[32m2412 MHz[0m:[32m54 Mb/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mwlan0[0m:[32mnie[0m:[32m [0m:[32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
 [32mAP[2][0m:[32mwlan0-ap-1[0m:[32m776C616E302D61702D31[0m:[32m61\:95\:77\:AC\:1E\:4C[0m:[32mInfrastruktura[0m:[32m1[0m:[32m2412 MHz[0m:[32m54 Mb/s[0m:[32m81[0m:[32m****[0m:[32mWPA1 WPA2[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mwlan0[0m:[32mnie[0m:[32m [0m:[32m/org/freedesktop/NetworkManager/AccessPoint/1[0m
 [35mAP[3][0m:[35mwlan0-ap-3[0m:[35m776C616E302D61702D33[0m:[35m9B\:F6\:B7\:EC\:97\:76[0m:[35mInfrastruktura[0m:[35m1[0m:[35m2412 MHz[0m:[35m54 Mb/s[0m:[35m55[0m:[35m**  [0m:[35mWPA1 WPA2[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mwlan0[0m:[35mnie[0m:[35m [0m:[35m/org/freedesktop/NetworkManager/AccessPoint/3[0m
 
+[35mAP[1][0m:[35mwlan1-ap-4[0m:[35m776C616E312D61702D34[0m:[35m94\:2B\:E8\:F6\:D2\:86[0m:[35mInfrastruktura[0m:[35m1[0m:[35m2412 MHz[0m:[35m54 Mb/s[0m:[35m48[0m:[35m**  [0m:[35mWPA1 WPA2[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mwlan1[0m:[35mnie[0m:[35m [0m:[35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
+
+
 <<<
-size: 596
+size: 598
 location: clients/tests/test-client.py:1075:test_004()/287
 cmd: $NMCLI --terse --color yes -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 408 bytes
+stdout: 410 bytes
 >>>
 [32mAP[1][0m:[32mwlan0-ap-2[0m:[32m776C616E302D61702D32[0m:[32mC0\:E2\:BE\:E8\:EF\:B6[0m:[32mInfra[0m:[32m1[0m:[32m2412 MHz[0m:[32m54 Mbit/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mwlan0[0m:[32mno[0m:[32m [0m:[32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
 
+
+
 <<<
-size: 618
+size: 620
 location: clients/tests/test-client.py:1075:test_004()/288
 cmd: $NMCLI --terse --color yes -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 420 bytes
+stdout: 422 bytes
 >>>
 [32mAP[1][0m:[32mwlan0-ap-2[0m:[32m776C616E302D61702D32[0m:[32mC0\:E2\:BE\:E8\:EF\:B6[0m:[32mInfrastruktura[0m:[32m1[0m:[32m2412 MHz[0m:[32m54 Mb/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mwlan0[0m:[32mnie[0m:[32m [0m:[32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
 
+
+
 <<<
-size: 312
+size: 314
 location: clients/tests/test-client.py:1077:test_004()/289
 cmd: $NMCLI --terse --color yes -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 121 bytes
+stdout: 123 bytes
 >>>
 [32m [0m:[32mwlan0-ap-2[0m:[32mInfra[0m:[32m1[0m:[32m54 Mbit/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m
 
+
+
 <<<
-size: 331
+size: 333
 location: clients/tests/test-client.py:1077:test_004()/290
 cmd: $NMCLI --terse --color yes -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 130 bytes
+stdout: 132 bytes
 >>>
 [32m [0m:[32mwlan0-ap-2[0m:[32mInfrastruktura[0m:[32m1[0m:[32m54 Mb/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m
 
+
+
 <<<
-size: 709
+size: 711
 location: clients/tests/test-client.py:1080:test_004()/291
 cmd: $NMCLI --terse --color yes -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 408 bytes
+stdout: 410 bytes
 >>>
 [32mAP[1][0m:[32mwlan0-ap-2[0m:[32m776C616E302D61702D32[0m:[32mC0\:E2\:BE\:E8\:EF\:B6[0m:[32mInfra[0m:[32m1[0m:[32m2412 MHz[0m:[32m54 Mbit/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mwlan0[0m:[32mno[0m:[32m [0m:[32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
 
+
+
 <<<
-size: 731
+size: 733
 location: clients/tests/test-client.py:1080:test_004()/292
 cmd: $NMCLI --terse --color yes -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 420 bytes
+stdout: 422 bytes
 >>>
 [32mAP[1][0m:[32mwlan0-ap-2[0m:[32m776C616E302D61702D32[0m:[32mC0\:E2\:BE\:E8\:EF\:B6[0m:[32mInfrastruktura[0m:[32m1[0m:[32m2412 MHz[0m:[32m54 Mb/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mwlan0[0m:[32mnie[0m:[32m [0m:[32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
+
+
 
 <<<
 size: 2934
@@ -19420,11 +19492,11 @@ returncode: 0
 stdout: 258 bytes
 >>>
 DEVICE  TYPE      STATE        CONNECTION 
+wlan0   wifi      unavailable  con-vpn-1  
 eth0    ethernet  unavailable  --         
 eth1    ethernet  unavailable  --         
 wlan1   wifi      unavailable  --         
 wlan1   wifi      unavailable  --         
-wlan0   wifi      unavailable  con-vpn-1  
 
 <<<
 size: 414
@@ -19435,11 +19507,11 @@ returncode: 0
 stdout: 263 bytes
 >>>
 DEVICE  TYPE      STATE        CONNECTION 
+wlan0   wifi      niedostępne  con-vpn-1  
 eth0    ethernet  niedostępne  --         
 eth1    ethernet  niedostępne  --         
 wlan1   wifi      niedostępne  --         
 wlan1   wifi      niedostępne  --         
-wlan0   wifi      niedostępne  con-vpn-1  
 
 <<<
 size: 1426
@@ -19450,11 +19522,11 @@ returncode: 0
 stdout: 1272 bytes
 >>>
 DEVICE  TYPE      STATE        IP4-CONNECTIVITY  IP6-CONNECTIVITY  DBUS-PATH                                  CONNECTION  CON-UUID                              CON-PATH                                           
+wlan0   wifi      unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/3  con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2 
 eth0    ethernet  unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/1  --          --                                    --                                                 
 eth1    ethernet  unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/2  --          --                                    --                                                 
 wlan1   wifi      unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/4  --          --                                    --                                                 
 wlan1   wifi      unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/5  --          --                                    --                                                 
-wlan0   wifi      unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/3  con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2 
 
 <<<
 size: 1441
@@ -19465,11 +19537,11 @@ returncode: 0
 stdout: 1277 bytes
 >>>
 DEVICE  TYPE      STATE        IP4-CONNECTIVITY  IP6-CONNECTIVITY  DBUS-PATH                                  CONNECTION  CON-UUID                              CON-PATH                                           
+wlan0   wifi      niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/3  con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2 
 eth0    ethernet  niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/1  --          --                                    --                                                 
 eth1    ethernet  niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/2  --          --                                    --                                                 
 wlan1   wifi      niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/4  --          --                                    --                                                 
 wlan1   wifi      niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/5  --          --                                    --                                                 
-wlan0   wifi      niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/3  con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2 
 
 <<<
 size: 6361
@@ -19480,6 +19552,33 @@ returncode: 0
 stdout: 6216 bytes
 >>>
 DEVICE 
+wlan0  
+
+TYPE 
+wifi 
+
+HWADDR            
+13:E0:74:85:7C:D9 
+
+MTU 
+0   
+
+STATE            
+20 (unavailable) 
+
+CONNECTION 
+con-vpn-1  
+
+CON-PATH                                           
+/org/freedesktop/NetworkManager/ActiveConnection/2 
+
+GROUP  ADDRESS                                 GATEWAY         ROUTE  DNS  DOMAIN                                                                            WINS           
+IP4    192.168.228.18/32 | 192.168.209.179/25  192.168.41.120  --     --   sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar  192.168.120.79 
+
+GROUP  ADDRESS  GATEWAY  ROUTE                                                           DNS  DOMAIN                                                                                            
+IP6    --       --       dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086  --   sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar 
+
+DEVICE 
 eth0   
 
 TYPE     
@@ -19592,33 +19691,6 @@ IP4    192.168.97.124/29 | 192.168.76.154/18  --       dst = 192.168.33.233/22, 
 
 GROUP  ADDRESS                        GATEWAY  ROUTE                                                                                                                                                                                                      DNS                          DOMAIN       
 IP6    2001:a::88ca:3654:96b:ab44/89  --       dst = 2001:a::cc8b:7c09:4673:bbb0/85, nh = ::, mt = 2821465568 | dst = 2001:a::a976:2488:f49f:b48/106, nh = 2001:a::62ae:c734:fc7b:e931, mt = 2248613879 | dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::  2001:a::2934:bd66:550d:ec19  sear6.fo.x.y 
-
-DEVICE 
-wlan0  
-
-TYPE 
-wifi 
-
-HWADDR            
-13:E0:74:85:7C:D9 
-
-MTU 
-0   
-
-STATE            
-20 (unavailable) 
-
-CONNECTION 
-con-vpn-1  
-
-CON-PATH                                           
-/org/freedesktop/NetworkManager/ActiveConnection/2 
-
-GROUP  ADDRESS                                 GATEWAY         ROUTE  DNS  DOMAIN                                                                            WINS           
-IP4    192.168.228.18/32 | 192.168.209.179/25  192.168.41.120  --     --   sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar  192.168.120.79 
-
-GROUP  ADDRESS  GATEWAY  ROUTE                                                           DNS  DOMAIN                                                                                            
-IP6    --       --       dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086  --   sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar 
 
 <<<
 size: 6388
@@ -19629,6 +19701,33 @@ returncode: 0
 stdout: 6233 bytes
 >>>
 DEVICE 
+wlan0  
+
+TYPE 
+wifi 
+
+HWADDR            
+13:E0:74:85:7C:D9 
+
+MTU 
+0   
+
+STATE            
+20 (niedostępne) 
+
+CONNECTION 
+con-vpn-1  
+
+CON-PATH                                           
+/org/freedesktop/NetworkManager/ActiveConnection/2 
+
+GROUP  ADDRESS                                 GATEWAY         ROUTE  DNS  DOMAIN                                                                            WINS           
+IP4    192.168.228.18/32 | 192.168.209.179/25  192.168.41.120  --     --   sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar  192.168.120.79 
+
+GROUP  ADDRESS  GATEWAY  ROUTE                                                           DNS  DOMAIN                                                                                            
+IP6    --       --       dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086  --   sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar 
+
+DEVICE 
 eth0   
 
 TYPE     
@@ -19742,33 +19841,6 @@ IP4    192.168.97.124/29 | 192.168.76.154/18  --       dst = 192.168.33.233/22, 
 GROUP  ADDRESS                        GATEWAY  ROUTE                                                                                                                                                                                                      DNS                          DOMAIN       
 IP6    2001:a::88ca:3654:96b:ab44/89  --       dst = 2001:a::cc8b:7c09:4673:bbb0/85, nh = ::, mt = 2821465568 | dst = 2001:a::a976:2488:f49f:b48/106, nh = 2001:a::62ae:c734:fc7b:e931, mt = 2248613879 | dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::  2001:a::2934:bd66:550d:ec19  sear6.fo.x.y 
 
-DEVICE 
-wlan0  
-
-TYPE 
-wifi 
-
-HWADDR            
-13:E0:74:85:7C:D9 
-
-MTU 
-0   
-
-STATE            
-20 (niedostępne) 
-
-CONNECTION 
-con-vpn-1  
-
-CON-PATH                                           
-/org/freedesktop/NetworkManager/ActiveConnection/2 
-
-GROUP  ADDRESS                                 GATEWAY         ROUTE  DNS  DOMAIN                                                                            WINS           
-IP4    192.168.228.18/32 | 192.168.209.179/25  192.168.41.120  --     --   sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar  192.168.120.79 
-
-GROUP  ADDRESS  GATEWAY  ROUTE                                                           DNS  DOMAIN                                                                                            
-IP6    --       --       dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086  --   sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar 
-
 <<<
 size: 14861
 location: clients/tests/test-client.py:1050:test_004()/315
@@ -19777,6 +19849,35 @@ lang: C
 returncode: 0
 stdout: 14708 bytes
 >>>
+NAME     DEVICE  TYPE  NM-TYPE       VENDOR  PRODUCT  DRIVER   DRIVER-VERSION  FIRMWARE-VERSION  HWADDR             MTU  STATE             REASON               IP4-CONNECTIVITY  IP6-CONNECTIVITY  UDI                         IP-IFACE  IS-SOFTWARE  NM-MANAGED  AUTOCONNECT  FIRMWARE-MISSING  NM-PLUGIN-MISSING  PHYS-PORT-ID  CONNECTION  CON-UUID                              CON-PATH                                            METERED 
+GENERAL  wlan0   wifi  NMDeviceWifi  --      --       virtual  --              --                13:E0:74:85:7C:D9  0    20 (unavailable)  0 (No reason given)  0 (unknown)       0 (unknown)       /sys/devices/virtual/wlan0  --        no           yes         yes          no                no                 --            con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2  unknown 
+
+NAME          CARRIER-DETECT  SPEED    IS-SOFTWARE  SRIOV 
+CAPABILITIES  no              unknown  no           no    
+
+NAME             WEP  WPA  WPA2  TKIP  CCMP  AP   ADHOC  2GHZ     5GHZ    
+WIFI-PROPERTIES  yes  yes  yes   yes   yes   yes  yes    unknown  unknown 
+
+NAME   IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
+AP[1]          wlan0-ap-2  Infra  1     54 Mbit/s  92      ****  WPA1 WPA2 
+AP[2]          wlan0-ap-1  Infra  1     54 Mbit/s  81      ****  WPA1 WPA2 
+AP[3]          wlan0-ap-3  Infra  1     54 Mbit/s  55      **    WPA1 WPA2 
+
+GROUP  ADDRESS                                 GATEWAY         ROUTE  DNS  DOMAIN                                                                            WINS           
+IP4    192.168.228.18/32 | 192.168.209.179/25  192.168.41.120  --     --   sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar  192.168.120.79 
+
+GROUP  OPTION                                                                                    
+DHCP4  dhcp-4-opt-0 = val-0 | dhcp-4-opt-2 = val-2 | dhcp-4-opt-4 = val-4 | dhcp-4-opt-7 = val-7 
+
+GROUP  ADDRESS  GATEWAY  ROUTE                                                           DNS  DOMAIN                                                                                            
+IP6    --       --       dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086  --   sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar 
+
+GROUP  OPTION                                                                                                           
+DHCP6  dhcp-6-opt-1 = val-1 | dhcp-6-opt-2 = val-2 | dhcp-6-opt-3 = val-3 | dhcp-6-opt-4 = val-4 | dhcp-6-opt-5 = val-5 
+
+NAME         AVAILABLE-CONNECTION-PATHS                               AVAILABLE-CONNECTIONS                          
+CONNECTIONS  /org/freedesktop/NetworkManager/Settings/Connection/{2}  UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1 
+
 NAME     DEVICE  TYPE      NM-TYPE           VENDOR  PRODUCT  DRIVER   DRIVER-VERSION  FIRMWARE-VERSION  HWADDR             MTU  STATE             REASON               IP4-CONNECTIVITY  IP6-CONNECTIVITY  UDI                        IP-IFACE  IS-SOFTWARE  NM-MANAGED  AUTOCONNECT  FIRMWARE-MISSING  NM-PLUGIN-MISSING  PHYS-PORT-ID  CONNECTION  CON-UUID  CON-PATH  METERED 
 GENERAL  eth0    ethernet  NMDeviceEthernet  --      --       virtual  --              --                AB:B7:BF:E2:48:E8  0    20 (unavailable)  0 (No reason given)  0 (unknown)       0 (unknown)       /sys/devices/virtual/eth0  --        no           yes         yes          no                no                 --            --          --        --        unknown 
 
@@ -19878,19 +19979,27 @@ DHCP6  dhcp-6-opt-2 = val-2 | dhcp-6-opt-6 = val-6 | dhcp-6-opt-7 = val-7 | dhcp
 NAME         AVAILABLE-CONNECTION-PATHS                               AVAILABLE-CONNECTIONS                          
 CONNECTIONS  /org/freedesktop/NetworkManager/Settings/Connection/{2}  UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1 
 
-NAME     DEVICE  TYPE  NM-TYPE       VENDOR  PRODUCT  DRIVER   DRIVER-VERSION  FIRMWARE-VERSION  HWADDR             MTU  STATE             REASON               IP4-CONNECTIVITY  IP6-CONNECTIVITY  UDI                         IP-IFACE  IS-SOFTWARE  NM-MANAGED  AUTOCONNECT  FIRMWARE-MISSING  NM-PLUGIN-MISSING  PHYS-PORT-ID  CONNECTION  CON-UUID                              CON-PATH                                            METERED 
-GENERAL  wlan0   wifi  NMDeviceWifi  --      --       virtual  --              --                13:E0:74:85:7C:D9  0    20 (unavailable)  0 (No reason given)  0 (unknown)       0 (unknown)       /sys/devices/virtual/wlan0  --        no           yes         yes          no                no                 --            con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2  unknown 
+<<<
+size: 15020
+location: clients/tests/test-client.py:1050:test_004()/316
+cmd: $NMCLI --mode tabular -f all dev show
+lang: pl_PL.UTF-8
+returncode: 0
+stdout: 14857 bytes
+>>>
+NAME     DEVICE  TYPE  NM-TYPE       VENDOR  PRODUCT  DRIVER   DRIVER-VERSION  FIRMWARE-VERSION  HWADDR             MTU  STATE             REASON                    IP4-CONNECTIVITY  IP6-CONNECTIVITY  UDI                         IP-IFACE  IS-SOFTWARE  NM-MANAGED  AUTOCONNECT  FIRMWARE-MISSING  NM-PLUGIN-MISSING  PHYS-PORT-ID  CONNECTION  CON-UUID                              CON-PATH                                            METERED  
+GENERAL  wlan0   wifi  NMDeviceWifi  --      --       virtual  --              --                13:E0:74:85:7C:D9  0    20 (niedostępne)  0 (Nie podano przyczyny)  0 (nieznane)      0 (nieznane)      /sys/devices/virtual/wlan0  --        nie          tak         tak          nie               nie                --            con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2  nieznane 
 
-NAME          CARRIER-DETECT  SPEED    IS-SOFTWARE  SRIOV 
-CAPABILITIES  no              unknown  no           no    
+NAME          CARRIER-DETECT  SPEED     IS-SOFTWARE  SRIOV 
+CAPABILITIES  nie             nieznane  nie          nie   
 
-NAME             WEP  WPA  WPA2  TKIP  CCMP  AP   ADHOC  2GHZ     5GHZ    
-WIFI-PROPERTIES  yes  yes  yes   yes   yes   yes  yes    unknown  unknown 
+NAME             WEP  WPA  WPA2  TKIP  CCMP  AP   ADHOC  2GHZ      5GHZ     
+WIFI-PROPERTIES  tak  tak  tak   tak   tak   tak  tak    nieznane  nieznane 
 
-NAME   IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
-AP[1]          wlan0-ap-2  Infra  1     54 Mbit/s  92      ****  WPA1 WPA2 
-AP[2]          wlan0-ap-1  Infra  1     54 Mbit/s  81      ****  WPA1 WPA2 
-AP[3]          wlan0-ap-3  Infra  1     54 Mbit/s  55      **    WPA1 WPA2 
+NAME   IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
+AP[1]          wlan0-ap-2  Infrastruktura  1     54 Mb/s  92      ****  WPA1 WPA2 
+AP[2]          wlan0-ap-1  Infrastruktura  1     54 Mb/s  81      ****  WPA1 WPA2 
+AP[3]          wlan0-ap-3  Infrastruktura  1     54 Mb/s  55      **    WPA1 WPA2 
 
 GROUP  ADDRESS                                 GATEWAY         ROUTE  DNS  DOMAIN                                                                            WINS           
 IP4    192.168.228.18/32 | 192.168.209.179/25  192.168.41.120  --     --   sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar  192.168.120.79 
@@ -19907,14 +20016,6 @@ DHCP6  dhcp-6-opt-1 = val-1 | dhcp-6-opt-2 = val-2 | dhcp-6-opt-3 = val-3 | dhcp
 NAME         AVAILABLE-CONNECTION-PATHS                               AVAILABLE-CONNECTIONS                          
 CONNECTIONS  /org/freedesktop/NetworkManager/Settings/Connection/{2}  UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1 
 
-<<<
-size: 15020
-location: clients/tests/test-client.py:1050:test_004()/316
-cmd: $NMCLI --mode tabular -f all dev show
-lang: pl_PL.UTF-8
-returncode: 0
-stdout: 14857 bytes
->>>
 NAME     DEVICE  TYPE      NM-TYPE           VENDOR  PRODUCT  DRIVER   DRIVER-VERSION  FIRMWARE-VERSION  HWADDR             MTU  STATE             REASON                    IP4-CONNECTIVITY  IP6-CONNECTIVITY  UDI                        IP-IFACE  IS-SOFTWARE  NM-MANAGED  AUTOCONNECT  FIRMWARE-MISSING  NM-PLUGIN-MISSING  PHYS-PORT-ID  CONNECTION  CON-UUID  CON-PATH  METERED  
 GENERAL  eth0    ethernet  NMDeviceEthernet  --      --       virtual  --              --                AB:B7:BF:E2:48:E8  0    20 (niedostępne)  0 (Nie podano przyczyny)  0 (nieznane)      0 (nieznane)      /sys/devices/virtual/eth0  --        nie          tak         tak          nie               nie                --            --          --        --        nieznane 
 
@@ -20012,35 +20113,6 @@ IP6    2001:a::88ca:3654:96b:ab44/89  --       dst = 2001:a::cc8b:7c09:4673:bbb0
 
 GROUP  OPTION                                                                                                           
 DHCP6  dhcp-6-opt-2 = val-2 | dhcp-6-opt-6 = val-6 | dhcp-6-opt-7 = val-7 | dhcp-6-opt-8 = val-8 | dhcp-6-opt-9 = val-9 
-
-NAME         AVAILABLE-CONNECTION-PATHS                               AVAILABLE-CONNECTIONS                          
-CONNECTIONS  /org/freedesktop/NetworkManager/Settings/Connection/{2}  UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1 
-
-NAME     DEVICE  TYPE  NM-TYPE       VENDOR  PRODUCT  DRIVER   DRIVER-VERSION  FIRMWARE-VERSION  HWADDR             MTU  STATE             REASON                    IP4-CONNECTIVITY  IP6-CONNECTIVITY  UDI                         IP-IFACE  IS-SOFTWARE  NM-MANAGED  AUTOCONNECT  FIRMWARE-MISSING  NM-PLUGIN-MISSING  PHYS-PORT-ID  CONNECTION  CON-UUID                              CON-PATH                                            METERED  
-GENERAL  wlan0   wifi  NMDeviceWifi  --      --       virtual  --              --                13:E0:74:85:7C:D9  0    20 (niedostępne)  0 (Nie podano przyczyny)  0 (nieznane)      0 (nieznane)      /sys/devices/virtual/wlan0  --        nie          tak         tak          nie               nie                --            con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2  nieznane 
-
-NAME          CARRIER-DETECT  SPEED     IS-SOFTWARE  SRIOV 
-CAPABILITIES  nie             nieznane  nie          nie   
-
-NAME             WEP  WPA  WPA2  TKIP  CCMP  AP   ADHOC  2GHZ      5GHZ     
-WIFI-PROPERTIES  tak  tak  tak   tak   tak   tak  tak    nieznane  nieznane 
-
-NAME   IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
-AP[1]          wlan0-ap-2  Infrastruktura  1     54 Mb/s  92      ****  WPA1 WPA2 
-AP[2]          wlan0-ap-1  Infrastruktura  1     54 Mb/s  81      ****  WPA1 WPA2 
-AP[3]          wlan0-ap-3  Infrastruktura  1     54 Mb/s  55      **    WPA1 WPA2 
-
-GROUP  ADDRESS                                 GATEWAY         ROUTE  DNS  DOMAIN                                                                            WINS           
-IP4    192.168.228.18/32 | 192.168.209.179/25  192.168.41.120  --     --   sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar  192.168.120.79 
-
-GROUP  OPTION                                                                                    
-DHCP4  dhcp-4-opt-0 = val-0 | dhcp-4-opt-2 = val-2 | dhcp-4-opt-4 = val-4 | dhcp-4-opt-7 = val-7 
-
-GROUP  ADDRESS  GATEWAY  ROUTE                                                           DNS  DOMAIN                                                                                            
-IP6    --       --       dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086  --   sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar 
-
-GROUP  OPTION                                                                                                           
-DHCP6  dhcp-6-opt-1 = val-1 | dhcp-6-opt-2 = val-2 | dhcp-6-opt-3 = val-3 | dhcp-6-opt-4 = val-4 | dhcp-6-opt-5 = val-5 
 
 NAME         AVAILABLE-CONNECTION-PATHS                               AVAILABLE-CONNECTIONS                          
 CONNECTIONS  /org/freedesktop/NetworkManager/Settings/Connection/{2}  UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1 
@@ -20266,11 +20338,11 @@ returncode: 0
 stdout: 366 bytes
 >>>
 DEVICE  TYPE      DBUS-PATH                                 
+wlan0   wifi      /org/freedesktop/NetworkManager/Devices/3 
 eth0    ethernet  /org/freedesktop/NetworkManager/Devices/1 
 eth1    ethernet  /org/freedesktop/NetworkManager/Devices/2 
 wlan1   wifi      /org/freedesktop/NetworkManager/Devices/4 
 wlan1   wifi      /org/freedesktop/NetworkManager/Devices/5 
-wlan0   wifi      /org/freedesktop/NetworkManager/Devices/3 
 
 <<<
 size: 540
@@ -20281,11 +20353,11 @@ returncode: 0
 stdout: 366 bytes
 >>>
 DEVICE  TYPE      DBUS-PATH                                 
+wlan0   wifi      /org/freedesktop/NetworkManager/Devices/3 
 eth0    ethernet  /org/freedesktop/NetworkManager/Devices/1 
 eth1    ethernet  /org/freedesktop/NetworkManager/Devices/2 
 wlan1   wifi      /org/freedesktop/NetworkManager/Devices/4 
 wlan1   wifi      /org/freedesktop/NetworkManager/Devices/5 
-wlan0   wifi      /org/freedesktop/NetworkManager/Devices/3 
 
 <<<
 size: 2000
@@ -20296,14 +20368,14 @@ returncode: 0
 stdout: 1840 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
-AP[1]  wlan1-ap-4  776C616E312D61702D34  94:2B:E8:F6:D2:86  Infra  1     2412 MHz  54 Mbit/s  48      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan1   no              /org/freedesktop/NetworkManager/AccessPoint/4 
-
-NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
-
-NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infra  1     2412 MHz  54 Mbit/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/2 
 AP[2]  wlan0-ap-1  776C616E302D61702D31  61:95:77:AC:1E:4C  Infra  1     2412 MHz  54 Mbit/s  81      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/1 
 AP[3]  wlan0-ap-3  776C616E302D61702D33  9B:F6:B7:EC:97:76  Infra  1     2412 MHz  54 Mbit/s  55      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/3 
+
+NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+AP[1]  wlan1-ap-4  776C616E312D61702D34  94:2B:E8:F6:D2:86  Infra  1     2412 MHz  54 Mbit/s  48      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan1   no              /org/freedesktop/NetworkManager/AccessPoint/4 
+
+NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 
 <<<
 size: 2068
@@ -20314,14 +20386,14 @@ returncode: 0
 stdout: 1898 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
-AP[1]  wlan1-ap-4  776C616E312D61702D34  94:2B:E8:F6:D2:86  Infrastruktura  1     2412 MHz  54 Mb/s  48      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan1   nie             /org/freedesktop/NetworkManager/AccessPoint/4 
-
-NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
-
-NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infrastruktura  1     2412 MHz  54 Mb/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/2 
 AP[2]  wlan0-ap-1  776C616E302D61702D31  61:95:77:AC:1E:4C  Infrastruktura  1     2412 MHz  54 Mb/s  81      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/1 
 AP[3]  wlan0-ap-3  776C616E302D61702D33  9B:F6:B7:EC:97:76  Infrastruktura  1     2412 MHz  54 Mb/s  55      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/3 
+
+NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+AP[1]  wlan1-ap-4  776C616E312D61702D34  94:2B:E8:F6:D2:86  Infrastruktura  1     2412 MHz  54 Mb/s  48      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan1   nie             /org/freedesktop/NetworkManager/AccessPoint/4 
+
+NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 
 <<<
 size: 634
@@ -20332,14 +20404,14 @@ returncode: 0
 stdout: 472 bytes
 >>>
 IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
-        wlan1-ap-4  Infra  1     54 Mbit/s  48      **    WPA1 WPA2 
-
-IN-USE  SSID  MODE  CHAN  RATE  SIGNAL  BARS  SECURITY 
-
-IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
         wlan0-ap-2  Infra  1     54 Mbit/s  92      ****  WPA1 WPA2 
         wlan0-ap-1  Infra  1     54 Mbit/s  81      ****  WPA1 WPA2 
         wlan0-ap-3  Infra  1     54 Mbit/s  55      **    WPA1 WPA2 
+
+IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
+        wlan1-ap-4  Infra  1     54 Mbit/s  48      **    WPA1 WPA2 
+
+IN-USE  SSID  MODE  CHAN  RATE  SIGNAL  BARS  SECURITY 
 
 <<<
 size: 694
@@ -20350,14 +20422,14 @@ returncode: 0
 stdout: 522 bytes
 >>>
 IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
-        wlan1-ap-4  Infrastruktura  1     54 Mb/s  48      **    WPA1 WPA2 
-
-IN-USE  SSID  MODE  CHAN  RATE  SIGNAL  BARS  SECURITY 
-
-IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
         wlan0-ap-2  Infrastruktura  1     54 Mb/s  92      ****  WPA1 WPA2 
         wlan0-ap-1  Infrastruktura  1     54 Mb/s  81      ****  WPA1 WPA2 
         wlan0-ap-3  Infrastruktura  1     54 Mb/s  55      **    WPA1 WPA2 
+
+IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
+        wlan1-ap-4  Infrastruktura  1     54 Mb/s  48      **    WPA1 WPA2 
+
+IN-USE  SSID  MODE  CHAN  RATE  SIGNAL  BARS  SECURITY 
 
 <<<
 size: 2113
@@ -20368,14 +20440,14 @@ returncode: 0
 stdout: 1840 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
-AP[1]  wlan1-ap-4  776C616E312D61702D34  94:2B:E8:F6:D2:86  Infra  1     2412 MHz  54 Mbit/s  48      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan1   no              /org/freedesktop/NetworkManager/AccessPoint/4 
-
-NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
-
-NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infra  1     2412 MHz  54 Mbit/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/2 
 AP[2]  wlan0-ap-1  776C616E302D61702D31  61:95:77:AC:1E:4C  Infra  1     2412 MHz  54 Mbit/s  81      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/1 
 AP[3]  wlan0-ap-3  776C616E302D61702D33  9B:F6:B7:EC:97:76  Infra  1     2412 MHz  54 Mbit/s  55      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/3 
+
+NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+AP[1]  wlan1-ap-4  776C616E312D61702D34  94:2B:E8:F6:D2:86  Infra  1     2412 MHz  54 Mbit/s  48      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan1   no              /org/freedesktop/NetworkManager/AccessPoint/4 
+
+NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 
 <<<
 size: 2181
@@ -20386,80 +20458,92 @@ returncode: 0
 stdout: 1898 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
-AP[1]  wlan1-ap-4  776C616E312D61702D34  94:2B:E8:F6:D2:86  Infrastruktura  1     2412 MHz  54 Mb/s  48      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan1   nie             /org/freedesktop/NetworkManager/AccessPoint/4 
-
-NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
-
-NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infrastruktura  1     2412 MHz  54 Mb/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/2 
 AP[2]  wlan0-ap-1  776C616E302D61702D31  61:95:77:AC:1E:4C  Infrastruktura  1     2412 MHz  54 Mb/s  81      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/1 
 AP[3]  wlan0-ap-3  776C616E302D61702D33  9B:F6:B7:EC:97:76  Infrastruktura  1     2412 MHz  54 Mb/s  55      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/3 
 
+NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+AP[1]  wlan1-ap-4  776C616E312D61702D34  94:2B:E8:F6:D2:86  Infrastruktura  1     2412 MHz  54 Mb/s  48      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan1   nie             /org/freedesktop/NetworkManager/AccessPoint/4 
+
+NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
+
 <<<
-size: 751
+size: 753
 location: clients/tests/test-client.py:1075:test_004()/333
 cmd: $NMCLI --mode tabular -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 568 bytes
+stdout: 570 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infra  1     2412 MHz  54 Mbit/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/2 
 
+
+
 <<<
-size: 779
+size: 781
 location: clients/tests/test-client.py:1075:test_004()/334
 cmd: $NMCLI --mode tabular -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 586 bytes
+stdout: 588 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infrastruktura  1     2412 MHz  54 Mb/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/2 
 
+
+
 <<<
-size: 324
+size: 326
 location: clients/tests/test-client.py:1077:test_004()/335
 cmd: $NMCLI --mode tabular -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 138 bytes
+stdout: 140 bytes
 >>>
 IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
         wlan0-ap-2  Infra  1     54 Mbit/s  92      ****  WPA1 WPA2 
 
+
+
 <<<
-size: 350
+size: 352
 location: clients/tests/test-client.py:1077:test_004()/336
 cmd: $NMCLI --mode tabular -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 154 bytes
+stdout: 156 bytes
 >>>
 IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
         wlan0-ap-2  Infrastruktura  1     54 Mb/s  92      ****  WPA1 WPA2 
 
+
+
 <<<
-size: 864
+size: 866
 location: clients/tests/test-client.py:1080:test_004()/337
 cmd: $NMCLI --mode tabular -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 568 bytes
+stdout: 570 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infra  1     2412 MHz  54 Mbit/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/2 
 
+
+
 <<<
-size: 892
+size: 894
 location: clients/tests/test-client.py:1080:test_004()/338
 cmd: $NMCLI --mode tabular -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 586 bytes
+stdout: 588 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infrastruktura  1     2412 MHz  54 Mb/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/2 
+
+
 
 <<<
 size: 3015
@@ -20896,11 +20980,11 @@ returncode: 0
 stdout: 418 bytes
 >>>
 DEVICE  TYPE      STATE        CONNECTION 
+[2mwlan0[0m   [2mwifi[0m      [2munavailable[0m  [2mcon-vpn-1[0m  
 [2meth0[0m    [2methernet[0m  [2munavailable[0m  [2m--[0m         
 [2meth1[0m    [2methernet[0m  [2munavailable[0m  [2m--[0m         
 [2mwlan1[0m   [2mwifi[0m      [2munavailable[0m  [2m--[0m         
 [2mwlan1[0m   [2mwifi[0m      [2munavailable[0m  [2m--[0m         
-[2mwlan0[0m   [2mwifi[0m      [2munavailable[0m  [2mcon-vpn-1[0m  
 
 <<<
 size: 586
@@ -20911,11 +20995,11 @@ returncode: 0
 stdout: 423 bytes
 >>>
 DEVICE  TYPE      STATE        CONNECTION 
+[2mwlan0[0m   [2mwifi[0m      [2mniedostępne[0m  [2mcon-vpn-1[0m  
 [2meth0[0m    [2methernet[0m  [2mniedostępne[0m  [2m--[0m         
 [2meth1[0m    [2methernet[0m  [2mniedostępne[0m  [2m--[0m         
 [2mwlan1[0m   [2mwifi[0m      [2mniedostępne[0m  [2m--[0m         
 [2mwlan1[0m   [2mwifi[0m      [2mniedostępne[0m  [2m--[0m         
-[2mwlan0[0m   [2mwifi[0m      [2mniedostępne[0m  [2mcon-vpn-1[0m  
 
 <<<
 size: 1798
@@ -20926,11 +21010,11 @@ returncode: 0
 stdout: 1632 bytes
 >>>
 DEVICE  TYPE      STATE        IP4-CONNECTIVITY  IP6-CONNECTIVITY  DBUS-PATH                                  CONNECTION  CON-UUID                              CON-PATH                                           
+[2mwlan0[0m   [2mwifi[0m      [2munavailable[0m  [2munknown[0m           [2munknown[0m           [2m/org/freedesktop/NetworkManager/Devices/3[0m  [2mcon-vpn-1[0m   [2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m  [2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m 
 [2meth0[0m    [2methernet[0m  [2munavailable[0m  [2munknown[0m           [2munknown[0m           [2m/org/freedesktop/NetworkManager/Devices/1[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
 [2meth1[0m    [2methernet[0m  [2munavailable[0m  [2munknown[0m           [2munknown[0m           [2m/org/freedesktop/NetworkManager/Devices/2[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
 [2mwlan1[0m   [2mwifi[0m      [2munavailable[0m  [2munknown[0m           [2munknown[0m           [2m/org/freedesktop/NetworkManager/Devices/4[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
 [2mwlan1[0m   [2mwifi[0m      [2munavailable[0m  [2munknown[0m           [2munknown[0m           [2m/org/freedesktop/NetworkManager/Devices/5[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
-[2mwlan0[0m   [2mwifi[0m      [2munavailable[0m  [2munknown[0m           [2munknown[0m           [2m/org/freedesktop/NetworkManager/Devices/3[0m  [2mcon-vpn-1[0m   [2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m  [2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m 
 
 <<<
 size: 1813
@@ -20941,11 +21025,11 @@ returncode: 0
 stdout: 1637 bytes
 >>>
 DEVICE  TYPE      STATE        IP4-CONNECTIVITY  IP6-CONNECTIVITY  DBUS-PATH                                  CONNECTION  CON-UUID                              CON-PATH                                           
+[2mwlan0[0m   [2mwifi[0m      [2mniedostępne[0m  [2mnieznane[0m          [2mnieznane[0m          [2m/org/freedesktop/NetworkManager/Devices/3[0m  [2mcon-vpn-1[0m   [2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m  [2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m 
 [2meth0[0m    [2methernet[0m  [2mniedostępne[0m  [2mnieznane[0m          [2mnieznane[0m          [2m/org/freedesktop/NetworkManager/Devices/1[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
 [2meth1[0m    [2methernet[0m  [2mniedostępne[0m  [2mnieznane[0m          [2mnieznane[0m          [2m/org/freedesktop/NetworkManager/Devices/2[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
 [2mwlan1[0m   [2mwifi[0m      [2mniedostępne[0m  [2mnieznane[0m          [2mnieznane[0m          [2m/org/freedesktop/NetworkManager/Devices/4[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
 [2mwlan1[0m   [2mwifi[0m      [2mniedostępne[0m  [2mnieznane[0m          [2mnieznane[0m          [2m/org/freedesktop/NetworkManager/Devices/5[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
-[2mwlan0[0m   [2mwifi[0m      [2mniedostępne[0m  [2mnieznane[0m          [2mnieznane[0m          [2m/org/freedesktop/NetworkManager/Devices/3[0m  [2mcon-vpn-1[0m   [2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m  [2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m 
 
 <<<
 size: 6373
@@ -20956,6 +21040,33 @@ returncode: 0
 stdout: 6216 bytes
 >>>
 DEVICE 
+wlan0  
+
+TYPE 
+wifi 
+
+HWADDR            
+13:E0:74:85:7C:D9 
+
+MTU 
+0   
+
+STATE            
+20 (unavailable) 
+
+CONNECTION 
+con-vpn-1  
+
+CON-PATH                                           
+/org/freedesktop/NetworkManager/ActiveConnection/2 
+
+GROUP  ADDRESS                                 GATEWAY         ROUTE  DNS  DOMAIN                                                                            WINS           
+IP4    192.168.228.18/32 | 192.168.209.179/25  192.168.41.120  --     --   sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar  192.168.120.79 
+
+GROUP  ADDRESS  GATEWAY  ROUTE                                                           DNS  DOMAIN                                                                                            
+IP6    --       --       dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086  --   sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar 
+
+DEVICE 
 eth0   
 
 TYPE     
@@ -21068,33 +21179,6 @@ IP4    192.168.97.124/29 | 192.168.76.154/18  --       dst = 192.168.33.233/22, 
 
 GROUP  ADDRESS                        GATEWAY  ROUTE                                                                                                                                                                                                      DNS                          DOMAIN       
 IP6    2001:a::88ca:3654:96b:ab44/89  --       dst = 2001:a::cc8b:7c09:4673:bbb0/85, nh = ::, mt = 2821465568 | dst = 2001:a::a976:2488:f49f:b48/106, nh = 2001:a::62ae:c734:fc7b:e931, mt = 2248613879 | dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::  2001:a::2934:bd66:550d:ec19  sear6.fo.x.y 
-
-DEVICE 
-wlan0  
-
-TYPE 
-wifi 
-
-HWADDR            
-13:E0:74:85:7C:D9 
-
-MTU 
-0   
-
-STATE            
-20 (unavailable) 
-
-CONNECTION 
-con-vpn-1  
-
-CON-PATH                                           
-/org/freedesktop/NetworkManager/ActiveConnection/2 
-
-GROUP  ADDRESS                                 GATEWAY         ROUTE  DNS  DOMAIN                                                                            WINS           
-IP4    192.168.228.18/32 | 192.168.209.179/25  192.168.41.120  --     --   sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar  192.168.120.79 
-
-GROUP  ADDRESS  GATEWAY  ROUTE                                                           DNS  DOMAIN                                                                                            
-IP6    --       --       dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086  --   sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar 
 
 <<<
 size: 6400
@@ -21105,6 +21189,33 @@ returncode: 0
 stdout: 6233 bytes
 >>>
 DEVICE 
+wlan0  
+
+TYPE 
+wifi 
+
+HWADDR            
+13:E0:74:85:7C:D9 
+
+MTU 
+0   
+
+STATE            
+20 (niedostępne) 
+
+CONNECTION 
+con-vpn-1  
+
+CON-PATH                                           
+/org/freedesktop/NetworkManager/ActiveConnection/2 
+
+GROUP  ADDRESS                                 GATEWAY         ROUTE  DNS  DOMAIN                                                                            WINS           
+IP4    192.168.228.18/32 | 192.168.209.179/25  192.168.41.120  --     --   sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar  192.168.120.79 
+
+GROUP  ADDRESS  GATEWAY  ROUTE                                                           DNS  DOMAIN                                                                                            
+IP6    --       --       dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086  --   sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar 
+
+DEVICE 
 eth0   
 
 TYPE     
@@ -21218,33 +21329,6 @@ IP4    192.168.97.124/29 | 192.168.76.154/18  --       dst = 192.168.33.233/22, 
 GROUP  ADDRESS                        GATEWAY  ROUTE                                                                                                                                                                                                      DNS                          DOMAIN       
 IP6    2001:a::88ca:3654:96b:ab44/89  --       dst = 2001:a::cc8b:7c09:4673:bbb0/85, nh = ::, mt = 2821465568 | dst = 2001:a::a976:2488:f49f:b48/106, nh = 2001:a::62ae:c734:fc7b:e931, mt = 2248613879 | dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::  2001:a::2934:bd66:550d:ec19  sear6.fo.x.y 
 
-DEVICE 
-wlan0  
-
-TYPE 
-wifi 
-
-HWADDR            
-13:E0:74:85:7C:D9 
-
-MTU 
-0   
-
-STATE            
-20 (niedostępne) 
-
-CONNECTION 
-con-vpn-1  
-
-CON-PATH                                           
-/org/freedesktop/NetworkManager/ActiveConnection/2 
-
-GROUP  ADDRESS                                 GATEWAY         ROUTE  DNS  DOMAIN                                                                            WINS           
-IP4    192.168.228.18/32 | 192.168.209.179/25  192.168.41.120  --     --   sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar  192.168.120.79 
-
-GROUP  ADDRESS  GATEWAY  ROUTE                                                           DNS  DOMAIN                                                                                            
-IP6    --       --       dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086  --   sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar 
-
 <<<
 size: 15197
 location: clients/tests/test-client.py:1050:test_004()/361
@@ -21253,6 +21337,35 @@ lang: C
 returncode: 0
 stdout: 15032 bytes
 >>>
+NAME     DEVICE  TYPE  NM-TYPE       VENDOR  PRODUCT  DRIVER   DRIVER-VERSION  FIRMWARE-VERSION  HWADDR             MTU  STATE             REASON               IP4-CONNECTIVITY  IP6-CONNECTIVITY  UDI                         IP-IFACE  IS-SOFTWARE  NM-MANAGED  AUTOCONNECT  FIRMWARE-MISSING  NM-PLUGIN-MISSING  PHYS-PORT-ID  CONNECTION  CON-UUID                              CON-PATH                                            METERED 
+GENERAL  wlan0   wifi  NMDeviceWifi  --      --       virtual  --              --                13:E0:74:85:7C:D9  0    20 (unavailable)  0 (No reason given)  0 (unknown)       0 (unknown)       /sys/devices/virtual/wlan0  --        no           yes         yes          no                no                 --            con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2  unknown 
+
+NAME          CARRIER-DETECT  SPEED    IS-SOFTWARE  SRIOV 
+CAPABILITIES  no              unknown  no           no    
+
+NAME             WEP  WPA  WPA2  TKIP  CCMP  AP   ADHOC  2GHZ     5GHZ    
+WIFI-PROPERTIES  yes  yes  yes   yes   yes   yes  yes    unknown  unknown 
+
+NAME   IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
+[32mAP[1][0m  [32m [0m       [32mwlan0-ap-2[0m  [32mInfra[0m  [32m1[0m     [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
+[32mAP[2][0m  [32m [0m       [32mwlan0-ap-1[0m  [32mInfra[0m  [32m1[0m     [32m54 Mbit/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m 
+[35mAP[3][0m  [35m [0m       [35mwlan0-ap-3[0m  [35mInfra[0m  [35m1[0m     [35m54 Mbit/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
+
+GROUP  ADDRESS                                 GATEWAY         ROUTE  DNS  DOMAIN                                                                            WINS           
+IP4    192.168.228.18/32 | 192.168.209.179/25  192.168.41.120  --     --   sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar  192.168.120.79 
+
+GROUP  OPTION                                                                                    
+DHCP4  dhcp-4-opt-0 = val-0 | dhcp-4-opt-2 = val-2 | dhcp-4-opt-4 = val-4 | dhcp-4-opt-7 = val-7 
+
+GROUP  ADDRESS  GATEWAY  ROUTE                                                           DNS  DOMAIN                                                                                            
+IP6    --       --       dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086  --   sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar 
+
+GROUP  OPTION                                                                                                           
+DHCP6  dhcp-6-opt-1 = val-1 | dhcp-6-opt-2 = val-2 | dhcp-6-opt-3 = val-3 | dhcp-6-opt-4 = val-4 | dhcp-6-opt-5 = val-5 
+
+NAME         AVAILABLE-CONNECTION-PATHS                               AVAILABLE-CONNECTIONS                          
+CONNECTIONS  /org/freedesktop/NetworkManager/Settings/Connection/{2}  UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1 
+
 NAME     DEVICE  TYPE      NM-TYPE           VENDOR  PRODUCT  DRIVER   DRIVER-VERSION  FIRMWARE-VERSION  HWADDR             MTU  STATE             REASON               IP4-CONNECTIVITY  IP6-CONNECTIVITY  UDI                        IP-IFACE  IS-SOFTWARE  NM-MANAGED  AUTOCONNECT  FIRMWARE-MISSING  NM-PLUGIN-MISSING  PHYS-PORT-ID  CONNECTION  CON-UUID  CON-PATH  METERED 
 GENERAL  eth0    ethernet  NMDeviceEthernet  --      --       virtual  --              --                AB:B7:BF:E2:48:E8  0    20 (unavailable)  0 (No reason given)  0 (unknown)       0 (unknown)       /sys/devices/virtual/eth0  --        no           yes         yes          no                no                 --            --          --        --        unknown 
 
@@ -21354,19 +21467,27 @@ DHCP6  dhcp-6-opt-2 = val-2 | dhcp-6-opt-6 = val-6 | dhcp-6-opt-7 = val-7 | dhcp
 NAME         AVAILABLE-CONNECTION-PATHS                               AVAILABLE-CONNECTIONS                          
 CONNECTIONS  /org/freedesktop/NetworkManager/Settings/Connection/{2}  UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1 
 
-NAME     DEVICE  TYPE  NM-TYPE       VENDOR  PRODUCT  DRIVER   DRIVER-VERSION  FIRMWARE-VERSION  HWADDR             MTU  STATE             REASON               IP4-CONNECTIVITY  IP6-CONNECTIVITY  UDI                         IP-IFACE  IS-SOFTWARE  NM-MANAGED  AUTOCONNECT  FIRMWARE-MISSING  NM-PLUGIN-MISSING  PHYS-PORT-ID  CONNECTION  CON-UUID                              CON-PATH                                            METERED 
-GENERAL  wlan0   wifi  NMDeviceWifi  --      --       virtual  --              --                13:E0:74:85:7C:D9  0    20 (unavailable)  0 (No reason given)  0 (unknown)       0 (unknown)       /sys/devices/virtual/wlan0  --        no           yes         yes          no                no                 --            con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2  unknown 
+<<<
+size: 15356
+location: clients/tests/test-client.py:1050:test_004()/362
+cmd: $NMCLI --mode tabular --color yes -f all dev show
+lang: pl_PL.UTF-8
+returncode: 0
+stdout: 15181 bytes
+>>>
+NAME     DEVICE  TYPE  NM-TYPE       VENDOR  PRODUCT  DRIVER   DRIVER-VERSION  FIRMWARE-VERSION  HWADDR             MTU  STATE             REASON                    IP4-CONNECTIVITY  IP6-CONNECTIVITY  UDI                         IP-IFACE  IS-SOFTWARE  NM-MANAGED  AUTOCONNECT  FIRMWARE-MISSING  NM-PLUGIN-MISSING  PHYS-PORT-ID  CONNECTION  CON-UUID                              CON-PATH                                            METERED  
+GENERAL  wlan0   wifi  NMDeviceWifi  --      --       virtual  --              --                13:E0:74:85:7C:D9  0    20 (niedostępne)  0 (Nie podano przyczyny)  0 (nieznane)      0 (nieznane)      /sys/devices/virtual/wlan0  --        nie          tak         tak          nie               nie                --            con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2  nieznane 
 
-NAME          CARRIER-DETECT  SPEED    IS-SOFTWARE  SRIOV 
-CAPABILITIES  no              unknown  no           no    
+NAME          CARRIER-DETECT  SPEED     IS-SOFTWARE  SRIOV 
+CAPABILITIES  nie             nieznane  nie          nie   
 
-NAME             WEP  WPA  WPA2  TKIP  CCMP  AP   ADHOC  2GHZ     5GHZ    
-WIFI-PROPERTIES  yes  yes  yes   yes   yes   yes  yes    unknown  unknown 
+NAME             WEP  WPA  WPA2  TKIP  CCMP  AP   ADHOC  2GHZ      5GHZ     
+WIFI-PROPERTIES  tak  tak  tak   tak   tak   tak  tak    nieznane  nieznane 
 
-NAME   IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
-[32mAP[1][0m  [32m [0m       [32mwlan0-ap-2[0m  [32mInfra[0m  [32m1[0m     [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
-[32mAP[2][0m  [32m [0m       [32mwlan0-ap-1[0m  [32mInfra[0m  [32m1[0m     [32m54 Mbit/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m 
-[35mAP[3][0m  [35m [0m       [35mwlan0-ap-3[0m  [35mInfra[0m  [35m1[0m     [35m54 Mbit/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
+NAME   IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
+[32mAP[1][0m  [32m [0m       [32mwlan0-ap-2[0m  [32mInfrastruktura[0m  [32m1[0m     [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
+[32mAP[2][0m  [32m [0m       [32mwlan0-ap-1[0m  [32mInfrastruktura[0m  [32m1[0m     [32m54 Mb/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m 
+[35mAP[3][0m  [35m [0m       [35mwlan0-ap-3[0m  [35mInfrastruktura[0m  [35m1[0m     [35m54 Mb/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
 
 GROUP  ADDRESS                                 GATEWAY         ROUTE  DNS  DOMAIN                                                                            WINS           
 IP4    192.168.228.18/32 | 192.168.209.179/25  192.168.41.120  --     --   sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar  192.168.120.79 
@@ -21383,14 +21504,6 @@ DHCP6  dhcp-6-opt-1 = val-1 | dhcp-6-opt-2 = val-2 | dhcp-6-opt-3 = val-3 | dhcp
 NAME         AVAILABLE-CONNECTION-PATHS                               AVAILABLE-CONNECTIONS                          
 CONNECTIONS  /org/freedesktop/NetworkManager/Settings/Connection/{2}  UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1 
 
-<<<
-size: 15356
-location: clients/tests/test-client.py:1050:test_004()/362
-cmd: $NMCLI --mode tabular --color yes -f all dev show
-lang: pl_PL.UTF-8
-returncode: 0
-stdout: 15181 bytes
->>>
 NAME     DEVICE  TYPE      NM-TYPE           VENDOR  PRODUCT  DRIVER   DRIVER-VERSION  FIRMWARE-VERSION  HWADDR             MTU  STATE             REASON                    IP4-CONNECTIVITY  IP6-CONNECTIVITY  UDI                        IP-IFACE  IS-SOFTWARE  NM-MANAGED  AUTOCONNECT  FIRMWARE-MISSING  NM-PLUGIN-MISSING  PHYS-PORT-ID  CONNECTION  CON-UUID  CON-PATH  METERED  
 GENERAL  eth0    ethernet  NMDeviceEthernet  --      --       virtual  --              --                AB:B7:BF:E2:48:E8  0    20 (niedostępne)  0 (Nie podano przyczyny)  0 (nieznane)      0 (nieznane)      /sys/devices/virtual/eth0  --        nie          tak         tak          nie               nie                --            --          --        --        nieznane 
 
@@ -21488,35 +21601,6 @@ IP6    2001:a::88ca:3654:96b:ab44/89  --       dst = 2001:a::cc8b:7c09:4673:bbb0
 
 GROUP  OPTION                                                                                                           
 DHCP6  dhcp-6-opt-2 = val-2 | dhcp-6-opt-6 = val-6 | dhcp-6-opt-7 = val-7 | dhcp-6-opt-8 = val-8 | dhcp-6-opt-9 = val-9 
-
-NAME         AVAILABLE-CONNECTION-PATHS                               AVAILABLE-CONNECTIONS                          
-CONNECTIONS  /org/freedesktop/NetworkManager/Settings/Connection/{2}  UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1 
-
-NAME     DEVICE  TYPE  NM-TYPE       VENDOR  PRODUCT  DRIVER   DRIVER-VERSION  FIRMWARE-VERSION  HWADDR             MTU  STATE             REASON                    IP4-CONNECTIVITY  IP6-CONNECTIVITY  UDI                         IP-IFACE  IS-SOFTWARE  NM-MANAGED  AUTOCONNECT  FIRMWARE-MISSING  NM-PLUGIN-MISSING  PHYS-PORT-ID  CONNECTION  CON-UUID                              CON-PATH                                            METERED  
-GENERAL  wlan0   wifi  NMDeviceWifi  --      --       virtual  --              --                13:E0:74:85:7C:D9  0    20 (niedostępne)  0 (Nie podano przyczyny)  0 (nieznane)      0 (nieznane)      /sys/devices/virtual/wlan0  --        nie          tak         tak          nie               nie                --            con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2  nieznane 
-
-NAME          CARRIER-DETECT  SPEED     IS-SOFTWARE  SRIOV 
-CAPABILITIES  nie             nieznane  nie          nie   
-
-NAME             WEP  WPA  WPA2  TKIP  CCMP  AP   ADHOC  2GHZ      5GHZ     
-WIFI-PROPERTIES  tak  tak  tak   tak   tak   tak  tak    nieznane  nieznane 
-
-NAME   IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
-[32mAP[1][0m  [32m [0m       [32mwlan0-ap-2[0m  [32mInfrastruktura[0m  [32m1[0m     [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
-[32mAP[2][0m  [32m [0m       [32mwlan0-ap-1[0m  [32mInfrastruktura[0m  [32m1[0m     [32m54 Mb/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m 
-[35mAP[3][0m  [35m [0m       [35mwlan0-ap-3[0m  [35mInfrastruktura[0m  [35m1[0m     [35m54 Mb/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
-
-GROUP  ADDRESS                                 GATEWAY         ROUTE  DNS  DOMAIN                                                                            WINS           
-IP4    192.168.228.18/32 | 192.168.209.179/25  192.168.41.120  --     --   sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar  192.168.120.79 
-
-GROUP  OPTION                                                                                    
-DHCP4  dhcp-4-opt-0 = val-0 | dhcp-4-opt-2 = val-2 | dhcp-4-opt-4 = val-4 | dhcp-4-opt-7 = val-7 
-
-GROUP  ADDRESS  GATEWAY  ROUTE                                                           DNS  DOMAIN                                                                                            
-IP6    --       --       dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086  --   sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar 
-
-GROUP  OPTION                                                                                                           
-DHCP6  dhcp-6-opt-1 = val-1 | dhcp-6-opt-2 = val-2 | dhcp-6-opt-3 = val-3 | dhcp-6-opt-4 = val-4 | dhcp-6-opt-5 = val-5 
 
 NAME         AVAILABLE-CONNECTION-PATHS                               AVAILABLE-CONNECTIONS                          
 CONNECTIONS  /org/freedesktop/NetworkManager/Settings/Connection/{2}  UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1 
@@ -21742,11 +21826,11 @@ returncode: 0
 stdout: 486 bytes
 >>>
 DEVICE  TYPE      DBUS-PATH                                 
+[2mwlan0[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/3[0m 
 [2meth0[0m    [2methernet[0m  [2m/org/freedesktop/NetworkManager/Devices/1[0m 
 [2meth1[0m    [2methernet[0m  [2m/org/freedesktop/NetworkManager/Devices/2[0m 
 [2mwlan1[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/4[0m 
 [2mwlan1[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/5[0m 
-[2mwlan0[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/3[0m 
 
 <<<
 size: 672
@@ -21757,11 +21841,11 @@ returncode: 0
 stdout: 486 bytes
 >>>
 DEVICE  TYPE      DBUS-PATH                                 
+[2mwlan0[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/3[0m 
 [2meth0[0m    [2methernet[0m  [2m/org/freedesktop/NetworkManager/Devices/1[0m 
 [2meth1[0m    [2methernet[0m  [2m/org/freedesktop/NetworkManager/Devices/2[0m 
 [2mwlan1[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/4[0m 
 [2mwlan1[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/5[0m 
-[2mwlan0[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/3[0m 
 
 <<<
 size: 2624
@@ -21772,14 +21856,14 @@ returncode: 0
 stdout: 2452 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
-[35mAP[1][0m  [35mwlan1-ap-4[0m  [35m776C616E312D61702D34[0m  [35m94:2B:E8:F6:D2:86[0m  [35mInfra[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mbit/s[0m  [35m48[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan1[0m   [35mno[0m      [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m 
-
-NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
-
-NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 [32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
 [32mAP[2][0m  [32mwlan0-ap-1[0m  [32m776C616E302D61702D31[0m  [32m61:95:77:AC:1E:4C[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/1[0m 
 [35mAP[3][0m  [35mwlan0-ap-3[0m  [35m776C616E302D61702D33[0m  [35m9B:F6:B7:EC:97:76[0m  [35mInfra[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mbit/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan0[0m   [35mno[0m      [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m 
+
+NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+[35mAP[1][0m  [35mwlan1-ap-4[0m  [35m776C616E312D61702D34[0m  [35m94:2B:E8:F6:D2:86[0m  [35mInfra[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mbit/s[0m  [35m48[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan1[0m   [35mno[0m      [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m 
+
+NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 
 <<<
 size: 2692
@@ -21790,14 +21874,14 @@ returncode: 0
 stdout: 2510 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
-[35mAP[1][0m  [35mwlan1-ap-4[0m  [35m776C616E312D61702D34[0m  [35m94:2B:E8:F6:D2:86[0m  [35mInfrastruktura[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mb/s[0m  [35m48[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan1[0m   [35mnie[0m     [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m 
-
-NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
-
-NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 [32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
 [32mAP[2][0m  [32mwlan0-ap-1[0m  [32m776C616E302D61702D31[0m  [32m61:95:77:AC:1E:4C[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/1[0m 
 [35mAP[3][0m  [35mwlan0-ap-3[0m  [35m776C616E302D61702D33[0m  [35m9B:F6:B7:EC:97:76[0m  [35mInfrastruktura[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mb/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan0[0m   [35mnie[0m     [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m 
+
+NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+[35mAP[1][0m  [35mwlan1-ap-4[0m  [35m776C616E312D61702D34[0m  [35m94:2B:E8:F6:D2:86[0m  [35mInfrastruktura[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mb/s[0m  [35m48[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan1[0m   [35mnie[0m     [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m 
+
+NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 
 <<<
 size: 934
@@ -21808,14 +21892,14 @@ returncode: 0
 stdout: 760 bytes
 >>>
 IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
-[35m [0m       [35mwlan1-ap-4[0m  [35mInfra[0m  [35m1[0m     [35m54 Mbit/s[0m  [35m48[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
-
-IN-USE  SSID  MODE  CHAN  RATE  SIGNAL  BARS  SECURITY 
-
-IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
 [32m [0m       [32mwlan0-ap-2[0m  [32mInfra[0m  [32m1[0m     [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
 [32m [0m       [32mwlan0-ap-1[0m  [32mInfra[0m  [32m1[0m     [32m54 Mbit/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m 
 [35m [0m       [35mwlan0-ap-3[0m  [35mInfra[0m  [35m1[0m     [35m54 Mbit/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
+
+IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
+[35m [0m       [35mwlan1-ap-4[0m  [35mInfra[0m  [35m1[0m     [35m54 Mbit/s[0m  [35m48[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
+
+IN-USE  SSID  MODE  CHAN  RATE  SIGNAL  BARS  SECURITY 
 
 <<<
 size: 994
@@ -21826,14 +21910,14 @@ returncode: 0
 stdout: 810 bytes
 >>>
 IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
-[35m [0m       [35mwlan1-ap-4[0m  [35mInfrastruktura[0m  [35m1[0m     [35m54 Mb/s[0m  [35m48[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
-
-IN-USE  SSID  MODE  CHAN  RATE  SIGNAL  BARS  SECURITY 
-
-IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
 [32m [0m       [32mwlan0-ap-2[0m  [32mInfrastruktura[0m  [32m1[0m     [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
 [32m [0m       [32mwlan0-ap-1[0m  [32mInfrastruktura[0m  [32m1[0m     [32m54 Mb/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m 
 [35m [0m       [35mwlan0-ap-3[0m  [35mInfrastruktura[0m  [35m1[0m     [35m54 Mb/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
+
+IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
+[35m [0m       [35mwlan1-ap-4[0m  [35mInfrastruktura[0m  [35m1[0m     [35m54 Mb/s[0m  [35m48[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
+
+IN-USE  SSID  MODE  CHAN  RATE  SIGNAL  BARS  SECURITY 
 
 <<<
 size: 2737
@@ -21844,14 +21928,14 @@ returncode: 0
 stdout: 2452 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
-[35mAP[1][0m  [35mwlan1-ap-4[0m  [35m776C616E312D61702D34[0m  [35m94:2B:E8:F6:D2:86[0m  [35mInfra[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mbit/s[0m  [35m48[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan1[0m   [35mno[0m      [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m 
-
-NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
-
-NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 [32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
 [32mAP[2][0m  [32mwlan0-ap-1[0m  [32m776C616E302D61702D31[0m  [32m61:95:77:AC:1E:4C[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/1[0m 
 [35mAP[3][0m  [35mwlan0-ap-3[0m  [35m776C616E302D61702D33[0m  [35m9B:F6:B7:EC:97:76[0m  [35mInfra[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mbit/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan0[0m   [35mno[0m      [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m 
+
+NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+[35mAP[1][0m  [35mwlan1-ap-4[0m  [35m776C616E312D61702D34[0m  [35m94:2B:E8:F6:D2:86[0m  [35mInfra[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mbit/s[0m  [35m48[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan1[0m   [35mno[0m      [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m 
+
+NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 
 <<<
 size: 2805
@@ -21862,80 +21946,92 @@ returncode: 0
 stdout: 2510 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
-[35mAP[1][0m  [35mwlan1-ap-4[0m  [35m776C616E312D61702D34[0m  [35m94:2B:E8:F6:D2:86[0m  [35mInfrastruktura[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mb/s[0m  [35m48[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan1[0m   [35mnie[0m     [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m 
-
-NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
-
-NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 [32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
 [32mAP[2][0m  [32mwlan0-ap-1[0m  [32m776C616E302D61702D31[0m  [32m61:95:77:AC:1E:4C[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/1[0m 
 [35mAP[3][0m  [35mwlan0-ap-3[0m  [35m776C616E302D61702D33[0m  [35m9B:F6:B7:EC:97:76[0m  [35mInfrastruktura[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mb/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan0[0m   [35mnie[0m     [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m 
 
+NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+[35mAP[1][0m  [35mwlan1-ap-4[0m  [35m776C616E312D61702D34[0m  [35m94:2B:E8:F6:D2:86[0m  [35mInfrastruktura[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mb/s[0m  [35m48[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan1[0m   [35mnie[0m     [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m 
+
+NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
+
 <<<
-size: 916
+size: 918
 location: clients/tests/test-client.py:1075:test_004()/379
 cmd: $NMCLI --mode tabular --color yes -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 721 bytes
+stdout: 723 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 [32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
 
+
+
 <<<
-size: 944
+size: 946
 location: clients/tests/test-client.py:1075:test_004()/380
 cmd: $NMCLI --mode tabular --color yes -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 739 bytes
+stdout: 741 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 [32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
 
+
+
 <<<
-size: 408
+size: 410
 location: clients/tests/test-client.py:1077:test_004()/381
 cmd: $NMCLI --mode tabular --color yes -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 210 bytes
+stdout: 212 bytes
 >>>
 IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
 [32m [0m       [32mwlan0-ap-2[0m  [32mInfra[0m  [32m1[0m     [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
 
+
+
 <<<
-size: 434
+size: 436
 location: clients/tests/test-client.py:1077:test_004()/382
 cmd: $NMCLI --mode tabular --color yes -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 226 bytes
+stdout: 228 bytes
 >>>
 IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
 [32m [0m       [32mwlan0-ap-2[0m  [32mInfrastruktura[0m  [32m1[0m     [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
 
+
+
 <<<
-size: 1029
+size: 1031
 location: clients/tests/test-client.py:1080:test_004()/383
 cmd: $NMCLI --mode tabular --color yes -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 721 bytes
+stdout: 723 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 [32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
 
+
+
 <<<
-size: 1057
+size: 1059
 location: clients/tests/test-client.py:1080:test_004()/384
 cmd: $NMCLI --mode tabular --color yes -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 739 bytes
+stdout: 741 bytes
 >>>
 NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 [32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
+
+
 
 <<<
 size: 3270
@@ -22460,11 +22556,11 @@ stdout: 387 bytes
 =====================
 DEVICE  TYPE      STATE        CONNECTION 
 ----------------------------------------------------------------
+wlan0   wifi      unavailable  con-vpn-1  
 eth0    ethernet  unavailable  --         
 eth1    ethernet  unavailable  --         
 wlan1   wifi      unavailable  --         
 wlan1   wifi      unavailable  --         
-wlan0   wifi      unavailable  con-vpn-1  
 
 <<<
 size: 545
@@ -22479,11 +22575,11 @@ stdout: 385 bytes
 ===================
 DEVICE  TYPE      STATE        CONNECTION 
 --------------------------------------------------------------
+wlan0   wifi      niedostępne  con-vpn-1  
 eth0    ethernet  niedostępne  --         
 eth1    ethernet  niedostępne  --         
 wlan1   wifi      niedostępne  --         
 wlan1   wifi      niedostępne  --         
-wlan0   wifi      niedostępne  con-vpn-1  
 
 <<<
 size: 1733
@@ -22498,11 +22594,11 @@ stdout: 1570 bytes
 =====================
 DEVICE  TYPE      STATE        IP4-CONNECTIVITY  IP6-CONNECTIVITY  DBUS-PATH                                  CONNECTION  CON-UUID                              CON-PATH                                           
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+wlan0   wifi      unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/3  con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2 
 eth0    ethernet  unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/1  --          --                                    --                                                 
 eth1    ethernet  unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/2  --          --                                    --                                                 
 wlan1   wifi      unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/4  --          --                                    --                                                 
 wlan1   wifi      unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/5  --          --                                    --                                                 
-wlan0   wifi      unavailable  unknown           unknown           /org/freedesktop/NetworkManager/Devices/3  con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2 
 
 <<<
 size: 1741
@@ -22517,11 +22613,11 @@ stdout: 1568 bytes
 ===================
 DEVICE  TYPE      STATE        IP4-CONNECTIVITY  IP6-CONNECTIVITY  DBUS-PATH                                  CONNECTION  CON-UUID                              CON-PATH                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+wlan0   wifi      niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/3  con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2 
 eth0    ethernet  niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/1  --          --                                    --                                                 
 eth1    ethernet  niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/2  --          --                                    --                                                 
 wlan1   wifi      niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/4  --          --                                    --                                                 
 wlan1   wifi      niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/5  --          --                                    --                                                 
-wlan0   wifi      niedostępne  nieznane          nieznane          /org/freedesktop/NetworkManager/Devices/3  con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2 
 
 <<<
 size: 9891
@@ -22531,6 +22627,45 @@ lang: C
 returncode: 0
 stdout: 9737 bytes
 >>>
+==========================
+  Device details (wlan0)
+==========================
+DEVICE 
+--------
+wlan0  
+
+TYPE 
+------
+wifi 
+
+HWADDR            
+-------------------
+13:E0:74:85:7C:D9 
+
+MTU 
+-----
+0   
+
+STATE            
+------------------
+20 (unavailable) 
+
+CONNECTION 
+------------
+con-vpn-1  
+
+CON-PATH                                           
+----------------------------------------------------
+/org/freedesktop/NetworkManager/ActiveConnection/2 
+
+GROUP  ADDRESS                                 GATEWAY         ROUTE  DNS  DOMAIN                                                                            WINS           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+IP4    192.168.228.18/32 | 192.168.209.179/25  192.168.41.120  --     --   sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar  192.168.120.79 
+
+GROUP  ADDRESS  GATEWAY  ROUTE                                                           DNS  DOMAIN                                                                                            
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+IP6    --       --       dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086  --   sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar 
+
 =========================
   Device details (eth0)
 =========================
@@ -22695,9 +22830,17 @@ GROUP  ADDRESS                        GATEWAY  ROUTE                            
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 IP6    2001:a::88ca:3654:96b:ab44/89  --       dst = 2001:a::cc8b:7c09:4673:bbb0/85, nh = ::, mt = 2821465568 | dst = 2001:a::a976:2488:f49f:b48/106, nh = 2001:a::62ae:c734:fc7b:e931, mt = 2248613879 | dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::  2001:a::2934:bd66:550d:ec19  sear6.fo.x.y 
 
-==========================
-  Device details (wlan0)
-==========================
+<<<
+size: 10067
+location: clients/tests/test-client.py:1047:test_004()/406
+cmd: $NMCLI --mode tabular --pretty dev show
+lang: pl_PL.UTF-8
+returncode: 0
+stdout: 9903 bytes
+>>>
+===================================
+  Informacje o urządzeniu (wlan0)
+===================================
 DEVICE 
 --------
 wlan0  
@@ -22716,7 +22859,7 @@ MTU
 
 STATE            
 ------------------
-20 (unavailable) 
+20 (niedostępne) 
 
 CONNECTION 
 ------------
@@ -22734,14 +22877,6 @@ GROUP  ADDRESS  GATEWAY  ROUTE                                                  
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 IP6    --       --       dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086  --   sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar 
 
-<<<
-size: 10067
-location: clients/tests/test-client.py:1047:test_004()/406
-cmd: $NMCLI --mode tabular --pretty dev show
-lang: pl_PL.UTF-8
-returncode: 0
-stdout: 9903 bytes
->>>
 ==================================
   Informacje o urządzeniu (eth0)
 ==================================
@@ -22906,45 +23041,6 @@ GROUP  ADDRESS                        GATEWAY  ROUTE                            
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 IP6    2001:a::88ca:3654:96b:ab44/89  --       dst = 2001:a::cc8b:7c09:4673:bbb0/85, nh = ::, mt = 2821465568 | dst = 2001:a::a976:2488:f49f:b48/106, nh = 2001:a::62ae:c734:fc7b:e931, mt = 2248613879 | dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::  2001:a::2934:bd66:550d:ec19  sear6.fo.x.y 
 
-===================================
-  Informacje o urządzeniu (wlan0)
-===================================
-DEVICE 
---------
-wlan0  
-
-TYPE 
-------
-wifi 
-
-HWADDR            
--------------------
-13:E0:74:85:7C:D9 
-
-MTU 
------
-0   
-
-STATE            
-------------------
-20 (niedostępne) 
-
-CONNECTION 
-------------
-con-vpn-1  
-
-CON-PATH                                           
-----------------------------------------------------
-/org/freedesktop/NetworkManager/ActiveConnection/2 
-
-GROUP  ADDRESS                                 GATEWAY         ROUTE  DNS  DOMAIN                                                                            WINS           
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-IP4    192.168.228.18/32 | 192.168.209.179/25  192.168.41.120  --     --   sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar  192.168.120.79 
-
-GROUP  ADDRESS  GATEWAY  ROUTE                                                           DNS  DOMAIN                                                                                            
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-IP6    --       --       dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086  --   sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar 
-
 <<<
 size: 22590
 location: clients/tests/test-client.py:1050:test_004()/407
@@ -22953,6 +23049,47 @@ lang: C
 returncode: 0
 stdout: 22428 bytes
 >>>
+==========================
+  Device details (wlan0)
+==========================
+NAME     DEVICE  TYPE  NM-TYPE       VENDOR  PRODUCT  DRIVER   DRIVER-VERSION  FIRMWARE-VERSION  HWADDR             MTU  STATE             REASON               IP4-CONNECTIVITY  IP6-CONNECTIVITY  UDI                         IP-IFACE  IS-SOFTWARE  NM-MANAGED  AUTOCONNECT  FIRMWARE-MISSING  NM-PLUGIN-MISSING  PHYS-PORT-ID  CONNECTION  CON-UUID                              CON-PATH                                            METERED 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+GENERAL  wlan0   wifi  NMDeviceWifi  --      --       virtual  --              --                13:E0:74:85:7C:D9  0    20 (unavailable)  0 (No reason given)  0 (unknown)       0 (unknown)       /sys/devices/virtual/wlan0  --        no           yes         yes          no                no                 --            con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2  unknown 
+
+NAME          CARRIER-DETECT  SPEED    IS-SOFTWARE  SRIOV 
+-----------------------------------------------------------
+CAPABILITIES  no              unknown  no           no    
+
+NAME             WEP  WPA  WPA2  TKIP  CCMP  AP   ADHOC  2GHZ     5GHZ    
+---------------------------------------------------------------------------
+WIFI-PROPERTIES  yes  yes  yes   yes   yes   yes  yes    unknown  unknown 
+
+NAME   IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
+----------------------------------------------------------------------------
+AP[1]          wlan0-ap-2  Infra  1     54 Mbit/s  92      ****  WPA1 WPA2 
+AP[2]          wlan0-ap-1  Infra  1     54 Mbit/s  81      ****  WPA1 WPA2 
+AP[3]          wlan0-ap-3  Infra  1     54 Mbit/s  55      **    WPA1 WPA2 
+
+GROUP  ADDRESS                                 GATEWAY         ROUTE  DNS  DOMAIN                                                                            WINS           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+IP4    192.168.228.18/32 | 192.168.209.179/25  192.168.41.120  --     --   sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar  192.168.120.79 
+
+GROUP  OPTION                                                                                    
+--------------------------------------------------------------------------------------------------
+DHCP4  dhcp-4-opt-0 = val-0 | dhcp-4-opt-2 = val-2 | dhcp-4-opt-4 = val-4 | dhcp-4-opt-7 = val-7 
+
+GROUP  ADDRESS  GATEWAY  ROUTE                                                           DNS  DOMAIN                                                                                            
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+IP6    --       --       dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086  --   sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar 
+
+GROUP  OPTION                                                                                                           
+-------------------------------------------------------------------------------------------------------------------------
+DHCP6  dhcp-6-opt-1 = val-1 | dhcp-6-opt-2 = val-2 | dhcp-6-opt-3 = val-3 | dhcp-6-opt-4 = val-4 | dhcp-6-opt-5 = val-5 
+
+NAME         AVAILABLE-CONNECTION-PATHS                               AVAILABLE-CONNECTIONS                          
+----------------------------------------------------------------------------------------------------------------------
+CONNECTIONS  /org/freedesktop/NetworkManager/Settings/Connection/{2}  UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1 
+
 =========================
   Device details (eth0)
 =========================
@@ -23100,26 +23237,34 @@ NAME         AVAILABLE-CONNECTION-PATHS                               AVAILABLE-
 ----------------------------------------------------------------------------------------------------------------------
 CONNECTIONS  /org/freedesktop/NetworkManager/Settings/Connection/{2}  UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1 
 
-==========================
-  Device details (wlan0)
-==========================
-NAME     DEVICE  TYPE  NM-TYPE       VENDOR  PRODUCT  DRIVER   DRIVER-VERSION  FIRMWARE-VERSION  HWADDR             MTU  STATE             REASON               IP4-CONNECTIVITY  IP6-CONNECTIVITY  UDI                         IP-IFACE  IS-SOFTWARE  NM-MANAGED  AUTOCONNECT  FIRMWARE-MISSING  NM-PLUGIN-MISSING  PHYS-PORT-ID  CONNECTION  CON-UUID                              CON-PATH                                            METERED 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-GENERAL  wlan0   wifi  NMDeviceWifi  --      --       virtual  --              --                13:E0:74:85:7C:D9  0    20 (unavailable)  0 (No reason given)  0 (unknown)       0 (unknown)       /sys/devices/virtual/wlan0  --        no           yes         yes          no                no                 --            con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2  unknown 
+<<<
+size: 22951
+location: clients/tests/test-client.py:1050:test_004()/408
+cmd: $NMCLI --mode tabular --pretty -f all dev show
+lang: pl_PL.UTF-8
+returncode: 0
+stdout: 22779 bytes
+>>>
+===================================
+  Informacje o urządzeniu (wlan0)
+===================================
+NAME     DEVICE  TYPE  NM-TYPE       VENDOR  PRODUCT  DRIVER   DRIVER-VERSION  FIRMWARE-VERSION  HWADDR             MTU  STATE             REASON                    IP4-CONNECTIVITY  IP6-CONNECTIVITY  UDI                         IP-IFACE  IS-SOFTWARE  NM-MANAGED  AUTOCONNECT  FIRMWARE-MISSING  NM-PLUGIN-MISSING  PHYS-PORT-ID  CONNECTION  CON-UUID                              CON-PATH                                            METERED  
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+GENERAL  wlan0   wifi  NMDeviceWifi  --      --       virtual  --              --                13:E0:74:85:7C:D9  0    20 (niedostępne)  0 (Nie podano przyczyny)  0 (nieznane)      0 (nieznane)      /sys/devices/virtual/wlan0  --        nie          tak         tak          nie               nie                --            con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2  nieznane 
 
-NAME          CARRIER-DETECT  SPEED    IS-SOFTWARE  SRIOV 
------------------------------------------------------------
-CAPABILITIES  no              unknown  no           no    
+NAME          CARRIER-DETECT  SPEED     IS-SOFTWARE  SRIOV 
+------------------------------------------------------------
+CAPABILITIES  nie             nieznane  nie          nie   
 
-NAME             WEP  WPA  WPA2  TKIP  CCMP  AP   ADHOC  2GHZ     5GHZ    
----------------------------------------------------------------------------
-WIFI-PROPERTIES  yes  yes  yes   yes   yes   yes  yes    unknown  unknown 
+NAME             WEP  WPA  WPA2  TKIP  CCMP  AP   ADHOC  2GHZ      5GHZ     
+-----------------------------------------------------------------------------
+WIFI-PROPERTIES  tak  tak  tak   tak   tak   tak  tak    nieznane  nieznane 
 
-NAME   IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
-----------------------------------------------------------------------------
-AP[1]          wlan0-ap-2  Infra  1     54 Mbit/s  92      ****  WPA1 WPA2 
-AP[2]          wlan0-ap-1  Infra  1     54 Mbit/s  81      ****  WPA1 WPA2 
-AP[3]          wlan0-ap-3  Infra  1     54 Mbit/s  55      **    WPA1 WPA2 
+NAME   IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
+-----------------------------------------------------------------------------------
+AP[1]          wlan0-ap-2  Infrastruktura  1     54 Mb/s  92      ****  WPA1 WPA2 
+AP[2]          wlan0-ap-1  Infrastruktura  1     54 Mb/s  81      ****  WPA1 WPA2 
+AP[3]          wlan0-ap-3  Infrastruktura  1     54 Mb/s  55      **    WPA1 WPA2 
 
 GROUP  ADDRESS                                 GATEWAY         ROUTE  DNS  DOMAIN                                                                            WINS           
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -23141,14 +23286,6 @@ NAME         AVAILABLE-CONNECTION-PATHS                               AVAILABLE-
 ----------------------------------------------------------------------------------------------------------------------
 CONNECTIONS  /org/freedesktop/NetworkManager/Settings/Connection/{2}  UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1 
 
-<<<
-size: 22951
-location: clients/tests/test-client.py:1050:test_004()/408
-cmd: $NMCLI --mode tabular --pretty -f all dev show
-lang: pl_PL.UTF-8
-returncode: 0
-stdout: 22779 bytes
->>>
 ==================================
   Informacje o urządzeniu (eth0)
 ==================================
@@ -23291,47 +23428,6 @@ IP6    2001:a::88ca:3654:96b:ab44/89  --       dst = 2001:a::cc8b:7c09:4673:bbb0
 GROUP  OPTION                                                                                                           
 -------------------------------------------------------------------------------------------------------------------------
 DHCP6  dhcp-6-opt-2 = val-2 | dhcp-6-opt-6 = val-6 | dhcp-6-opt-7 = val-7 | dhcp-6-opt-8 = val-8 | dhcp-6-opt-9 = val-9 
-
-NAME         AVAILABLE-CONNECTION-PATHS                               AVAILABLE-CONNECTIONS                          
-----------------------------------------------------------------------------------------------------------------------
-CONNECTIONS  /org/freedesktop/NetworkManager/Settings/Connection/{2}  UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1 
-
-===================================
-  Informacje o urządzeniu (wlan0)
-===================================
-NAME     DEVICE  TYPE  NM-TYPE       VENDOR  PRODUCT  DRIVER   DRIVER-VERSION  FIRMWARE-VERSION  HWADDR             MTU  STATE             REASON                    IP4-CONNECTIVITY  IP6-CONNECTIVITY  UDI                         IP-IFACE  IS-SOFTWARE  NM-MANAGED  AUTOCONNECT  FIRMWARE-MISSING  NM-PLUGIN-MISSING  PHYS-PORT-ID  CONNECTION  CON-UUID                              CON-PATH                                            METERED  
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-GENERAL  wlan0   wifi  NMDeviceWifi  --      --       virtual  --              --                13:E0:74:85:7C:D9  0    20 (niedostępne)  0 (Nie podano przyczyny)  0 (nieznane)      0 (nieznane)      /sys/devices/virtual/wlan0  --        nie          tak         tak          nie               nie                --            con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2  nieznane 
-
-NAME          CARRIER-DETECT  SPEED     IS-SOFTWARE  SRIOV 
-------------------------------------------------------------
-CAPABILITIES  nie             nieznane  nie          nie   
-
-NAME             WEP  WPA  WPA2  TKIP  CCMP  AP   ADHOC  2GHZ      5GHZ     
------------------------------------------------------------------------------
-WIFI-PROPERTIES  tak  tak  tak   tak   tak   tak  tak    nieznane  nieznane 
-
-NAME   IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
------------------------------------------------------------------------------------
-AP[1]          wlan0-ap-2  Infrastruktura  1     54 Mb/s  92      ****  WPA1 WPA2 
-AP[2]          wlan0-ap-1  Infrastruktura  1     54 Mb/s  81      ****  WPA1 WPA2 
-AP[3]          wlan0-ap-3  Infrastruktura  1     54 Mb/s  55      **    WPA1 WPA2 
-
-GROUP  ADDRESS                                 GATEWAY         ROUTE  DNS  DOMAIN                                                                            WINS           
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-IP4    192.168.228.18/32 | 192.168.209.179/25  192.168.41.120  --     --   sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar  192.168.120.79 
-
-GROUP  OPTION                                                                                    
---------------------------------------------------------------------------------------------------
-DHCP4  dhcp-4-opt-0 = val-0 | dhcp-4-opt-2 = val-2 | dhcp-4-opt-4 = val-4 | dhcp-4-opt-7 = val-7 
-
-GROUP  ADDRESS  GATEWAY  ROUTE                                                           DNS  DOMAIN                                                                                            
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-IP6    --       --       dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086  --   sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar 
-
-GROUP  OPTION                                                                                                           
--------------------------------------------------------------------------------------------------------------------------
-DHCP6  dhcp-6-opt-1 = val-1 | dhcp-6-opt-2 = val-2 | dhcp-6-opt-3 = val-3 | dhcp-6-opt-4 = val-4 | dhcp-6-opt-5 = val-5 
 
 NAME         AVAILABLE-CONNECTION-PATHS                               AVAILABLE-CONNECTIONS                          
 ----------------------------------------------------------------------------------------------------------------------
@@ -23634,11 +23730,11 @@ stdout: 513 bytes
 =====================
 DEVICE  TYPE      DBUS-PATH                                 
 ----------------------------------------------------------------------------------
+wlan0   wifi      /org/freedesktop/NetworkManager/Devices/3 
 eth0    ethernet  /org/freedesktop/NetworkManager/Devices/1 
 eth1    ethernet  /org/freedesktop/NetworkManager/Devices/2 
 wlan1   wifi      /org/freedesktop/NetworkManager/Devices/4 
 wlan1   wifi      /org/freedesktop/NetworkManager/Devices/5 
-wlan0   wifi      /org/freedesktop/NetworkManager/Devices/3 
 
 <<<
 size: 689
@@ -23653,11 +23749,11 @@ stdout: 506 bytes
 ===================
 DEVICE  TYPE      DBUS-PATH                                 
 --------------------------------------------------------------------------------
+wlan0   wifi      /org/freedesktop/NetworkManager/Devices/3 
 eth0    ethernet  /org/freedesktop/NetworkManager/Devices/1 
 eth1    ethernet  /org/freedesktop/NetworkManager/Devices/2 
 wlan1   wifi      /org/freedesktop/NetworkManager/Devices/4 
 wlan1   wifi      /org/freedesktop/NetworkManager/Devices/5 
-wlan0   wifi      /org/freedesktop/NetworkManager/Devices/3 
 
 <<<
 size: 3041
@@ -23667,6 +23763,15 @@ lang: C
 returncode: 0
 stdout: 2872 bytes
 >>>
+===========================
+  Wi-Fi scan list (wlan0)
+===========================
+NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infra  1     2412 MHz  54 Mbit/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/2 
+AP[2]  wlan0-ap-1  776C616E302D61702D31  61:95:77:AC:1E:4C  Infra  1     2412 MHz  54 Mbit/s  81      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/1 
+AP[3]  wlan0-ap-3  776C616E302D61702D33  9B:F6:B7:EC:97:76  Infra  1     2412 MHz  54 Mbit/s  55      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/3 
+
 ===========================
   Wi-Fi scan list (wlan1)
 ===========================
@@ -23680,15 +23785,6 @@ AP[1]  wlan1-ap-4  776C616E312D61702D34  94:2B:E8:F6:D2:86  Infra  1     2412 MH
 NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-===========================
-  Wi-Fi scan list (wlan0)
-===========================
-NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infra  1     2412 MHz  54 Mbit/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/2 
-AP[2]  wlan0-ap-1  776C616E302D61702D31  61:95:77:AC:1E:4C  Infra  1     2412 MHz  54 Mbit/s  81      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/1 
-AP[3]  wlan0-ap-3  776C616E302D61702D33  9B:F6:B7:EC:97:76  Infra  1     2412 MHz  54 Mbit/s  55      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/3 
-
 <<<
 size: 3279
 location: clients/tests/test-client.py:1068:test_004()/420
@@ -23697,6 +23793,15 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 3100 bytes
 >>>
+========================================
+  Lista skanowania sieci Wi-Fi (wlan0)
+========================================
+NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infrastruktura  1     2412 MHz  54 Mb/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/2 
+AP[2]  wlan0-ap-1  776C616E302D61702D31  61:95:77:AC:1E:4C  Infrastruktura  1     2412 MHz  54 Mb/s  81      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/1 
+AP[3]  wlan0-ap-3  776C616E302D61702D33  9B:F6:B7:EC:97:76  Infrastruktura  1     2412 MHz  54 Mb/s  55      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/3 
+
 ========================================
   Lista skanowania sieci Wi-Fi (wlan1)
 ========================================
@@ -23710,15 +23815,6 @@ AP[1]  wlan1-ap-4  776C616E312D61702D34  94:2B:E8:F6:D2:86  Infrastruktura  1   
 NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-========================================
-  Lista skanowania sieci Wi-Fi (wlan0)
-========================================
-NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infrastruktura  1     2412 MHz  54 Mb/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/2 
-AP[2]  wlan0-ap-1  776C616E302D61702D31  61:95:77:AC:1E:4C  Infrastruktura  1     2412 MHz  54 Mb/s  81      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/1 
-AP[3]  wlan0-ap-3  776C616E302D61702D33  9B:F6:B7:EC:97:76  Infrastruktura  1     2412 MHz  54 Mb/s  55      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/3 
-
 <<<
 size: 1167
 location: clients/tests/test-client.py:1070:test_004()/421
@@ -23727,6 +23823,15 @@ lang: C
 returncode: 0
 stdout: 996 bytes
 >>>
+===========================
+  Wi-Fi scan list (wlan0)
+===========================
+IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
+------------------------------------------------------------------------------------------------
+        wlan0-ap-2  Infra  1     54 Mbit/s  92      ****  WPA1 WPA2 
+        wlan0-ap-1  Infra  1     54 Mbit/s  81      ****  WPA1 WPA2 
+        wlan0-ap-3  Infra  1     54 Mbit/s  55      **    WPA1 WPA2 
+
 ===========================
   Wi-Fi scan list (wlan1)
 ===========================
@@ -23740,15 +23845,6 @@ IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY
 IN-USE  SSID  MODE  CHAN  RATE  SIGNAL  BARS  SECURITY 
 -----------------------------------------------------------------------------------
 
-===========================
-  Wi-Fi scan list (wlan0)
-===========================
-IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
-------------------------------------------------------------------------------------------------
-        wlan0-ap-2  Infra  1     54 Mbit/s  92      ****  WPA1 WPA2 
-        wlan0-ap-1  Infra  1     54 Mbit/s  81      ****  WPA1 WPA2 
-        wlan0-ap-3  Infra  1     54 Mbit/s  55      **    WPA1 WPA2 
-
 <<<
 size: 1398
 location: clients/tests/test-client.py:1070:test_004()/422
@@ -23757,6 +23853,15 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 1216 bytes
 >>>
+========================================
+  Lista skanowania sieci Wi-Fi (wlan0)
+========================================
+IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
+--------------------------------------------------------------------------------------------------------------------
+        wlan0-ap-2  Infrastruktura  1     54 Mb/s  92      ****  WPA1 WPA2 
+        wlan0-ap-1  Infrastruktura  1     54 Mb/s  81      ****  WPA1 WPA2 
+        wlan0-ap-3  Infrastruktura  1     54 Mb/s  55      **    WPA1 WPA2 
+
 ========================================
   Lista skanowania sieci Wi-Fi (wlan1)
 ========================================
@@ -23770,15 +23875,6 @@ IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY
 IN-USE  SSID  MODE  CHAN  RATE  SIGNAL  BARS  SECURITY 
 ------------------------------------------------------------------------------------------------
 
-========================================
-  Lista skanowania sieci Wi-Fi (wlan0)
-========================================
-IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
---------------------------------------------------------------------------------------------------------------------
-        wlan0-ap-2  Infrastruktura  1     54 Mb/s  92      ****  WPA1 WPA2 
-        wlan0-ap-1  Infrastruktura  1     54 Mb/s  81      ****  WPA1 WPA2 
-        wlan0-ap-3  Infrastruktura  1     54 Mb/s  55      **    WPA1 WPA2 
-
 <<<
 size: 3154
 location: clients/tests/test-client.py:1073:test_004()/423
@@ -23787,6 +23883,15 @@ lang: C
 returncode: 0
 stdout: 2872 bytes
 >>>
+===========================
+  Wi-Fi scan list (wlan0)
+===========================
+NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infra  1     2412 MHz  54 Mbit/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/2 
+AP[2]  wlan0-ap-1  776C616E302D61702D31  61:95:77:AC:1E:4C  Infra  1     2412 MHz  54 Mbit/s  81      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/1 
+AP[3]  wlan0-ap-3  776C616E302D61702D33  9B:F6:B7:EC:97:76  Infra  1     2412 MHz  54 Mbit/s  55      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/3 
+
 ===========================
   Wi-Fi scan list (wlan1)
 ===========================
@@ -23800,15 +23905,6 @@ AP[1]  wlan1-ap-4  776C616E312D61702D34  94:2B:E8:F6:D2:86  Infra  1     2412 MH
 NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-===========================
-  Wi-Fi scan list (wlan0)
-===========================
-NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infra  1     2412 MHz  54 Mbit/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/2 
-AP[2]  wlan0-ap-1  776C616E302D61702D31  61:95:77:AC:1E:4C  Infra  1     2412 MHz  54 Mbit/s  81      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/1 
-AP[3]  wlan0-ap-3  776C616E302D61702D33  9B:F6:B7:EC:97:76  Infra  1     2412 MHz  54 Mbit/s  55      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/3 
-
 <<<
 size: 3392
 location: clients/tests/test-client.py:1073:test_004()/424
@@ -23817,6 +23913,15 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 3100 bytes
 >>>
+========================================
+  Lista skanowania sieci Wi-Fi (wlan0)
+========================================
+NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infrastruktura  1     2412 MHz  54 Mb/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/2 
+AP[2]  wlan0-ap-1  776C616E302D61702D31  61:95:77:AC:1E:4C  Infrastruktura  1     2412 MHz  54 Mb/s  81      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/1 
+AP[3]  wlan0-ap-3  776C616E302D61702D33  9B:F6:B7:EC:97:76  Infrastruktura  1     2412 MHz  54 Mb/s  55      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/3 
+
 ========================================
   Lista skanowania sieci Wi-Fi (wlan1)
 ========================================
@@ -23830,22 +23935,13 @@ AP[1]  wlan1-ap-4  776C616E312D61702D34  94:2B:E8:F6:D2:86  Infrastruktura  1   
 NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-========================================
-  Lista skanowania sieci Wi-Fi (wlan0)
-========================================
-NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infrastruktura  1     2412 MHz  54 Mb/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/2 
-AP[2]  wlan0-ap-1  776C616E302D61702D31  61:95:77:AC:1E:4C  Infrastruktura  1     2412 MHz  54 Mb/s  81      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/1 
-AP[3]  wlan0-ap-3  776C616E302D61702D33  9B:F6:B7:EC:97:76  Infrastruktura  1     2412 MHz  54 Mb/s  55      **    WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/3 
-
 <<<
-size: 1154
+size: 1156
 location: clients/tests/test-client.py:1075:test_004()/425
 cmd: $NMCLI --mode tabular --pretty -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 962 bytes
+stdout: 964 bytes
 >>>
 ===========================
   Wi-Fi scan list (wlan0)
@@ -23854,13 +23950,15 @@ NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ   
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infra  1     2412 MHz  54 Mbit/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/2 
 
+
+
 <<<
-size: 1242
+size: 1244
 location: clients/tests/test-client.py:1075:test_004()/426
 cmd: $NMCLI --mode tabular --pretty -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 1039 bytes
+stdout: 1041 bytes
 >>>
 ========================================
   Lista skanowania sieci Wi-Fi (wlan0)
@@ -23869,13 +23967,15 @@ NAME   SSID        SSID-HEX              BSSID              MODE            CHAN
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infrastruktura  1     2412 MHz  54 Mb/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/2 
 
+
+
 <<<
-size: 512
+size: 514
 location: clients/tests/test-client.py:1077:test_004()/427
 cmd: $NMCLI --mode tabular --pretty -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 317 bytes
+stdout: 319 bytes
 >>>
 ===========================
   Wi-Fi scan list (wlan0)
@@ -23884,13 +23984,15 @@ IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY
 ------------------------------------------------------------------------------------------------
         wlan0-ap-2  Infra  1     54 Mbit/s  92      ****  WPA1 WPA2 
 
+
+
 <<<
-size: 597
+size: 599
 location: clients/tests/test-client.py:1077:test_004()/428
 cmd: $NMCLI --mode tabular --pretty -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 392 bytes
+stdout: 394 bytes
 >>>
 ========================================
   Lista skanowania sieci Wi-Fi (wlan0)
@@ -23899,13 +24001,15 @@ IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY
 --------------------------------------------------------------------------------------------------------------------
         wlan0-ap-2  Infrastruktura  1     54 Mb/s  92      ****  WPA1 WPA2 
 
+
+
 <<<
-size: 1267
+size: 1269
 location: clients/tests/test-client.py:1080:test_004()/429
 cmd: $NMCLI --mode tabular --pretty -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 962 bytes
+stdout: 964 bytes
 >>>
 ===========================
   Wi-Fi scan list (wlan0)
@@ -23914,13 +24018,15 @@ NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ   
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infra  1     2412 MHz  54 Mbit/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   no              /org/freedesktop/NetworkManager/AccessPoint/2 
 
+
+
 <<<
-size: 1355
+size: 1357
 location: clients/tests/test-client.py:1080:test_004()/430
 cmd: $NMCLI --mode tabular --pretty -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 1039 bytes
+stdout: 1041 bytes
 >>>
 ========================================
   Lista skanowania sieci Wi-Fi (wlan0)
@@ -23928,6 +24034,8 @@ stdout: 1039 bytes
 NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 AP[1]  wlan0-ap-2  776C616E302D61702D32  C0:E2:BE:E8:EF:B6  Infrastruktura  1     2412 MHz  54 Mb/s  92      ****  WPA1 WPA2  pair_tkip pair_ccmp group_tkip group_ccmp psk  pair_tkip pair_ccmp group_tkip group_ccmp psk  wlan0   nie             /org/freedesktop/NetworkManager/AccessPoint/2 
+
+
 
 <<<
 size: 4459
@@ -24524,11 +24632,11 @@ stdout: 547 bytes
 =====================
 DEVICE  TYPE      STATE        CONNECTION 
 ----------------------------------------------------------------
+[2mwlan0[0m   [2mwifi[0m      [2munavailable[0m  [2mcon-vpn-1[0m  
 [2meth0[0m    [2methernet[0m  [2munavailable[0m  [2m--[0m         
 [2meth1[0m    [2methernet[0m  [2munavailable[0m  [2m--[0m         
 [2mwlan1[0m   [2mwifi[0m      [2munavailable[0m  [2m--[0m         
 [2mwlan1[0m   [2mwifi[0m      [2munavailable[0m  [2m--[0m         
-[2mwlan0[0m   [2mwifi[0m      [2munavailable[0m  [2mcon-vpn-1[0m  
 
 <<<
 size: 717
@@ -24543,11 +24651,11 @@ stdout: 545 bytes
 ===================
 DEVICE  TYPE      STATE        CONNECTION 
 --------------------------------------------------------------
+[2mwlan0[0m   [2mwifi[0m      [2mniedostępne[0m  [2mcon-vpn-1[0m  
 [2meth0[0m    [2methernet[0m  [2mniedostępne[0m  [2m--[0m         
 [2meth1[0m    [2methernet[0m  [2mniedostępne[0m  [2m--[0m         
 [2mwlan1[0m   [2mwifi[0m      [2mniedostępne[0m  [2m--[0m         
 [2mwlan1[0m   [2mwifi[0m      [2mniedostępne[0m  [2m--[0m         
-[2mwlan0[0m   [2mwifi[0m      [2mniedostępne[0m  [2mcon-vpn-1[0m  
 
 <<<
 size: 2105
@@ -24562,11 +24670,11 @@ stdout: 1930 bytes
 =====================
 DEVICE  TYPE      STATE        IP4-CONNECTIVITY  IP6-CONNECTIVITY  DBUS-PATH                                  CONNECTION  CON-UUID                              CON-PATH                                           
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+[2mwlan0[0m   [2mwifi[0m      [2munavailable[0m  [2munknown[0m           [2munknown[0m           [2m/org/freedesktop/NetworkManager/Devices/3[0m  [2mcon-vpn-1[0m   [2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m  [2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m 
 [2meth0[0m    [2methernet[0m  [2munavailable[0m  [2munknown[0m           [2munknown[0m           [2m/org/freedesktop/NetworkManager/Devices/1[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
 [2meth1[0m    [2methernet[0m  [2munavailable[0m  [2munknown[0m           [2munknown[0m           [2m/org/freedesktop/NetworkManager/Devices/2[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
 [2mwlan1[0m   [2mwifi[0m      [2munavailable[0m  [2munknown[0m           [2munknown[0m           [2m/org/freedesktop/NetworkManager/Devices/4[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
 [2mwlan1[0m   [2mwifi[0m      [2munavailable[0m  [2munknown[0m           [2munknown[0m           [2m/org/freedesktop/NetworkManager/Devices/5[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
-[2mwlan0[0m   [2mwifi[0m      [2munavailable[0m  [2munknown[0m           [2munknown[0m           [2m/org/freedesktop/NetworkManager/Devices/3[0m  [2mcon-vpn-1[0m   [2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m  [2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m 
 
 <<<
 size: 2113
@@ -24581,11 +24689,11 @@ stdout: 1928 bytes
 ===================
 DEVICE  TYPE      STATE        IP4-CONNECTIVITY  IP6-CONNECTIVITY  DBUS-PATH                                  CONNECTION  CON-UUID                              CON-PATH                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+[2mwlan0[0m   [2mwifi[0m      [2mniedostępne[0m  [2mnieznane[0m          [2mnieznane[0m          [2m/org/freedesktop/NetworkManager/Devices/3[0m  [2mcon-vpn-1[0m   [2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m  [2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m 
 [2meth0[0m    [2methernet[0m  [2mniedostępne[0m  [2mnieznane[0m          [2mnieznane[0m          [2m/org/freedesktop/NetworkManager/Devices/1[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
 [2meth1[0m    [2methernet[0m  [2mniedostępne[0m  [2mnieznane[0m          [2mnieznane[0m          [2m/org/freedesktop/NetworkManager/Devices/2[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
 [2mwlan1[0m   [2mwifi[0m      [2mniedostępne[0m  [2mnieznane[0m          [2mnieznane[0m          [2m/org/freedesktop/NetworkManager/Devices/4[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
 [2mwlan1[0m   [2mwifi[0m      [2mniedostępne[0m  [2mnieznane[0m          [2mnieznane[0m          [2m/org/freedesktop/NetworkManager/Devices/5[0m  [2m--[0m          [2m--[0m                                    [2m--[0m                                                 
-[2mwlan0[0m   [2mwifi[0m      [2mniedostępne[0m  [2mnieznane[0m          [2mnieznane[0m          [2m/org/freedesktop/NetworkManager/Devices/3[0m  [2mcon-vpn-1[0m   [2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m  [2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m 
 
 <<<
 size: 9903
@@ -24595,6 +24703,45 @@ lang: C
 returncode: 0
 stdout: 9737 bytes
 >>>
+==========================
+  Device details (wlan0)
+==========================
+DEVICE 
+--------
+wlan0  
+
+TYPE 
+------
+wifi 
+
+HWADDR            
+-------------------
+13:E0:74:85:7C:D9 
+
+MTU 
+-----
+0   
+
+STATE            
+------------------
+20 (unavailable) 
+
+CONNECTION 
+------------
+con-vpn-1  
+
+CON-PATH                                           
+----------------------------------------------------
+/org/freedesktop/NetworkManager/ActiveConnection/2 
+
+GROUP  ADDRESS                                 GATEWAY         ROUTE  DNS  DOMAIN                                                                            WINS           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+IP4    192.168.228.18/32 | 192.168.209.179/25  192.168.41.120  --     --   sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar  192.168.120.79 
+
+GROUP  ADDRESS  GATEWAY  ROUTE                                                           DNS  DOMAIN                                                                                            
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+IP6    --       --       dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086  --   sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar 
+
 =========================
   Device details (eth0)
 =========================
@@ -24759,9 +24906,17 @@ GROUP  ADDRESS                        GATEWAY  ROUTE                            
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 IP6    2001:a::88ca:3654:96b:ab44/89  --       dst = 2001:a::cc8b:7c09:4673:bbb0/85, nh = ::, mt = 2821465568 | dst = 2001:a::a976:2488:f49f:b48/106, nh = 2001:a::62ae:c734:fc7b:e931, mt = 2248613879 | dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::  2001:a::2934:bd66:550d:ec19  sear6.fo.x.y 
 
-==========================
-  Device details (wlan0)
-==========================
+<<<
+size: 10079
+location: clients/tests/test-client.py:1047:test_004()/452
+cmd: $NMCLI --mode tabular --pretty --color yes dev show
+lang: pl_PL.UTF-8
+returncode: 0
+stdout: 9903 bytes
+>>>
+===================================
+  Informacje o urządzeniu (wlan0)
+===================================
 DEVICE 
 --------
 wlan0  
@@ -24780,7 +24935,7 @@ MTU
 
 STATE            
 ------------------
-20 (unavailable) 
+20 (niedostępne) 
 
 CONNECTION 
 ------------
@@ -24798,14 +24953,6 @@ GROUP  ADDRESS  GATEWAY  ROUTE                                                  
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 IP6    --       --       dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086  --   sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar 
 
-<<<
-size: 10079
-location: clients/tests/test-client.py:1047:test_004()/452
-cmd: $NMCLI --mode tabular --pretty --color yes dev show
-lang: pl_PL.UTF-8
-returncode: 0
-stdout: 9903 bytes
->>>
 ==================================
   Informacje o urządzeniu (eth0)
 ==================================
@@ -24970,45 +25117,6 @@ GROUP  ADDRESS                        GATEWAY  ROUTE                            
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 IP6    2001:a::88ca:3654:96b:ab44/89  --       dst = 2001:a::cc8b:7c09:4673:bbb0/85, nh = ::, mt = 2821465568 | dst = 2001:a::a976:2488:f49f:b48/106, nh = 2001:a::62ae:c734:fc7b:e931, mt = 2248613879 | dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::  2001:a::2934:bd66:550d:ec19  sear6.fo.x.y 
 
-===================================
-  Informacje o urządzeniu (wlan0)
-===================================
-DEVICE 
---------
-wlan0  
-
-TYPE 
-------
-wifi 
-
-HWADDR            
--------------------
-13:E0:74:85:7C:D9 
-
-MTU 
------
-0   
-
-STATE            
-------------------
-20 (niedostępne) 
-
-CONNECTION 
-------------
-con-vpn-1  
-
-CON-PATH                                           
-----------------------------------------------------
-/org/freedesktop/NetworkManager/ActiveConnection/2 
-
-GROUP  ADDRESS                                 GATEWAY         ROUTE  DNS  DOMAIN                                                                            WINS           
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-IP4    192.168.228.18/32 | 192.168.209.179/25  192.168.41.120  --     --   sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar  192.168.120.79 
-
-GROUP  ADDRESS  GATEWAY  ROUTE                                                           DNS  DOMAIN                                                                                            
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-IP6    --       --       dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086  --   sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar 
-
 <<<
 size: 22926
 location: clients/tests/test-client.py:1050:test_004()/453
@@ -25017,6 +25125,47 @@ lang: C
 returncode: 0
 stdout: 22752 bytes
 >>>
+==========================
+  Device details (wlan0)
+==========================
+NAME     DEVICE  TYPE  NM-TYPE       VENDOR  PRODUCT  DRIVER   DRIVER-VERSION  FIRMWARE-VERSION  HWADDR             MTU  STATE             REASON               IP4-CONNECTIVITY  IP6-CONNECTIVITY  UDI                         IP-IFACE  IS-SOFTWARE  NM-MANAGED  AUTOCONNECT  FIRMWARE-MISSING  NM-PLUGIN-MISSING  PHYS-PORT-ID  CONNECTION  CON-UUID                              CON-PATH                                            METERED 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+GENERAL  wlan0   wifi  NMDeviceWifi  --      --       virtual  --              --                13:E0:74:85:7C:D9  0    20 (unavailable)  0 (No reason given)  0 (unknown)       0 (unknown)       /sys/devices/virtual/wlan0  --        no           yes         yes          no                no                 --            con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2  unknown 
+
+NAME          CARRIER-DETECT  SPEED    IS-SOFTWARE  SRIOV 
+-----------------------------------------------------------
+CAPABILITIES  no              unknown  no           no    
+
+NAME             WEP  WPA  WPA2  TKIP  CCMP  AP   ADHOC  2GHZ     5GHZ    
+---------------------------------------------------------------------------
+WIFI-PROPERTIES  yes  yes  yes   yes   yes   yes  yes    unknown  unknown 
+
+NAME   IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
+----------------------------------------------------------------------------
+[32mAP[1][0m  [32m [0m       [32mwlan0-ap-2[0m  [32mInfra[0m  [32m1[0m     [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
+[32mAP[2][0m  [32m [0m       [32mwlan0-ap-1[0m  [32mInfra[0m  [32m1[0m     [32m54 Mbit/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m 
+[35mAP[3][0m  [35m [0m       [35mwlan0-ap-3[0m  [35mInfra[0m  [35m1[0m     [35m54 Mbit/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
+
+GROUP  ADDRESS                                 GATEWAY         ROUTE  DNS  DOMAIN                                                                            WINS           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+IP4    192.168.228.18/32 | 192.168.209.179/25  192.168.41.120  --     --   sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar  192.168.120.79 
+
+GROUP  OPTION                                                                                    
+--------------------------------------------------------------------------------------------------
+DHCP4  dhcp-4-opt-0 = val-0 | dhcp-4-opt-2 = val-2 | dhcp-4-opt-4 = val-4 | dhcp-4-opt-7 = val-7 
+
+GROUP  ADDRESS  GATEWAY  ROUTE                                                           DNS  DOMAIN                                                                                            
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+IP6    --       --       dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086  --   sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar 
+
+GROUP  OPTION                                                                                                           
+-------------------------------------------------------------------------------------------------------------------------
+DHCP6  dhcp-6-opt-1 = val-1 | dhcp-6-opt-2 = val-2 | dhcp-6-opt-3 = val-3 | dhcp-6-opt-4 = val-4 | dhcp-6-opt-5 = val-5 
+
+NAME         AVAILABLE-CONNECTION-PATHS                               AVAILABLE-CONNECTIONS                          
+----------------------------------------------------------------------------------------------------------------------
+CONNECTIONS  /org/freedesktop/NetworkManager/Settings/Connection/{2}  UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1 
+
 =========================
   Device details (eth0)
 =========================
@@ -25164,26 +25313,34 @@ NAME         AVAILABLE-CONNECTION-PATHS                               AVAILABLE-
 ----------------------------------------------------------------------------------------------------------------------
 CONNECTIONS  /org/freedesktop/NetworkManager/Settings/Connection/{2}  UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1 
 
-==========================
-  Device details (wlan0)
-==========================
-NAME     DEVICE  TYPE  NM-TYPE       VENDOR  PRODUCT  DRIVER   DRIVER-VERSION  FIRMWARE-VERSION  HWADDR             MTU  STATE             REASON               IP4-CONNECTIVITY  IP6-CONNECTIVITY  UDI                         IP-IFACE  IS-SOFTWARE  NM-MANAGED  AUTOCONNECT  FIRMWARE-MISSING  NM-PLUGIN-MISSING  PHYS-PORT-ID  CONNECTION  CON-UUID                              CON-PATH                                            METERED 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-GENERAL  wlan0   wifi  NMDeviceWifi  --      --       virtual  --              --                13:E0:74:85:7C:D9  0    20 (unavailable)  0 (No reason given)  0 (unknown)       0 (unknown)       /sys/devices/virtual/wlan0  --        no           yes         yes          no                no                 --            con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2  unknown 
+<<<
+size: 23287
+location: clients/tests/test-client.py:1050:test_004()/454
+cmd: $NMCLI --mode tabular --pretty --color yes -f all dev show
+lang: pl_PL.UTF-8
+returncode: 0
+stdout: 23103 bytes
+>>>
+===================================
+  Informacje o urządzeniu (wlan0)
+===================================
+NAME     DEVICE  TYPE  NM-TYPE       VENDOR  PRODUCT  DRIVER   DRIVER-VERSION  FIRMWARE-VERSION  HWADDR             MTU  STATE             REASON                    IP4-CONNECTIVITY  IP6-CONNECTIVITY  UDI                         IP-IFACE  IS-SOFTWARE  NM-MANAGED  AUTOCONNECT  FIRMWARE-MISSING  NM-PLUGIN-MISSING  PHYS-PORT-ID  CONNECTION  CON-UUID                              CON-PATH                                            METERED  
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+GENERAL  wlan0   wifi  NMDeviceWifi  --      --       virtual  --              --                13:E0:74:85:7C:D9  0    20 (niedostępne)  0 (Nie podano przyczyny)  0 (nieznane)      0 (nieznane)      /sys/devices/virtual/wlan0  --        nie          tak         tak          nie               nie                --            con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2  nieznane 
 
-NAME          CARRIER-DETECT  SPEED    IS-SOFTWARE  SRIOV 
------------------------------------------------------------
-CAPABILITIES  no              unknown  no           no    
+NAME          CARRIER-DETECT  SPEED     IS-SOFTWARE  SRIOV 
+------------------------------------------------------------
+CAPABILITIES  nie             nieznane  nie          nie   
 
-NAME             WEP  WPA  WPA2  TKIP  CCMP  AP   ADHOC  2GHZ     5GHZ    
----------------------------------------------------------------------------
-WIFI-PROPERTIES  yes  yes  yes   yes   yes   yes  yes    unknown  unknown 
+NAME             WEP  WPA  WPA2  TKIP  CCMP  AP   ADHOC  2GHZ      5GHZ     
+-----------------------------------------------------------------------------
+WIFI-PROPERTIES  tak  tak  tak   tak   tak   tak  tak    nieznane  nieznane 
 
-NAME   IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
-----------------------------------------------------------------------------
-[32mAP[1][0m  [32m [0m       [32mwlan0-ap-2[0m  [32mInfra[0m  [32m1[0m     [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
-[32mAP[2][0m  [32m [0m       [32mwlan0-ap-1[0m  [32mInfra[0m  [32m1[0m     [32m54 Mbit/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m 
-[35mAP[3][0m  [35m [0m       [35mwlan0-ap-3[0m  [35mInfra[0m  [35m1[0m     [35m54 Mbit/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
+NAME   IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
+-----------------------------------------------------------------------------------
+[32mAP[1][0m  [32m [0m       [32mwlan0-ap-2[0m  [32mInfrastruktura[0m  [32m1[0m     [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
+[32mAP[2][0m  [32m [0m       [32mwlan0-ap-1[0m  [32mInfrastruktura[0m  [32m1[0m     [32m54 Mb/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m 
+[35mAP[3][0m  [35m [0m       [35mwlan0-ap-3[0m  [35mInfrastruktura[0m  [35m1[0m     [35m54 Mb/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
 
 GROUP  ADDRESS                                 GATEWAY         ROUTE  DNS  DOMAIN                                                                            WINS           
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -25205,14 +25362,6 @@ NAME         AVAILABLE-CONNECTION-PATHS                               AVAILABLE-
 ----------------------------------------------------------------------------------------------------------------------
 CONNECTIONS  /org/freedesktop/NetworkManager/Settings/Connection/{2}  UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1 
 
-<<<
-size: 23287
-location: clients/tests/test-client.py:1050:test_004()/454
-cmd: $NMCLI --mode tabular --pretty --color yes -f all dev show
-lang: pl_PL.UTF-8
-returncode: 0
-stdout: 23103 bytes
->>>
 ==================================
   Informacje o urządzeniu (eth0)
 ==================================
@@ -25355,47 +25504,6 @@ IP6    2001:a::88ca:3654:96b:ab44/89  --       dst = 2001:a::cc8b:7c09:4673:bbb0
 GROUP  OPTION                                                                                                           
 -------------------------------------------------------------------------------------------------------------------------
 DHCP6  dhcp-6-opt-2 = val-2 | dhcp-6-opt-6 = val-6 | dhcp-6-opt-7 = val-7 | dhcp-6-opt-8 = val-8 | dhcp-6-opt-9 = val-9 
-
-NAME         AVAILABLE-CONNECTION-PATHS                               AVAILABLE-CONNECTIONS                          
-----------------------------------------------------------------------------------------------------------------------
-CONNECTIONS  /org/freedesktop/NetworkManager/Settings/Connection/{2}  UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1 
-
-===================================
-  Informacje o urządzeniu (wlan0)
-===================================
-NAME     DEVICE  TYPE  NM-TYPE       VENDOR  PRODUCT  DRIVER   DRIVER-VERSION  FIRMWARE-VERSION  HWADDR             MTU  STATE             REASON                    IP4-CONNECTIVITY  IP6-CONNECTIVITY  UDI                         IP-IFACE  IS-SOFTWARE  NM-MANAGED  AUTOCONNECT  FIRMWARE-MISSING  NM-PLUGIN-MISSING  PHYS-PORT-ID  CONNECTION  CON-UUID                              CON-PATH                                            METERED  
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-GENERAL  wlan0   wifi  NMDeviceWifi  --      --       virtual  --              --                13:E0:74:85:7C:D9  0    20 (niedostępne)  0 (Nie podano przyczyny)  0 (nieznane)      0 (nieznane)      /sys/devices/virtual/wlan0  --        nie          tak         tak          nie               nie                --            con-vpn-1   UUID-con-vpn-1-REPLACED-REPLACED-REP  /org/freedesktop/NetworkManager/ActiveConnection/2  nieznane 
-
-NAME          CARRIER-DETECT  SPEED     IS-SOFTWARE  SRIOV 
-------------------------------------------------------------
-CAPABILITIES  nie             nieznane  nie          nie   
-
-NAME             WEP  WPA  WPA2  TKIP  CCMP  AP   ADHOC  2GHZ      5GHZ     
------------------------------------------------------------------------------
-WIFI-PROPERTIES  tak  tak  tak   tak   tak   tak  tak    nieznane  nieznane 
-
-NAME   IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
------------------------------------------------------------------------------------
-[32mAP[1][0m  [32m [0m       [32mwlan0-ap-2[0m  [32mInfrastruktura[0m  [32m1[0m     [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
-[32mAP[2][0m  [32m [0m       [32mwlan0-ap-1[0m  [32mInfrastruktura[0m  [32m1[0m     [32m54 Mb/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m 
-[35mAP[3][0m  [35m [0m       [35mwlan0-ap-3[0m  [35mInfrastruktura[0m  [35m1[0m     [35m54 Mb/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
-
-GROUP  ADDRESS                                 GATEWAY         ROUTE  DNS  DOMAIN                                                                            WINS           
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-IP4    192.168.228.18/32 | 192.168.209.179/25  192.168.41.120  --     --   sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar  192.168.120.79 
-
-GROUP  OPTION                                                                                    
---------------------------------------------------------------------------------------------------
-DHCP4  dhcp-4-opt-0 = val-0 | dhcp-4-opt-2 = val-2 | dhcp-4-opt-4 = val-4 | dhcp-4-opt-7 = val-7 
-
-GROUP  ADDRESS  GATEWAY  ROUTE                                                           DNS  DOMAIN                                                                                            
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-IP6    --       --       dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086  --   sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar 
-
-GROUP  OPTION                                                                                                           
--------------------------------------------------------------------------------------------------------------------------
-DHCP6  dhcp-6-opt-1 = val-1 | dhcp-6-opt-2 = val-2 | dhcp-6-opt-3 = val-3 | dhcp-6-opt-4 = val-4 | dhcp-6-opt-5 = val-5 
 
 NAME         AVAILABLE-CONNECTION-PATHS                               AVAILABLE-CONNECTIONS                          
 ----------------------------------------------------------------------------------------------------------------------
@@ -25698,11 +25806,11 @@ stdout: 633 bytes
 =====================
 DEVICE  TYPE      DBUS-PATH                                 
 ----------------------------------------------------------------------------------
+[2mwlan0[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/3[0m 
 [2meth0[0m    [2methernet[0m  [2m/org/freedesktop/NetworkManager/Devices/1[0m 
 [2meth1[0m    [2methernet[0m  [2m/org/freedesktop/NetworkManager/Devices/2[0m 
 [2mwlan1[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/4[0m 
 [2mwlan1[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/5[0m 
-[2mwlan0[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/3[0m 
 
 <<<
 size: 821
@@ -25717,11 +25825,11 @@ stdout: 626 bytes
 ===================
 DEVICE  TYPE      DBUS-PATH                                 
 --------------------------------------------------------------------------------
+[2mwlan0[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/3[0m 
 [2meth0[0m    [2methernet[0m  [2m/org/freedesktop/NetworkManager/Devices/1[0m 
 [2meth1[0m    [2methernet[0m  [2m/org/freedesktop/NetworkManager/Devices/2[0m 
 [2mwlan1[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/4[0m 
 [2mwlan1[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/5[0m 
-[2mwlan0[0m   [2mwifi[0m      [2m/org/freedesktop/NetworkManager/Devices/3[0m 
 
 <<<
 size: 3665
@@ -25731,6 +25839,15 @@ lang: C
 returncode: 0
 stdout: 3484 bytes
 >>>
+===========================
+  Wi-Fi scan list (wlan0)
+===========================
+NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+[32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
+[32mAP[2][0m  [32mwlan0-ap-1[0m  [32m776C616E302D61702D31[0m  [32m61:95:77:AC:1E:4C[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/1[0m 
+[35mAP[3][0m  [35mwlan0-ap-3[0m  [35m776C616E302D61702D33[0m  [35m9B:F6:B7:EC:97:76[0m  [35mInfra[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mbit/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan0[0m   [35mno[0m      [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m 
+
 ===========================
   Wi-Fi scan list (wlan1)
 ===========================
@@ -25744,15 +25861,6 @@ NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ   
 NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-===========================
-  Wi-Fi scan list (wlan0)
-===========================
-NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-[32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
-[32mAP[2][0m  [32mwlan0-ap-1[0m  [32m776C616E302D61702D31[0m  [32m61:95:77:AC:1E:4C[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/1[0m 
-[35mAP[3][0m  [35mwlan0-ap-3[0m  [35m776C616E302D61702D33[0m  [35m9B:F6:B7:EC:97:76[0m  [35mInfra[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mbit/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan0[0m   [35mno[0m      [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m 
-
 <<<
 size: 3903
 location: clients/tests/test-client.py:1068:test_004()/466
@@ -25761,6 +25869,15 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 3712 bytes
 >>>
+========================================
+  Lista skanowania sieci Wi-Fi (wlan0)
+========================================
+NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+[32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
+[32mAP[2][0m  [32mwlan0-ap-1[0m  [32m776C616E302D61702D31[0m  [32m61:95:77:AC:1E:4C[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/1[0m 
+[35mAP[3][0m  [35mwlan0-ap-3[0m  [35m776C616E302D61702D33[0m  [35m9B:F6:B7:EC:97:76[0m  [35mInfrastruktura[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mb/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan0[0m   [35mnie[0m     [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m 
+
 ========================================
   Lista skanowania sieci Wi-Fi (wlan1)
 ========================================
@@ -25774,15 +25891,6 @@ NAME   SSID        SSID-HEX              BSSID              MODE            CHAN
 NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-========================================
-  Lista skanowania sieci Wi-Fi (wlan0)
-========================================
-NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-[32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
-[32mAP[2][0m  [32mwlan0-ap-1[0m  [32m776C616E302D61702D31[0m  [32m61:95:77:AC:1E:4C[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/1[0m 
-[35mAP[3][0m  [35mwlan0-ap-3[0m  [35m776C616E302D61702D33[0m  [35m9B:F6:B7:EC:97:76[0m  [35mInfrastruktura[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mb/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan0[0m   [35mnie[0m     [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m 
-
 <<<
 size: 1468
 location: clients/tests/test-client.py:1070:test_004()/467
@@ -25791,6 +25899,15 @@ lang: C
 returncode: 0
 stdout: 1284 bytes
 >>>
+===========================
+  Wi-Fi scan list (wlan0)
+===========================
+IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
+------------------------------------------------------------------------------------------------
+[32m [0m       [32mwlan0-ap-2[0m  [32mInfra[0m  [32m1[0m     [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
+[32m [0m       [32mwlan0-ap-1[0m  [32mInfra[0m  [32m1[0m     [32m54 Mbit/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m 
+[35m [0m       [35mwlan0-ap-3[0m  [35mInfra[0m  [35m1[0m     [35m54 Mbit/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
+
 ===========================
   Wi-Fi scan list (wlan1)
 ===========================
@@ -25804,15 +25921,6 @@ IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY
 IN-USE  SSID  MODE  CHAN  RATE  SIGNAL  BARS  SECURITY 
 -----------------------------------------------------------------------------------
 
-===========================
-  Wi-Fi scan list (wlan0)
-===========================
-IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY  
-------------------------------------------------------------------------------------------------
-[32m [0m       [32mwlan0-ap-2[0m  [32mInfra[0m  [32m1[0m     [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
-[32m [0m       [32mwlan0-ap-1[0m  [32mInfra[0m  [32m1[0m     [32m54 Mbit/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m 
-[35m [0m       [35mwlan0-ap-3[0m  [35mInfra[0m  [35m1[0m     [35m54 Mbit/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
-
 <<<
 size: 1698
 location: clients/tests/test-client.py:1070:test_004()/468
@@ -25821,6 +25929,15 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 1504 bytes
 >>>
+========================================
+  Lista skanowania sieci Wi-Fi (wlan0)
+========================================
+IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
+--------------------------------------------------------------------------------------------------------------------
+[32m [0m       [32mwlan0-ap-2[0m  [32mInfrastruktura[0m  [32m1[0m     [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
+[32m [0m       [32mwlan0-ap-1[0m  [32mInfrastruktura[0m  [32m1[0m     [32m54 Mb/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m 
+[35m [0m       [35mwlan0-ap-3[0m  [35mInfrastruktura[0m  [35m1[0m     [35m54 Mb/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
+
 ========================================
   Lista skanowania sieci Wi-Fi (wlan1)
 ========================================
@@ -25834,15 +25951,6 @@ IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY
 IN-USE  SSID  MODE  CHAN  RATE  SIGNAL  BARS  SECURITY 
 ------------------------------------------------------------------------------------------------
 
-========================================
-  Lista skanowania sieci Wi-Fi (wlan0)
-========================================
-IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY  
---------------------------------------------------------------------------------------------------------------------
-[32m [0m       [32mwlan0-ap-2[0m  [32mInfrastruktura[0m  [32m1[0m     [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
-[32m [0m       [32mwlan0-ap-1[0m  [32mInfrastruktura[0m  [32m1[0m     [32m54 Mb/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m 
-[35m [0m       [35mwlan0-ap-3[0m  [35mInfrastruktura[0m  [35m1[0m     [35m54 Mb/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m 
-
 <<<
 size: 3778
 location: clients/tests/test-client.py:1073:test_004()/469
@@ -25851,6 +25959,15 @@ lang: C
 returncode: 0
 stdout: 3484 bytes
 >>>
+===========================
+  Wi-Fi scan list (wlan0)
+===========================
+NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+[32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
+[32mAP[2][0m  [32mwlan0-ap-1[0m  [32m776C616E302D61702D31[0m  [32m61:95:77:AC:1E:4C[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/1[0m 
+[35mAP[3][0m  [35mwlan0-ap-3[0m  [35m776C616E302D61702D33[0m  [35m9B:F6:B7:EC:97:76[0m  [35mInfra[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mbit/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan0[0m   [35mno[0m      [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m 
+
 ===========================
   Wi-Fi scan list (wlan1)
 ===========================
@@ -25864,15 +25981,6 @@ NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ   
 NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-===========================
-  Wi-Fi scan list (wlan0)
-===========================
-NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ      RATE       SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-[32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
-[32mAP[2][0m  [32mwlan0-ap-1[0m  [32m776C616E302D61702D31[0m  [32m61:95:77:AC:1E:4C[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/1[0m 
-[35mAP[3][0m  [35mwlan0-ap-3[0m  [35m776C616E302D61702D33[0m  [35m9B:F6:B7:EC:97:76[0m  [35mInfra[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mbit/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan0[0m   [35mno[0m      [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m 
-
 <<<
 size: 4016
 location: clients/tests/test-client.py:1073:test_004()/470
@@ -25881,6 +25989,15 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 3712 bytes
 >>>
+========================================
+  Lista skanowania sieci Wi-Fi (wlan0)
+========================================
+NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+[32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
+[32mAP[2][0m  [32mwlan0-ap-1[0m  [32m776C616E302D61702D31[0m  [32m61:95:77:AC:1E:4C[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/1[0m 
+[35mAP[3][0m  [35mwlan0-ap-3[0m  [35m776C616E302D61702D33[0m  [35m9B:F6:B7:EC:97:76[0m  [35mInfrastruktura[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mb/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan0[0m   [35mnie[0m     [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m 
+
 ========================================
   Lista skanowania sieci Wi-Fi (wlan1)
 ========================================
@@ -25894,22 +26011,13 @@ NAME   SSID        SSID-HEX              BSSID              MODE            CHAN
 NAME  SSID  SSID-HEX  BSSID  MODE  CHAN  FREQ  RATE  SIGNAL  BARS  SECURITY  WPA-FLAGS  RSN-FLAGS  DEVICE  ACTIVE  IN-USE  DBUS-PATH 
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-========================================
-  Lista skanowania sieci Wi-Fi (wlan0)
-========================================
-NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-[32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
-[32mAP[2][0m  [32mwlan0-ap-1[0m  [32m776C616E302D61702D31[0m  [32m61:95:77:AC:1E:4C[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m81[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/1[0m 
-[35mAP[3][0m  [35mwlan0-ap-3[0m  [35m776C616E302D61702D33[0m  [35m9B:F6:B7:EC:97:76[0m  [35mInfrastruktura[0m  [35m1[0m     [35m2412 MHz[0m  [35m54 Mb/s[0m  [35m55[0m      [35m**  [0m  [35mWPA1 WPA2[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [35mwlan0[0m   [35mnie[0m     [35m [0m       [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m 
-
 <<<
-size: 1320
+size: 1322
 location: clients/tests/test-client.py:1075:test_004()/471
 cmd: $NMCLI --mode tabular --pretty --color yes -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 1115 bytes
+stdout: 1117 bytes
 >>>
 ===========================
   Wi-Fi scan list (wlan0)
@@ -25918,13 +26026,15 @@ NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ   
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 [32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
 
+
+
 <<<
-size: 1407
+size: 1409
 location: clients/tests/test-client.py:1075:test_004()/472
 cmd: $NMCLI --mode tabular --pretty --color yes -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 1192 bytes
+stdout: 1194 bytes
 >>>
 ========================================
   Lista skanowania sieci Wi-Fi (wlan0)
@@ -25933,13 +26043,15 @@ NAME   SSID        SSID-HEX              BSSID              MODE            CHAN
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 [32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
 
+
+
 <<<
-size: 596
+size: 598
 location: clients/tests/test-client.py:1077:test_004()/473
 cmd: $NMCLI --mode tabular --pretty --color yes -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 389 bytes
+stdout: 391 bytes
 >>>
 ===========================
   Wi-Fi scan list (wlan0)
@@ -25948,13 +26060,15 @@ IN-USE  SSID        MODE   CHAN  RATE       SIGNAL  BARS  SECURITY
 ------------------------------------------------------------------------------------------------
 [32m [0m       [32mwlan0-ap-2[0m  [32mInfra[0m  [32m1[0m     [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
 
+
+
 <<<
-size: 681
+size: 683
 location: clients/tests/test-client.py:1077:test_004()/474
 cmd: $NMCLI --mode tabular --pretty --color yes -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 464 bytes
+stdout: 466 bytes
 >>>
 ========================================
   Lista skanowania sieci Wi-Fi (wlan0)
@@ -25963,13 +26077,15 @@ IN-USE  SSID        MODE            CHAN  RATE     SIGNAL  BARS  SECURITY
 --------------------------------------------------------------------------------------------------------------------
 [32m [0m       [32mwlan0-ap-2[0m  [32mInfrastruktura[0m  [32m1[0m     [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m 
 
+
+
 <<<
-size: 1433
+size: 1435
 location: clients/tests/test-client.py:1080:test_004()/475
 cmd: $NMCLI --mode tabular --pretty --color yes -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 1115 bytes
+stdout: 1117 bytes
 >>>
 ===========================
   Wi-Fi scan list (wlan0)
@@ -25978,13 +26094,15 @@ NAME   SSID        SSID-HEX              BSSID              MODE   CHAN  FREQ   
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 [32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfra[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mbit/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mno[0m      [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
 
+
+
 <<<
-size: 1520
+size: 1522
 location: clients/tests/test-client.py:1080:test_004()/476
 cmd: $NMCLI --mode tabular --pretty --color yes -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 1192 bytes
+stdout: 1194 bytes
 >>>
 ========================================
   Lista skanowania sieci Wi-Fi (wlan0)
@@ -25992,6 +26110,8 @@ stdout: 1192 bytes
 NAME   SSID        SSID-HEX              BSSID              MODE            CHAN  FREQ      RATE     SIGNAL  BARS  SECURITY   WPA-FLAGS                                      RSN-FLAGS                                      DEVICE  ACTIVE  IN-USE  DBUS-PATH                                     
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 [32mAP[1][0m  [32mwlan0-ap-2[0m  [32m776C616E302D61702D32[0m  [32mC0:E2:BE:E8:EF:B6[0m  [32mInfrastruktura[0m  [32m1[0m     [32m2412 MHz[0m  [32m54 Mb/s[0m  [32m92[0m      [32m****[0m  [32mWPA1 WPA2[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m  [32mwlan0[0m   [32mnie[0m     [32m [0m       [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m 
+
+
 
 <<<
 size: 4714
@@ -26423,11 +26543,11 @@ lang: C
 returncode: 0
 stdout: 135 bytes
 >>>
+wlan0:wifi:unavailable:con-vpn-1
 eth0:ethernet:unavailable:
 eth1:ethernet:unavailable:
 wlan1:wifi:unavailable:
 wlan1:wifi:unavailable:
-wlan0:wifi:unavailable:con-vpn-1
 
 <<<
 size: 294
@@ -26437,11 +26557,11 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 135 bytes
 >>>
+wlan0:wifi:unavailable:con-vpn-1
 eth0:ethernet:unavailable:
 eth1:ethernet:unavailable:
 wlan1:wifi:unavailable:
 wlan1:wifi:unavailable:
-wlan0:wifi:unavailable:con-vpn-1
 
 <<<
 size: 682
@@ -26451,11 +26571,11 @@ lang: C
 returncode: 0
 stdout: 521 bytes
 >>>
+wlan0:wifi:unavailable:unknown:unknown:/org/freedesktop/NetworkManager/Devices/3:con-vpn-1:UUID-con-vpn-1-REPLACED-REPLACED-REP:/org/freedesktop/NetworkManager/ActiveConnection/2
 eth0:ethernet:unavailable:unknown:unknown:/org/freedesktop/NetworkManager/Devices/1:::
 eth1:ethernet:unavailable:unknown:unknown:/org/freedesktop/NetworkManager/Devices/2:::
 wlan1:wifi:unavailable:unknown:unknown:/org/freedesktop/NetworkManager/Devices/4:::
 wlan1:wifi:unavailable:unknown:unknown:/org/freedesktop/NetworkManager/Devices/5:::
-wlan0:wifi:unavailable:unknown:unknown:/org/freedesktop/NetworkManager/Devices/3:con-vpn-1:UUID-con-vpn-1-REPLACED-REPLACED-REP:/org/freedesktop/NetworkManager/ActiveConnection/2
 
 <<<
 size: 702
@@ -26465,11 +26585,11 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 531 bytes
 >>>
+wlan0:wifi:unavailable:nieznane:nieznane:/org/freedesktop/NetworkManager/Devices/3:con-vpn-1:UUID-con-vpn-1-REPLACED-REPLACED-REP:/org/freedesktop/NetworkManager/ActiveConnection/2
 eth0:ethernet:unavailable:nieznane:nieznane:/org/freedesktop/NetworkManager/Devices/1:::
 eth1:ethernet:unavailable:nieznane:nieznane:/org/freedesktop/NetworkManager/Devices/2:::
 wlan1:wifi:unavailable:nieznane:nieznane:/org/freedesktop/NetworkManager/Devices/4:::
 wlan1:wifi:unavailable:nieznane:nieznane:/org/freedesktop/NetworkManager/Devices/5:::
-wlan0:wifi:unavailable:nieznane:nieznane:/org/freedesktop/NetworkManager/Devices/3:con-vpn-1:UUID-con-vpn-1-REPLACED-REPLACED-REP:/org/freedesktop/NetworkManager/ActiveConnection/2
 
 <<<
 size: 3096
@@ -26479,6 +26599,16 @@ lang: C
 returncode: 0
 stdout: 2943 bytes
 >>>
+wlan0
+wifi
+13\:E0\:74\:85\:7C\:D9
+0
+20 (unavailable)
+con-vpn-1
+/org/freedesktop/NetworkManager/ActiveConnection/2
+IP4:192.168.228.18/32 | 192.168.209.179/25:192.168.41.120:::sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar:192.168.120.79
+IP6:::dst = 2001\:a\:\:dd5b\:aa7b\:b4a2\:e42/102, nh = \:\:, mt = 2504159086::sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar
+
 eth0
 ethernet
 AB\:B7\:BF\:E2\:48\:E8
@@ -26520,16 +26650,6 @@ wifi
 
 IP4:192.168.97.124/29 | 192.168.76.154/18::dst = 192.168.33.233/22, nh = 192.168.222.210, mt = 2810496551:192.168.107.109:sear4.fo.o.bar | sear4.fo.x.y | sear4.foo2.bar | sear4.foo3.bar | sear4.foo4.bar:192.168.60.60 | 192.168.63.92
 IP6:2001\:a\:\:88ca\:3654\:96b\:ab44/89::dst = 2001\:a\:\:cc8b\:7c09\:4673\:bbb0/85, nh = \:\:, mt = 2821465568 | dst = 2001\:a\:\:a976\:2488\:f49f\:b48/106, nh = 2001\:a\:\:62ae\:c734\:fc7b\:e931, mt = 2248613879 | dst = 2001\:a\:\:afb7\:4449\:3787\:8bb4/123, nh = \:\::2001\:a\:\:2934\:bd66\:550d\:ec19:sear6.fo.x.y
-
-wlan0
-wifi
-13\:E0\:74\:85\:7C\:D9
-0
-20 (unavailable)
-con-vpn-1
-/org/freedesktop/NetworkManager/ActiveConnection/2
-IP4:192.168.228.18/32 | 192.168.209.179/25:192.168.41.120:::sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar:192.168.120.79
-IP6:::dst = 2001\:a\:\:dd5b\:aa7b\:b4a2\:e42/102, nh = \:\:, mt = 2504159086::sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar
 
 <<<
 size: 3106
@@ -26539,6 +26659,16 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 2943 bytes
 >>>
+wlan0
+wifi
+13\:E0\:74\:85\:7C\:D9
+0
+20 (unavailable)
+con-vpn-1
+/org/freedesktop/NetworkManager/ActiveConnection/2
+IP4:192.168.228.18/32 | 192.168.209.179/25:192.168.41.120:::sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar:192.168.120.79
+IP6:::dst = 2001\:a\:\:dd5b\:aa7b\:b4a2\:e42/102, nh = \:\:, mt = 2504159086::sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar
+
 eth0
 ethernet
 AB\:B7\:BF\:E2\:48\:E8
@@ -26581,16 +26711,6 @@ wifi
 IP4:192.168.97.124/29 | 192.168.76.154/18::dst = 192.168.33.233/22, nh = 192.168.222.210, mt = 2810496551:192.168.107.109:sear4.fo.o.bar | sear4.fo.x.y | sear4.foo2.bar | sear4.foo3.bar | sear4.foo4.bar:192.168.60.60 | 192.168.63.92
 IP6:2001\:a\:\:88ca\:3654\:96b\:ab44/89::dst = 2001\:a\:\:cc8b\:7c09\:4673\:bbb0/85, nh = \:\:, mt = 2821465568 | dst = 2001\:a\:\:a976\:2488\:f49f\:b48/106, nh = 2001\:a\:\:62ae\:c734\:fc7b\:e931, mt = 2248613879 | dst = 2001\:a\:\:afb7\:4449\:3787\:8bb4/123, nh = \:\::2001\:a\:\:2934\:bd66\:550d\:ec19:sear6.fo.x.y
 
-wlan0
-wifi
-13\:E0\:74\:85\:7C\:D9
-0
-20 (unavailable)
-con-vpn-1
-/org/freedesktop/NetworkManager/ActiveConnection/2
-IP4:192.168.228.18/32 | 192.168.209.179/25:192.168.41.120:::sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar:192.168.120.79
-IP6:::dst = 2001\:a\:\:dd5b\:aa7b\:b4a2\:e42/102, nh = \:\:, mt = 2504159086::sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar
-
 <<<
 size: 6325
 location: clients/tests/test-client.py:1050:test_004()/499
@@ -26599,6 +26719,18 @@ lang: C
 returncode: 0
 stdout: 6165 bytes
 >>>
+GENERAL:wlan0:wifi:NMDeviceWifi:::virtual:::13\:E0\:74\:85\:7C\:D9:0:20 (unavailable):0 (No reason given):0 (unknown):0 (unknown):/sys/devices/virtual/wlan0::no:yes:yes:no:no::con-vpn-1:UUID-con-vpn-1-REPLACED-REPLACED-REP:/org/freedesktop/NetworkManager/ActiveConnection/2:unknown
+CAPABILITIES:no:unknown:no:no
+WIFI-PROPERTIES:yes:yes:yes:yes:yes:yes:yes:unknown:unknown
+AP[1]: :wlan0-ap-2:Infra:1:54 Mbit/s:92:****:WPA1 WPA2
+AP[2]: :wlan0-ap-1:Infra:1:54 Mbit/s:81:****:WPA1 WPA2
+AP[3]: :wlan0-ap-3:Infra:1:54 Mbit/s:55:**  :WPA1 WPA2
+IP4:192.168.228.18/32 | 192.168.209.179/25:192.168.41.120:::sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar:192.168.120.79
+DHCP4:dhcp-4-opt-0 = val-0 | dhcp-4-opt-2 = val-2 | dhcp-4-opt-4 = val-4 | dhcp-4-opt-7 = val-7
+IP6:::dst = 2001\:a\:\:dd5b\:aa7b\:b4a2\:e42/102, nh = \:\:, mt = 2504159086::sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar
+DHCP6:dhcp-6-opt-1 = val-1 | dhcp-6-opt-2 = val-2 | dhcp-6-opt-3 = val-3 | dhcp-6-opt-4 = val-4 | dhcp-6-opt-5 = val-5
+CONNECTIONS:/org/freedesktop/NetworkManager/Settings/Connection/{2}:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
+
 GENERAL:eth0:ethernet:NMDeviceEthernet:::virtual:::AB\:B7\:BF\:E2\:48\:E8:0:20 (unavailable):0 (No reason given):0 (unknown):0 (unknown):/sys/devices/virtual/eth0::no:yes:yes:no:no:::::unknown
 CAPABILITIES:no:100 Mb/s:no:no
 WIRED-PROPERTIES:off:
@@ -26636,18 +26768,6 @@ IP6:2001\:a\:\:88ca\:3654\:96b\:ab44/89::dst = 2001\:a\:\:cc8b\:7c09\:4673\:bbb0
 DHCP6:dhcp-6-opt-2 = val-2 | dhcp-6-opt-6 = val-6 | dhcp-6-opt-7 = val-7 | dhcp-6-opt-8 = val-8 | dhcp-6-opt-9 = val-9
 CONNECTIONS:/org/freedesktop/NetworkManager/Settings/Connection/{2}:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
-GENERAL:wlan0:wifi:NMDeviceWifi:::virtual:::13\:E0\:74\:85\:7C\:D9:0:20 (unavailable):0 (No reason given):0 (unknown):0 (unknown):/sys/devices/virtual/wlan0::no:yes:yes:no:no::con-vpn-1:UUID-con-vpn-1-REPLACED-REPLACED-REP:/org/freedesktop/NetworkManager/ActiveConnection/2:unknown
-CAPABILITIES:no:unknown:no:no
-WIFI-PROPERTIES:yes:yes:yes:yes:yes:yes:yes:unknown:unknown
-AP[1]: :wlan0-ap-2:Infra:1:54 Mbit/s:92:****:WPA1 WPA2
-AP[2]: :wlan0-ap-1:Infra:1:54 Mbit/s:81:****:WPA1 WPA2
-AP[3]: :wlan0-ap-3:Infra:1:54 Mbit/s:55:**  :WPA1 WPA2
-IP4:192.168.228.18/32 | 192.168.209.179/25:192.168.41.120:::sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar:192.168.120.79
-DHCP4:dhcp-4-opt-0 = val-0 | dhcp-4-opt-2 = val-2 | dhcp-4-opt-4 = val-4 | dhcp-4-opt-7 = val-7
-IP6:::dst = 2001\:a\:\:dd5b\:aa7b\:b4a2\:e42/102, nh = \:\:, mt = 2504159086::sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar
-DHCP6:dhcp-6-opt-1 = val-1 | dhcp-6-opt-2 = val-2 | dhcp-6-opt-3 = val-3 | dhcp-6-opt-4 = val-4 | dhcp-6-opt-5 = val-5
-CONNECTIONS:/org/freedesktop/NetworkManager/Settings/Connection/{2}:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
-
 <<<
 size: 6381
 location: clients/tests/test-client.py:1050:test_004()/500
@@ -26656,6 +26776,18 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 6211 bytes
 >>>
+GENERAL:wlan0:wifi:NMDeviceWifi:::virtual:::13\:E0\:74\:85\:7C\:D9:0:20 (unavailable):0 (No reason given):0 (nieznane):0 (nieznane):/sys/devices/virtual/wlan0::no:yes:yes:no:no::con-vpn-1:UUID-con-vpn-1-REPLACED-REPLACED-REP:/org/freedesktop/NetworkManager/ActiveConnection/2:unknown
+CAPABILITIES:no:unknown:no:no
+WIFI-PROPERTIES:yes:yes:yes:yes:yes:yes:yes:unknown:unknown
+AP[1]: :wlan0-ap-2:Infrastruktura:1:54 Mb/s:92:****:WPA1 WPA2
+AP[2]: :wlan0-ap-1:Infrastruktura:1:54 Mb/s:81:****:WPA1 WPA2
+AP[3]: :wlan0-ap-3:Infrastruktura:1:54 Mb/s:55:**  :WPA1 WPA2
+IP4:192.168.228.18/32 | 192.168.209.179/25:192.168.41.120:::sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar:192.168.120.79
+DHCP4:dhcp-4-opt-0 = val-0 | dhcp-4-opt-2 = val-2 | dhcp-4-opt-4 = val-4 | dhcp-4-opt-7 = val-7
+IP6:::dst = 2001\:a\:\:dd5b\:aa7b\:b4a2\:e42/102, nh = \:\:, mt = 2504159086::sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar
+DHCP6:dhcp-6-opt-1 = val-1 | dhcp-6-opt-2 = val-2 | dhcp-6-opt-3 = val-3 | dhcp-6-opt-4 = val-4 | dhcp-6-opt-5 = val-5
+CONNECTIONS:/org/freedesktop/NetworkManager/Settings/Connection/{2}:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
+
 GENERAL:eth0:ethernet:NMDeviceEthernet:::virtual:::AB\:B7\:BF\:E2\:48\:E8:0:20 (unavailable):0 (No reason given):0 (nieznane):0 (nieznane):/sys/devices/virtual/eth0::no:yes:yes:no:no:::::unknown
 CAPABILITIES:no:100 Mb/s:no:no
 WIRED-PROPERTIES:off:
@@ -26691,18 +26823,6 @@ IP4:192.168.97.124/29 | 192.168.76.154/18::dst = 192.168.33.233/22, nh = 192.168
 DHCP4:dhcp-4-opt-0 = val-0 | dhcp-4-opt-5 = val-5
 IP6:2001\:a\:\:88ca\:3654\:96b\:ab44/89::dst = 2001\:a\:\:cc8b\:7c09\:4673\:bbb0/85, nh = \:\:, mt = 2821465568 | dst = 2001\:a\:\:a976\:2488\:f49f\:b48/106, nh = 2001\:a\:\:62ae\:c734\:fc7b\:e931, mt = 2248613879 | dst = 2001\:a\:\:afb7\:4449\:3787\:8bb4/123, nh = \:\::2001\:a\:\:2934\:bd66\:550d\:ec19:sear6.fo.x.y
 DHCP6:dhcp-6-opt-2 = val-2 | dhcp-6-opt-6 = val-6 | dhcp-6-opt-7 = val-7 | dhcp-6-opt-8 = val-8 | dhcp-6-opt-9 = val-9
-CONNECTIONS:/org/freedesktop/NetworkManager/Settings/Connection/{2}:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
-
-GENERAL:wlan0:wifi:NMDeviceWifi:::virtual:::13\:E0\:74\:85\:7C\:D9:0:20 (unavailable):0 (No reason given):0 (nieznane):0 (nieznane):/sys/devices/virtual/wlan0::no:yes:yes:no:no::con-vpn-1:UUID-con-vpn-1-REPLACED-REPLACED-REP:/org/freedesktop/NetworkManager/ActiveConnection/2:unknown
-CAPABILITIES:no:unknown:no:no
-WIFI-PROPERTIES:yes:yes:yes:yes:yes:yes:yes:unknown:unknown
-AP[1]: :wlan0-ap-2:Infrastruktura:1:54 Mb/s:92:****:WPA1 WPA2
-AP[2]: :wlan0-ap-1:Infrastruktura:1:54 Mb/s:81:****:WPA1 WPA2
-AP[3]: :wlan0-ap-3:Infrastruktura:1:54 Mb/s:55:**  :WPA1 WPA2
-IP4:192.168.228.18/32 | 192.168.209.179/25:192.168.41.120:::sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar:192.168.120.79
-DHCP4:dhcp-4-opt-0 = val-0 | dhcp-4-opt-2 = val-2 | dhcp-4-opt-4 = val-4 | dhcp-4-opt-7 = val-7
-IP6:::dst = 2001\:a\:\:dd5b\:aa7b\:b4a2\:e42/102, nh = \:\:, mt = 2504159086::sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar
-DHCP6:dhcp-6-opt-1 = val-1 | dhcp-6-opt-2 = val-2 | dhcp-6-opt-3 = val-3 | dhcp-6-opt-4 = val-4 | dhcp-6-opt-5 = val-5
 CONNECTIONS:/org/freedesktop/NetworkManager/Settings/Connection/{2}:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
 <<<
@@ -26837,11 +26957,11 @@ lang: C
 returncode: 0
 stdout: 271 bytes
 >>>
+wlan0:wifi:/org/freedesktop/NetworkManager/Devices/3
 eth0:ethernet:/org/freedesktop/NetworkManager/Devices/1
 eth1:ethernet:/org/freedesktop/NetworkManager/Devices/2
 wlan1:wifi:/org/freedesktop/NetworkManager/Devices/4
 wlan1:wifi:/org/freedesktop/NetworkManager/Devices/5
-wlan0:wifi:/org/freedesktop/NetworkManager/Devices/3
 
 <<<
 size: 453
@@ -26851,11 +26971,11 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 271 bytes
 >>>
+wlan0:wifi:/org/freedesktop/NetworkManager/Devices/3
 eth0:ethernet:/org/freedesktop/NetworkManager/Devices/1
 eth1:ethernet:/org/freedesktop/NetworkManager/Devices/2
 wlan1:wifi:/org/freedesktop/NetworkManager/Devices/4
 wlan1:wifi:/org/freedesktop/NetworkManager/Devices/5
-wlan0:wifi:/org/freedesktop/NetworkManager/Devices/3
 
 <<<
 size: 1190
@@ -26865,12 +26985,12 @@ lang: C
 returncode: 0
 stdout: 1022 bytes
 >>>
-AP[1]:wlan1-ap-4:776C616E312D61702D34:94\:2B\:E8\:F6\:D2\:86:Infra:1:2412 MHz:54 Mbit/s:48:**  :WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan1:no: :/org/freedesktop/NetworkManager/AccessPoint/4
-
-
 AP[1]:wlan0-ap-2:776C616E302D61702D32:C0\:E2\:BE\:E8\:EF\:B6:Infra:1:2412 MHz:54 Mbit/s:92:****:WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:no: :/org/freedesktop/NetworkManager/AccessPoint/2
 AP[2]:wlan0-ap-1:776C616E302D61702D31:61\:95\:77\:AC\:1E\:4C:Infra:1:2412 MHz:54 Mbit/s:81:****:WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:no: :/org/freedesktop/NetworkManager/AccessPoint/1
 AP[3]:wlan0-ap-3:776C616E302D61702D33:9B\:F6\:B7\:EC\:97\:76:Infra:1:2412 MHz:54 Mbit/s:55:**  :WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:no: :/org/freedesktop/NetworkManager/AccessPoint/3
+
+AP[1]:wlan1-ap-4:776C616E312D61702D34:94\:2B\:E8\:F6\:D2\:86:Infra:1:2412 MHz:54 Mbit/s:48:**  :WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan1:no: :/org/freedesktop/NetworkManager/AccessPoint/4
+
 
 <<<
 size: 1248
@@ -26880,12 +27000,12 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 1070 bytes
 >>>
-AP[1]:wlan1-ap-4:776C616E312D61702D34:94\:2B\:E8\:F6\:D2\:86:Infrastruktura:1:2412 MHz:54 Mb/s:48:**  :WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan1:nie: :/org/freedesktop/NetworkManager/AccessPoint/4
-
-
 AP[1]:wlan0-ap-2:776C616E302D61702D32:C0\:E2\:BE\:E8\:EF\:B6:Infrastruktura:1:2412 MHz:54 Mb/s:92:****:WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:nie: :/org/freedesktop/NetworkManager/AccessPoint/2
 AP[2]:wlan0-ap-1:776C616E302D61702D31:61\:95\:77\:AC\:1E\:4C:Infrastruktura:1:2412 MHz:54 Mb/s:81:****:WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:nie: :/org/freedesktop/NetworkManager/AccessPoint/1
 AP[3]:wlan0-ap-3:776C616E302D61702D33:9B\:F6\:B7\:EC\:97\:76:Infrastruktura:1:2412 MHz:54 Mb/s:55:**  :WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:nie: :/org/freedesktop/NetworkManager/AccessPoint/3
+
+AP[1]:wlan1-ap-4:776C616E312D61702D34:94\:2B\:E8\:F6\:D2\:86:Infrastruktura:1:2412 MHz:54 Mb/s:48:**  :WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan1:nie: :/org/freedesktop/NetworkManager/AccessPoint/4
+
 
 <<<
 size: 368
@@ -26895,12 +27015,12 @@ lang: C
 returncode: 0
 stdout: 198 bytes
 >>>
- :wlan1-ap-4:Infra:1:54 Mbit/s:48:**  :WPA1 WPA2
-
-
  :wlan0-ap-2:Infra:1:54 Mbit/s:92:****:WPA1 WPA2
  :wlan0-ap-1:Infra:1:54 Mbit/s:81:****:WPA1 WPA2
  :wlan0-ap-3:Infra:1:54 Mbit/s:55:**  :WPA1 WPA2
+
+ :wlan1-ap-4:Infra:1:54 Mbit/s:48:**  :WPA1 WPA2
+
 
 <<<
 size: 414
@@ -26910,12 +27030,12 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 234 bytes
 >>>
- :wlan1-ap-4:Infrastruktura:1:54 Mb/s:48:**  :WPA1 WPA2
-
-
  :wlan0-ap-2:Infrastruktura:1:54 Mb/s:92:****:WPA1 WPA2
  :wlan0-ap-1:Infrastruktura:1:54 Mb/s:81:****:WPA1 WPA2
  :wlan0-ap-3:Infrastruktura:1:54 Mb/s:55:**  :WPA1 WPA2
+
+ :wlan1-ap-4:Infrastruktura:1:54 Mb/s:48:**  :WPA1 WPA2
+
 
 <<<
 size: 1303
@@ -26925,12 +27045,12 @@ lang: C
 returncode: 0
 stdout: 1022 bytes
 >>>
-AP[1]:wlan1-ap-4:776C616E312D61702D34:94\:2B\:E8\:F6\:D2\:86:Infra:1:2412 MHz:54 Mbit/s:48:**  :WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan1:no: :/org/freedesktop/NetworkManager/AccessPoint/4
-
-
 AP[1]:wlan0-ap-2:776C616E302D61702D32:C0\:E2\:BE\:E8\:EF\:B6:Infra:1:2412 MHz:54 Mbit/s:92:****:WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:no: :/org/freedesktop/NetworkManager/AccessPoint/2
 AP[2]:wlan0-ap-1:776C616E302D61702D31:61\:95\:77\:AC\:1E\:4C:Infra:1:2412 MHz:54 Mbit/s:81:****:WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:no: :/org/freedesktop/NetworkManager/AccessPoint/1
 AP[3]:wlan0-ap-3:776C616E302D61702D33:9B\:F6\:B7\:EC\:97\:76:Infra:1:2412 MHz:54 Mbit/s:55:**  :WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:no: :/org/freedesktop/NetworkManager/AccessPoint/3
+
+AP[1]:wlan1-ap-4:776C616E312D61702D34:94\:2B\:E8\:F6\:D2\:86:Infra:1:2412 MHz:54 Mbit/s:48:**  :WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan1:no: :/org/freedesktop/NetworkManager/AccessPoint/4
+
 
 <<<
 size: 1361
@@ -26940,72 +27060,84 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 1070 bytes
 >>>
-AP[1]:wlan1-ap-4:776C616E312D61702D34:94\:2B\:E8\:F6\:D2\:86:Infrastruktura:1:2412 MHz:54 Mb/s:48:**  :WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan1:nie: :/org/freedesktop/NetworkManager/AccessPoint/4
-
-
 AP[1]:wlan0-ap-2:776C616E302D61702D32:C0\:E2\:BE\:E8\:EF\:B6:Infrastruktura:1:2412 MHz:54 Mb/s:92:****:WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:nie: :/org/freedesktop/NetworkManager/AccessPoint/2
 AP[2]:wlan0-ap-1:776C616E302D61702D31:61\:95\:77\:AC\:1E\:4C:Infrastruktura:1:2412 MHz:54 Mb/s:81:****:WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:nie: :/org/freedesktop/NetworkManager/AccessPoint/1
 AP[3]:wlan0-ap-3:776C616E302D61702D33:9B\:F6\:B7\:EC\:97\:76:Infrastruktura:1:2412 MHz:54 Mb/s:55:**  :WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:nie: :/org/freedesktop/NetworkManager/AccessPoint/3
 
+AP[1]:wlan1-ap-4:776C616E312D61702D34:94\:2B\:E8\:F6\:D2\:86:Infrastruktura:1:2412 MHz:54 Mb/s:48:**  :WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan1:nie: :/org/freedesktop/NetworkManager/AccessPoint/4
+
+
 <<<
-size: 446
+size: 448
 location: clients/tests/test-client.py:1075:test_004()/517
 cmd: $NMCLI --mode tabular --terse -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 255 bytes
+stdout: 257 bytes
 >>>
 AP[1]:wlan0-ap-2:776C616E302D61702D32:C0\:E2\:BE\:E8\:EF\:B6:Infra:1:2412 MHz:54 Mbit/s:92:****:WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:no: :/org/freedesktop/NetworkManager/AccessPoint/2
 
+
+
 <<<
-size: 468
+size: 470
 location: clients/tests/test-client.py:1075:test_004()/518
 cmd: $NMCLI --mode tabular --terse -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 267 bytes
+stdout: 269 bytes
 >>>
 AP[1]:wlan0-ap-2:776C616E302D61702D32:C0\:E2\:BE\:E8\:EF\:B6:Infrastruktura:1:2412 MHz:54 Mb/s:92:****:WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:nie: :/org/freedesktop/NetworkManager/AccessPoint/2
 
+
+
 <<<
-size: 242
+size: 244
 location: clients/tests/test-client.py:1077:test_004()/519
 cmd: $NMCLI --mode tabular --terse -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 49 bytes
+stdout: 51 bytes
 >>>
  :wlan0-ap-2:Infra:1:54 Mbit/s:92:****:WPA1 WPA2
 
+
+
 <<<
-size: 261
+size: 263
 location: clients/tests/test-client.py:1077:test_004()/520
 cmd: $NMCLI --mode tabular --terse -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 58 bytes
+stdout: 60 bytes
 >>>
  :wlan0-ap-2:Infrastruktura:1:54 Mb/s:92:****:WPA1 WPA2
 
+
+
 <<<
-size: 559
+size: 561
 location: clients/tests/test-client.py:1080:test_004()/521
 cmd: $NMCLI --mode tabular --terse -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 255 bytes
+stdout: 257 bytes
 >>>
 AP[1]:wlan0-ap-2:776C616E302D61702D32:C0\:E2\:BE\:E8\:EF\:B6:Infra:1:2412 MHz:54 Mbit/s:92:****:WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:no: :/org/freedesktop/NetworkManager/AccessPoint/2
 
+
+
 <<<
-size: 581
+size: 583
 location: clients/tests/test-client.py:1080:test_004()/522
 cmd: $NMCLI --mode tabular --terse -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 267 bytes
+stdout: 269 bytes
 >>>
 AP[1]:wlan0-ap-2:776C616E302D61702D32:C0\:E2\:BE\:E8\:EF\:B6:Infrastruktura:1:2412 MHz:54 Mb/s:92:****:WPA1 WPA2:pair_tkip pair_ccmp group_tkip group_ccmp psk:pair_tkip pair_ccmp group_tkip group_ccmp psk:wlan0:nie: :/org/freedesktop/NetworkManager/AccessPoint/2
+
+
 
 <<<
 size: 1368
@@ -27263,11 +27395,11 @@ lang: C
 returncode: 0
 stdout: 295 bytes
 >>>
+[2mwlan0[0m:[2mwifi[0m:[2munavailable[0m:[2mcon-vpn-1[0m
 [2meth0[0m:[2methernet[0m:[2munavailable[0m:[2m[0m
 [2meth1[0m:[2methernet[0m:[2munavailable[0m:[2m[0m
 [2mwlan1[0m:[2mwifi[0m:[2munavailable[0m:[2m[0m
 [2mwlan1[0m:[2mwifi[0m:[2munavailable[0m:[2m[0m
-[2mwlan0[0m:[2mwifi[0m:[2munavailable[0m:[2mcon-vpn-1[0m
 
 <<<
 size: 466
@@ -27277,11 +27409,11 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 295 bytes
 >>>
+[2mwlan0[0m:[2mwifi[0m:[2munavailable[0m:[2mcon-vpn-1[0m
 [2meth0[0m:[2methernet[0m:[2munavailable[0m:[2m[0m
 [2meth1[0m:[2methernet[0m:[2munavailable[0m:[2m[0m
 [2mwlan1[0m:[2mwifi[0m:[2munavailable[0m:[2m[0m
 [2mwlan1[0m:[2mwifi[0m:[2munavailable[0m:[2m[0m
-[2mwlan0[0m:[2mwifi[0m:[2munavailable[0m:[2mcon-vpn-1[0m
 
 <<<
 size: 1054
@@ -27291,11 +27423,11 @@ lang: C
 returncode: 0
 stdout: 881 bytes
 >>>
+[2mwlan0[0m:[2mwifi[0m:[2munavailable[0m:[2munknown[0m:[2munknown[0m:[2m/org/freedesktop/NetworkManager/Devices/3[0m:[2mcon-vpn-1[0m:[2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m:[2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
 [2meth0[0m:[2methernet[0m:[2munavailable[0m:[2munknown[0m:[2munknown[0m:[2m/org/freedesktop/NetworkManager/Devices/1[0m:[2m[0m:[2m[0m:[2m[0m
 [2meth1[0m:[2methernet[0m:[2munavailable[0m:[2munknown[0m:[2munknown[0m:[2m/org/freedesktop/NetworkManager/Devices/2[0m:[2m[0m:[2m[0m:[2m[0m
 [2mwlan1[0m:[2mwifi[0m:[2munavailable[0m:[2munknown[0m:[2munknown[0m:[2m/org/freedesktop/NetworkManager/Devices/4[0m:[2m[0m:[2m[0m:[2m[0m
 [2mwlan1[0m:[2mwifi[0m:[2munavailable[0m:[2munknown[0m:[2munknown[0m:[2m/org/freedesktop/NetworkManager/Devices/5[0m:[2m[0m:[2m[0m:[2m[0m
-[2mwlan0[0m:[2mwifi[0m:[2munavailable[0m:[2munknown[0m:[2munknown[0m:[2m/org/freedesktop/NetworkManager/Devices/3[0m:[2mcon-vpn-1[0m:[2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m:[2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
 
 <<<
 size: 1074
@@ -27305,11 +27437,11 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 891 bytes
 >>>
+[2mwlan0[0m:[2mwifi[0m:[2munavailable[0m:[2mnieznane[0m:[2mnieznane[0m:[2m/org/freedesktop/NetworkManager/Devices/3[0m:[2mcon-vpn-1[0m:[2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m:[2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
 [2meth0[0m:[2methernet[0m:[2munavailable[0m:[2mnieznane[0m:[2mnieznane[0m:[2m/org/freedesktop/NetworkManager/Devices/1[0m:[2m[0m:[2m[0m:[2m[0m
 [2meth1[0m:[2methernet[0m:[2munavailable[0m:[2mnieznane[0m:[2mnieznane[0m:[2m/org/freedesktop/NetworkManager/Devices/2[0m:[2m[0m:[2m[0m:[2m[0m
 [2mwlan1[0m:[2mwifi[0m:[2munavailable[0m:[2mnieznane[0m:[2mnieznane[0m:[2m/org/freedesktop/NetworkManager/Devices/4[0m:[2m[0m:[2m[0m:[2m[0m
 [2mwlan1[0m:[2mwifi[0m:[2munavailable[0m:[2mnieznane[0m:[2mnieznane[0m:[2m/org/freedesktop/NetworkManager/Devices/5[0m:[2m[0m:[2m[0m:[2m[0m
-[2mwlan0[0m:[2mwifi[0m:[2munavailable[0m:[2mnieznane[0m:[2mnieznane[0m:[2m/org/freedesktop/NetworkManager/Devices/3[0m:[2mcon-vpn-1[0m:[2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m:[2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
 
 <<<
 size: 3108
@@ -27319,6 +27451,16 @@ lang: C
 returncode: 0
 stdout: 2943 bytes
 >>>
+wlan0
+wifi
+13\:E0\:74\:85\:7C\:D9
+0
+20 (unavailable)
+con-vpn-1
+/org/freedesktop/NetworkManager/ActiveConnection/2
+IP4:192.168.228.18/32 | 192.168.209.179/25:192.168.41.120:::sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar:192.168.120.79
+IP6:::dst = 2001\:a\:\:dd5b\:aa7b\:b4a2\:e42/102, nh = \:\:, mt = 2504159086::sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar
+
 eth0
 ethernet
 AB\:B7\:BF\:E2\:48\:E8
@@ -27360,16 +27502,6 @@ wifi
 
 IP4:192.168.97.124/29 | 192.168.76.154/18::dst = 192.168.33.233/22, nh = 192.168.222.210, mt = 2810496551:192.168.107.109:sear4.fo.o.bar | sear4.fo.x.y | sear4.foo2.bar | sear4.foo3.bar | sear4.foo4.bar:192.168.60.60 | 192.168.63.92
 IP6:2001\:a\:\:88ca\:3654\:96b\:ab44/89::dst = 2001\:a\:\:cc8b\:7c09\:4673\:bbb0/85, nh = \:\:, mt = 2821465568 | dst = 2001\:a\:\:a976\:2488\:f49f\:b48/106, nh = 2001\:a\:\:62ae\:c734\:fc7b\:e931, mt = 2248613879 | dst = 2001\:a\:\:afb7\:4449\:3787\:8bb4/123, nh = \:\::2001\:a\:\:2934\:bd66\:550d\:ec19:sear6.fo.x.y
-
-wlan0
-wifi
-13\:E0\:74\:85\:7C\:D9
-0
-20 (unavailable)
-con-vpn-1
-/org/freedesktop/NetworkManager/ActiveConnection/2
-IP4:192.168.228.18/32 | 192.168.209.179/25:192.168.41.120:::sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar:192.168.120.79
-IP6:::dst = 2001\:a\:\:dd5b\:aa7b\:b4a2\:e42/102, nh = \:\:, mt = 2504159086::sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar
 
 <<<
 size: 3118
@@ -27379,6 +27511,16 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 2943 bytes
 >>>
+wlan0
+wifi
+13\:E0\:74\:85\:7C\:D9
+0
+20 (unavailable)
+con-vpn-1
+/org/freedesktop/NetworkManager/ActiveConnection/2
+IP4:192.168.228.18/32 | 192.168.209.179/25:192.168.41.120:::sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar:192.168.120.79
+IP6:::dst = 2001\:a\:\:dd5b\:aa7b\:b4a2\:e42/102, nh = \:\:, mt = 2504159086::sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar
+
 eth0
 ethernet
 AB\:B7\:BF\:E2\:48\:E8
@@ -27421,16 +27563,6 @@ wifi
 IP4:192.168.97.124/29 | 192.168.76.154/18::dst = 192.168.33.233/22, nh = 192.168.222.210, mt = 2810496551:192.168.107.109:sear4.fo.o.bar | sear4.fo.x.y | sear4.foo2.bar | sear4.foo3.bar | sear4.foo4.bar:192.168.60.60 | 192.168.63.92
 IP6:2001\:a\:\:88ca\:3654\:96b\:ab44/89::dst = 2001\:a\:\:cc8b\:7c09\:4673\:bbb0/85, nh = \:\:, mt = 2821465568 | dst = 2001\:a\:\:a976\:2488\:f49f\:b48/106, nh = 2001\:a\:\:62ae\:c734\:fc7b\:e931, mt = 2248613879 | dst = 2001\:a\:\:afb7\:4449\:3787\:8bb4/123, nh = \:\::2001\:a\:\:2934\:bd66\:550d\:ec19:sear6.fo.x.y
 
-wlan0
-wifi
-13\:E0\:74\:85\:7C\:D9
-0
-20 (unavailable)
-con-vpn-1
-/org/freedesktop/NetworkManager/ActiveConnection/2
-IP4:192.168.228.18/32 | 192.168.209.179/25:192.168.41.120:::sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar:192.168.120.79
-IP6:::dst = 2001\:a\:\:dd5b\:aa7b\:b4a2\:e42/102, nh = \:\:, mt = 2504159086::sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar
-
 <<<
 size: 6661
 location: clients/tests/test-client.py:1050:test_004()/545
@@ -27439,6 +27571,18 @@ lang: C
 returncode: 0
 stdout: 6489 bytes
 >>>
+GENERAL:wlan0:wifi:NMDeviceWifi:::virtual:::13\:E0\:74\:85\:7C\:D9:0:20 (unavailable):0 (No reason given):0 (unknown):0 (unknown):/sys/devices/virtual/wlan0::no:yes:yes:no:no::con-vpn-1:UUID-con-vpn-1-REPLACED-REPLACED-REP:/org/freedesktop/NetworkManager/ActiveConnection/2:unknown
+CAPABILITIES:no:unknown:no:no
+WIFI-PROPERTIES:yes:yes:yes:yes:yes:yes:yes:unknown:unknown
+[32mAP[1][0m:[32m [0m:[32mwlan0-ap-2[0m:[32mInfra[0m:[32m1[0m:[32m54 Mbit/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m
+[32mAP[2][0m:[32m [0m:[32mwlan0-ap-1[0m:[32mInfra[0m:[32m1[0m:[32m54 Mbit/s[0m:[32m81[0m:[32m****[0m:[32mWPA1 WPA2[0m
+[35mAP[3][0m:[35m [0m:[35mwlan0-ap-3[0m:[35mInfra[0m:[35m1[0m:[35m54 Mbit/s[0m:[35m55[0m:[35m**  [0m:[35mWPA1 WPA2[0m
+IP4:192.168.228.18/32 | 192.168.209.179/25:192.168.41.120:::sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar:192.168.120.79
+DHCP4:dhcp-4-opt-0 = val-0 | dhcp-4-opt-2 = val-2 | dhcp-4-opt-4 = val-4 | dhcp-4-opt-7 = val-7
+IP6:::dst = 2001\:a\:\:dd5b\:aa7b\:b4a2\:e42/102, nh = \:\:, mt = 2504159086::sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar
+DHCP6:dhcp-6-opt-1 = val-1 | dhcp-6-opt-2 = val-2 | dhcp-6-opt-3 = val-3 | dhcp-6-opt-4 = val-4 | dhcp-6-opt-5 = val-5
+CONNECTIONS:/org/freedesktop/NetworkManager/Settings/Connection/{2}:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
+
 GENERAL:eth0:ethernet:NMDeviceEthernet:::virtual:::AB\:B7\:BF\:E2\:48\:E8:0:20 (unavailable):0 (No reason given):0 (unknown):0 (unknown):/sys/devices/virtual/eth0::no:yes:yes:no:no:::::unknown
 CAPABILITIES:no:100 Mb/s:no:no
 WIRED-PROPERTIES:off:
@@ -27476,18 +27620,6 @@ IP6:2001\:a\:\:88ca\:3654\:96b\:ab44/89::dst = 2001\:a\:\:cc8b\:7c09\:4673\:bbb0
 DHCP6:dhcp-6-opt-2 = val-2 | dhcp-6-opt-6 = val-6 | dhcp-6-opt-7 = val-7 | dhcp-6-opt-8 = val-8 | dhcp-6-opt-9 = val-9
 CONNECTIONS:/org/freedesktop/NetworkManager/Settings/Connection/{2}:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
-GENERAL:wlan0:wifi:NMDeviceWifi:::virtual:::13\:E0\:74\:85\:7C\:D9:0:20 (unavailable):0 (No reason given):0 (unknown):0 (unknown):/sys/devices/virtual/wlan0::no:yes:yes:no:no::con-vpn-1:UUID-con-vpn-1-REPLACED-REPLACED-REP:/org/freedesktop/NetworkManager/ActiveConnection/2:unknown
-CAPABILITIES:no:unknown:no:no
-WIFI-PROPERTIES:yes:yes:yes:yes:yes:yes:yes:unknown:unknown
-[32mAP[1][0m:[32m [0m:[32mwlan0-ap-2[0m:[32mInfra[0m:[32m1[0m:[32m54 Mbit/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m
-[32mAP[2][0m:[32m [0m:[32mwlan0-ap-1[0m:[32mInfra[0m:[32m1[0m:[32m54 Mbit/s[0m:[32m81[0m:[32m****[0m:[32mWPA1 WPA2[0m
-[35mAP[3][0m:[35m [0m:[35mwlan0-ap-3[0m:[35mInfra[0m:[35m1[0m:[35m54 Mbit/s[0m:[35m55[0m:[35m**  [0m:[35mWPA1 WPA2[0m
-IP4:192.168.228.18/32 | 192.168.209.179/25:192.168.41.120:::sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar:192.168.120.79
-DHCP4:dhcp-4-opt-0 = val-0 | dhcp-4-opt-2 = val-2 | dhcp-4-opt-4 = val-4 | dhcp-4-opt-7 = val-7
-IP6:::dst = 2001\:a\:\:dd5b\:aa7b\:b4a2\:e42/102, nh = \:\:, mt = 2504159086::sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar
-DHCP6:dhcp-6-opt-1 = val-1 | dhcp-6-opt-2 = val-2 | dhcp-6-opt-3 = val-3 | dhcp-6-opt-4 = val-4 | dhcp-6-opt-5 = val-5
-CONNECTIONS:/org/freedesktop/NetworkManager/Settings/Connection/{2}:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
-
 <<<
 size: 6717
 location: clients/tests/test-client.py:1050:test_004()/546
@@ -27496,6 +27628,18 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 6535 bytes
 >>>
+GENERAL:wlan0:wifi:NMDeviceWifi:::virtual:::13\:E0\:74\:85\:7C\:D9:0:20 (unavailable):0 (No reason given):0 (nieznane):0 (nieznane):/sys/devices/virtual/wlan0::no:yes:yes:no:no::con-vpn-1:UUID-con-vpn-1-REPLACED-REPLACED-REP:/org/freedesktop/NetworkManager/ActiveConnection/2:unknown
+CAPABILITIES:no:unknown:no:no
+WIFI-PROPERTIES:yes:yes:yes:yes:yes:yes:yes:unknown:unknown
+[32mAP[1][0m:[32m [0m:[32mwlan0-ap-2[0m:[32mInfrastruktura[0m:[32m1[0m:[32m54 Mb/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m
+[32mAP[2][0m:[32m [0m:[32mwlan0-ap-1[0m:[32mInfrastruktura[0m:[32m1[0m:[32m54 Mb/s[0m:[32m81[0m:[32m****[0m:[32mWPA1 WPA2[0m
+[35mAP[3][0m:[35m [0m:[35mwlan0-ap-3[0m:[35mInfrastruktura[0m:[35m1[0m:[35m54 Mb/s[0m:[35m55[0m:[35m**  [0m:[35mWPA1 WPA2[0m
+IP4:192.168.228.18/32 | 192.168.209.179/25:192.168.41.120:::sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar:192.168.120.79
+DHCP4:dhcp-4-opt-0 = val-0 | dhcp-4-opt-2 = val-2 | dhcp-4-opt-4 = val-4 | dhcp-4-opt-7 = val-7
+IP6:::dst = 2001\:a\:\:dd5b\:aa7b\:b4a2\:e42/102, nh = \:\:, mt = 2504159086::sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar
+DHCP6:dhcp-6-opt-1 = val-1 | dhcp-6-opt-2 = val-2 | dhcp-6-opt-3 = val-3 | dhcp-6-opt-4 = val-4 | dhcp-6-opt-5 = val-5
+CONNECTIONS:/org/freedesktop/NetworkManager/Settings/Connection/{2}:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
+
 GENERAL:eth0:ethernet:NMDeviceEthernet:::virtual:::AB\:B7\:BF\:E2\:48\:E8:0:20 (unavailable):0 (No reason given):0 (nieznane):0 (nieznane):/sys/devices/virtual/eth0::no:yes:yes:no:no:::::unknown
 CAPABILITIES:no:100 Mb/s:no:no
 WIRED-PROPERTIES:off:
@@ -27531,18 +27675,6 @@ IP4:192.168.97.124/29 | 192.168.76.154/18::dst = 192.168.33.233/22, nh = 192.168
 DHCP4:dhcp-4-opt-0 = val-0 | dhcp-4-opt-5 = val-5
 IP6:2001\:a\:\:88ca\:3654\:96b\:ab44/89::dst = 2001\:a\:\:cc8b\:7c09\:4673\:bbb0/85, nh = \:\:, mt = 2821465568 | dst = 2001\:a\:\:a976\:2488\:f49f\:b48/106, nh = 2001\:a\:\:62ae\:c734\:fc7b\:e931, mt = 2248613879 | dst = 2001\:a\:\:afb7\:4449\:3787\:8bb4/123, nh = \:\::2001\:a\:\:2934\:bd66\:550d\:ec19:sear6.fo.x.y
 DHCP6:dhcp-6-opt-2 = val-2 | dhcp-6-opt-6 = val-6 | dhcp-6-opt-7 = val-7 | dhcp-6-opt-8 = val-8 | dhcp-6-opt-9 = val-9
-CONNECTIONS:/org/freedesktop/NetworkManager/Settings/Connection/{2}:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
-
-GENERAL:wlan0:wifi:NMDeviceWifi:::virtual:::13\:E0\:74\:85\:7C\:D9:0:20 (unavailable):0 (No reason given):0 (nieznane):0 (nieznane):/sys/devices/virtual/wlan0::no:yes:yes:no:no::con-vpn-1:UUID-con-vpn-1-REPLACED-REPLACED-REP:/org/freedesktop/NetworkManager/ActiveConnection/2:unknown
-CAPABILITIES:no:unknown:no:no
-WIFI-PROPERTIES:yes:yes:yes:yes:yes:yes:yes:unknown:unknown
-[32mAP[1][0m:[32m [0m:[32mwlan0-ap-2[0m:[32mInfrastruktura[0m:[32m1[0m:[32m54 Mb/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m
-[32mAP[2][0m:[32m [0m:[32mwlan0-ap-1[0m:[32mInfrastruktura[0m:[32m1[0m:[32m54 Mb/s[0m:[32m81[0m:[32m****[0m:[32mWPA1 WPA2[0m
-[35mAP[3][0m:[35m [0m:[35mwlan0-ap-3[0m:[35mInfrastruktura[0m:[35m1[0m:[35m54 Mb/s[0m:[35m55[0m:[35m**  [0m:[35mWPA1 WPA2[0m
-IP4:192.168.228.18/32 | 192.168.209.179/25:192.168.41.120:::sear4.foo2.bar | sear4.fo.x.y | sear4.foo1.bar | sear4.foo4.bar | sear4.fo.o.bar:192.168.120.79
-DHCP4:dhcp-4-opt-0 = val-0 | dhcp-4-opt-2 = val-2 | dhcp-4-opt-4 = val-4 | dhcp-4-opt-7 = val-7
-IP6:::dst = 2001\:a\:\:dd5b\:aa7b\:b4a2\:e42/102, nh = \:\:, mt = 2504159086::sear6.foo2.bar | sear6.foo1.bar | sear6.fo.x.y | sear6.fo.o.bar | sear6.foo3.bar | sear6.foo4.bar
-DHCP6:dhcp-6-opt-1 = val-1 | dhcp-6-opt-2 = val-2 | dhcp-6-opt-3 = val-3 | dhcp-6-opt-4 = val-4 | dhcp-6-opt-5 = val-5
 CONNECTIONS:/org/freedesktop/NetworkManager/Settings/Connection/{2}:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
 <<<
@@ -27677,11 +27809,11 @@ lang: C
 returncode: 0
 stdout: 391 bytes
 >>>
+[2mwlan0[0m:[2mwifi[0m:[2m/org/freedesktop/NetworkManager/Devices/3[0m
 [2meth0[0m:[2methernet[0m:[2m/org/freedesktop/NetworkManager/Devices/1[0m
 [2meth1[0m:[2methernet[0m:[2m/org/freedesktop/NetworkManager/Devices/2[0m
 [2mwlan1[0m:[2mwifi[0m:[2m/org/freedesktop/NetworkManager/Devices/4[0m
 [2mwlan1[0m:[2mwifi[0m:[2m/org/freedesktop/NetworkManager/Devices/5[0m
-[2mwlan0[0m:[2mwifi[0m:[2m/org/freedesktop/NetworkManager/Devices/3[0m
 
 <<<
 size: 585
@@ -27691,11 +27823,11 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 391 bytes
 >>>
+[2mwlan0[0m:[2mwifi[0m:[2m/org/freedesktop/NetworkManager/Devices/3[0m
 [2meth0[0m:[2methernet[0m:[2m/org/freedesktop/NetworkManager/Devices/1[0m
 [2meth1[0m:[2methernet[0m:[2m/org/freedesktop/NetworkManager/Devices/2[0m
 [2mwlan1[0m:[2mwifi[0m:[2m/org/freedesktop/NetworkManager/Devices/4[0m
 [2mwlan1[0m:[2mwifi[0m:[2m/org/freedesktop/NetworkManager/Devices/5[0m
-[2mwlan0[0m:[2mwifi[0m:[2m/org/freedesktop/NetworkManager/Devices/3[0m
 
 <<<
 size: 1814
@@ -27705,12 +27837,12 @@ lang: C
 returncode: 0
 stdout: 1634 bytes
 >>>
-[35mAP[1][0m:[35mwlan1-ap-4[0m:[35m776C616E312D61702D34[0m:[35m94\:2B\:E8\:F6\:D2\:86[0m:[35mInfra[0m:[35m1[0m:[35m2412 MHz[0m:[35m54 Mbit/s[0m:[35m48[0m:[35m**  [0m:[35mWPA1 WPA2[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mwlan1[0m:[35mno[0m:[35m [0m:[35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
-
-
 [32mAP[1][0m:[32mwlan0-ap-2[0m:[32m776C616E302D61702D32[0m:[32mC0\:E2\:BE\:E8\:EF\:B6[0m:[32mInfra[0m:[32m1[0m:[32m2412 MHz[0m:[32m54 Mbit/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mwlan0[0m:[32mno[0m:[32m [0m:[32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
 [32mAP[2][0m:[32mwlan0-ap-1[0m:[32m776C616E302D61702D31[0m:[32m61\:95\:77\:AC\:1E\:4C[0m:[32mInfra[0m:[32m1[0m:[32m2412 MHz[0m:[32m54 Mbit/s[0m:[32m81[0m:[32m****[0m:[32mWPA1 WPA2[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mwlan0[0m:[32mno[0m:[32m [0m:[32m/org/freedesktop/NetworkManager/AccessPoint/1[0m
 [35mAP[3][0m:[35mwlan0-ap-3[0m:[35m776C616E302D61702D33[0m:[35m9B\:F6\:B7\:EC\:97\:76[0m:[35mInfra[0m:[35m1[0m:[35m2412 MHz[0m:[35m54 Mbit/s[0m:[35m55[0m:[35m**  [0m:[35mWPA1 WPA2[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mwlan0[0m:[35mno[0m:[35m [0m:[35m/org/freedesktop/NetworkManager/AccessPoint/3[0m
+
+[35mAP[1][0m:[35mwlan1-ap-4[0m:[35m776C616E312D61702D34[0m:[35m94\:2B\:E8\:F6\:D2\:86[0m:[35mInfra[0m:[35m1[0m:[35m2412 MHz[0m:[35m54 Mbit/s[0m:[35m48[0m:[35m**  [0m:[35mWPA1 WPA2[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mwlan1[0m:[35mno[0m:[35m [0m:[35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
+
 
 <<<
 size: 1872
@@ -27720,12 +27852,12 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 1682 bytes
 >>>
-[35mAP[1][0m:[35mwlan1-ap-4[0m:[35m776C616E312D61702D34[0m:[35m94\:2B\:E8\:F6\:D2\:86[0m:[35mInfrastruktura[0m:[35m1[0m:[35m2412 MHz[0m:[35m54 Mb/s[0m:[35m48[0m:[35m**  [0m:[35mWPA1 WPA2[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mwlan1[0m:[35mnie[0m:[35m [0m:[35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
-
-
 [32mAP[1][0m:[32mwlan0-ap-2[0m:[32m776C616E302D61702D32[0m:[32mC0\:E2\:BE\:E8\:EF\:B6[0m:[32mInfrastruktura[0m:[32m1[0m:[32m2412 MHz[0m:[32m54 Mb/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mwlan0[0m:[32mnie[0m:[32m [0m:[32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
 [32mAP[2][0m:[32mwlan0-ap-1[0m:[32m776C616E302D61702D31[0m:[32m61\:95\:77\:AC\:1E\:4C[0m:[32mInfrastruktura[0m:[32m1[0m:[32m2412 MHz[0m:[32m54 Mb/s[0m:[32m81[0m:[32m****[0m:[32mWPA1 WPA2[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mwlan0[0m:[32mnie[0m:[32m [0m:[32m/org/freedesktop/NetworkManager/AccessPoint/1[0m
 [35mAP[3][0m:[35mwlan0-ap-3[0m:[35m776C616E302D61702D33[0m:[35m9B\:F6\:B7\:EC\:97\:76[0m:[35mInfrastruktura[0m:[35m1[0m:[35m2412 MHz[0m:[35m54 Mb/s[0m:[35m55[0m:[35m**  [0m:[35mWPA1 WPA2[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mwlan0[0m:[35mnie[0m:[35m [0m:[35m/org/freedesktop/NetworkManager/AccessPoint/3[0m
+
+[35mAP[1][0m:[35mwlan1-ap-4[0m:[35m776C616E312D61702D34[0m:[35m94\:2B\:E8\:F6\:D2\:86[0m:[35mInfrastruktura[0m:[35m1[0m:[35m2412 MHz[0m:[35m54 Mb/s[0m:[35m48[0m:[35m**  [0m:[35mWPA1 WPA2[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mwlan1[0m:[35mnie[0m:[35m [0m:[35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
+
 
 <<<
 size: 668
@@ -27735,12 +27867,12 @@ lang: C
 returncode: 0
 stdout: 486 bytes
 >>>
-[35m [0m:[35mwlan1-ap-4[0m:[35mInfra[0m:[35m1[0m:[35m54 Mbit/s[0m:[35m48[0m:[35m**  [0m:[35mWPA1 WPA2[0m
-
-
 [32m [0m:[32mwlan0-ap-2[0m:[32mInfra[0m:[32m1[0m:[32m54 Mbit/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m
 [32m [0m:[32mwlan0-ap-1[0m:[32mInfra[0m:[32m1[0m:[32m54 Mbit/s[0m:[32m81[0m:[32m****[0m:[32mWPA1 WPA2[0m
 [35m [0m:[35mwlan0-ap-3[0m:[35mInfra[0m:[35m1[0m:[35m54 Mbit/s[0m:[35m55[0m:[35m**  [0m:[35mWPA1 WPA2[0m
+
+[35m [0m:[35mwlan1-ap-4[0m:[35mInfra[0m:[35m1[0m:[35m54 Mbit/s[0m:[35m48[0m:[35m**  [0m:[35mWPA1 WPA2[0m
+
 
 <<<
 size: 714
@@ -27750,12 +27882,12 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 522 bytes
 >>>
-[35m [0m:[35mwlan1-ap-4[0m:[35mInfrastruktura[0m:[35m1[0m:[35m54 Mb/s[0m:[35m48[0m:[35m**  [0m:[35mWPA1 WPA2[0m
-
-
 [32m [0m:[32mwlan0-ap-2[0m:[32mInfrastruktura[0m:[32m1[0m:[32m54 Mb/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m
 [32m [0m:[32mwlan0-ap-1[0m:[32mInfrastruktura[0m:[32m1[0m:[32m54 Mb/s[0m:[32m81[0m:[32m****[0m:[32mWPA1 WPA2[0m
 [35m [0m:[35mwlan0-ap-3[0m:[35mInfrastruktura[0m:[35m1[0m:[35m54 Mb/s[0m:[35m55[0m:[35m**  [0m:[35mWPA1 WPA2[0m
+
+[35m [0m:[35mwlan1-ap-4[0m:[35mInfrastruktura[0m:[35m1[0m:[35m54 Mb/s[0m:[35m48[0m:[35m**  [0m:[35mWPA1 WPA2[0m
+
 
 <<<
 size: 1927
@@ -27765,12 +27897,12 @@ lang: C
 returncode: 0
 stdout: 1634 bytes
 >>>
-[35mAP[1][0m:[35mwlan1-ap-4[0m:[35m776C616E312D61702D34[0m:[35m94\:2B\:E8\:F6\:D2\:86[0m:[35mInfra[0m:[35m1[0m:[35m2412 MHz[0m:[35m54 Mbit/s[0m:[35m48[0m:[35m**  [0m:[35mWPA1 WPA2[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mwlan1[0m:[35mno[0m:[35m [0m:[35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
-
-
 [32mAP[1][0m:[32mwlan0-ap-2[0m:[32m776C616E302D61702D32[0m:[32mC0\:E2\:BE\:E8\:EF\:B6[0m:[32mInfra[0m:[32m1[0m:[32m2412 MHz[0m:[32m54 Mbit/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mwlan0[0m:[32mno[0m:[32m [0m:[32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
 [32mAP[2][0m:[32mwlan0-ap-1[0m:[32m776C616E302D61702D31[0m:[32m61\:95\:77\:AC\:1E\:4C[0m:[32mInfra[0m:[32m1[0m:[32m2412 MHz[0m:[32m54 Mbit/s[0m:[32m81[0m:[32m****[0m:[32mWPA1 WPA2[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mwlan0[0m:[32mno[0m:[32m [0m:[32m/org/freedesktop/NetworkManager/AccessPoint/1[0m
 [35mAP[3][0m:[35mwlan0-ap-3[0m:[35m776C616E302D61702D33[0m:[35m9B\:F6\:B7\:EC\:97\:76[0m:[35mInfra[0m:[35m1[0m:[35m2412 MHz[0m:[35m54 Mbit/s[0m:[35m55[0m:[35m**  [0m:[35mWPA1 WPA2[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mwlan0[0m:[35mno[0m:[35m [0m:[35m/org/freedesktop/NetworkManager/AccessPoint/3[0m
+
+[35mAP[1][0m:[35mwlan1-ap-4[0m:[35m776C616E312D61702D34[0m:[35m94\:2B\:E8\:F6\:D2\:86[0m:[35mInfra[0m:[35m1[0m:[35m2412 MHz[0m:[35m54 Mbit/s[0m:[35m48[0m:[35m**  [0m:[35mWPA1 WPA2[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mwlan1[0m:[35mno[0m:[35m [0m:[35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
+
 
 <<<
 size: 1985
@@ -27780,72 +27912,84 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 1682 bytes
 >>>
-[35mAP[1][0m:[35mwlan1-ap-4[0m:[35m776C616E312D61702D34[0m:[35m94\:2B\:E8\:F6\:D2\:86[0m:[35mInfrastruktura[0m:[35m1[0m:[35m2412 MHz[0m:[35m54 Mb/s[0m:[35m48[0m:[35m**  [0m:[35mWPA1 WPA2[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mwlan1[0m:[35mnie[0m:[35m [0m:[35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
-
-
 [32mAP[1][0m:[32mwlan0-ap-2[0m:[32m776C616E302D61702D32[0m:[32mC0\:E2\:BE\:E8\:EF\:B6[0m:[32mInfrastruktura[0m:[32m1[0m:[32m2412 MHz[0m:[32m54 Mb/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mwlan0[0m:[32mnie[0m:[32m [0m:[32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
 [32mAP[2][0m:[32mwlan0-ap-1[0m:[32m776C616E302D61702D31[0m:[32m61\:95\:77\:AC\:1E\:4C[0m:[32mInfrastruktura[0m:[32m1[0m:[32m2412 MHz[0m:[32m54 Mb/s[0m:[32m81[0m:[32m****[0m:[32mWPA1 WPA2[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mwlan0[0m:[32mnie[0m:[32m [0m:[32m/org/freedesktop/NetworkManager/AccessPoint/1[0m
 [35mAP[3][0m:[35mwlan0-ap-3[0m:[35m776C616E302D61702D33[0m:[35m9B\:F6\:B7\:EC\:97\:76[0m:[35mInfrastruktura[0m:[35m1[0m:[35m2412 MHz[0m:[35m54 Mb/s[0m:[35m55[0m:[35m**  [0m:[35mWPA1 WPA2[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mwlan0[0m:[35mnie[0m:[35m [0m:[35m/org/freedesktop/NetworkManager/AccessPoint/3[0m
 
+[35mAP[1][0m:[35mwlan1-ap-4[0m:[35m776C616E312D61702D34[0m:[35m94\:2B\:E8\:F6\:D2\:86[0m:[35mInfrastruktura[0m:[35m1[0m:[35m2412 MHz[0m:[35m54 Mb/s[0m:[35m48[0m:[35m**  [0m:[35mWPA1 WPA2[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[35mwlan1[0m:[35mnie[0m:[35m [0m:[35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
+
+
 <<<
-size: 611
+size: 613
 location: clients/tests/test-client.py:1075:test_004()/563
 cmd: $NMCLI --mode tabular --terse --color yes -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 408 bytes
+stdout: 410 bytes
 >>>
 [32mAP[1][0m:[32mwlan0-ap-2[0m:[32m776C616E302D61702D32[0m:[32mC0\:E2\:BE\:E8\:EF\:B6[0m:[32mInfra[0m:[32m1[0m:[32m2412 MHz[0m:[32m54 Mbit/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mwlan0[0m:[32mno[0m:[32m [0m:[32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
 
+
+
 <<<
-size: 633
+size: 635
 location: clients/tests/test-client.py:1075:test_004()/564
 cmd: $NMCLI --mode tabular --terse --color yes -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 420 bytes
+stdout: 422 bytes
 >>>
 [32mAP[1][0m:[32mwlan0-ap-2[0m:[32m776C616E302D61702D32[0m:[32mC0\:E2\:BE\:E8\:EF\:B6[0m:[32mInfrastruktura[0m:[32m1[0m:[32m2412 MHz[0m:[32m54 Mb/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mwlan0[0m:[32mnie[0m:[32m [0m:[32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
 
+
+
 <<<
-size: 327
+size: 329
 location: clients/tests/test-client.py:1077:test_004()/565
 cmd: $NMCLI --mode tabular --terse --color yes -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 121 bytes
+stdout: 123 bytes
 >>>
 [32m [0m:[32mwlan0-ap-2[0m:[32mInfra[0m:[32m1[0m:[32m54 Mbit/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m
 
+
+
 <<<
-size: 346
+size: 348
 location: clients/tests/test-client.py:1077:test_004()/566
 cmd: $NMCLI --mode tabular --terse --color yes -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 130 bytes
+stdout: 132 bytes
 >>>
 [32m [0m:[32mwlan0-ap-2[0m:[32mInfrastruktura[0m:[32m1[0m:[32m54 Mb/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m
 
+
+
 <<<
-size: 724
+size: 726
 location: clients/tests/test-client.py:1080:test_004()/567
 cmd: $NMCLI --mode tabular --terse --color yes -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 408 bytes
+stdout: 410 bytes
 >>>
 [32mAP[1][0m:[32mwlan0-ap-2[0m:[32m776C616E302D61702D32[0m:[32mC0\:E2\:BE\:E8\:EF\:B6[0m:[32mInfra[0m:[32m1[0m:[32m2412 MHz[0m:[32m54 Mbit/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mwlan0[0m:[32mno[0m:[32m [0m:[32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
 
+
+
 <<<
-size: 746
+size: 748
 location: clients/tests/test-client.py:1080:test_004()/568
 cmd: $NMCLI --mode tabular --terse --color yes -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 420 bytes
+stdout: 422 bytes
 >>>
 [32mAP[1][0m:[32mwlan0-ap-2[0m:[32m776C616E302D61702D32[0m:[32mC0\:E2\:BE\:E8\:EF\:B6[0m:[32mInfrastruktura[0m:[32m1[0m:[32m2412 MHz[0m:[32m54 Mb/s[0m:[32m92[0m:[32m****[0m:[32mWPA1 WPA2[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m:[32mwlan0[0m:[32mnie[0m:[32m [0m:[32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
+
+
 
 <<<
 size: 1623
@@ -28615,6 +28759,10 @@ lang: C
 returncode: 0
 stdout: 943 bytes
 >>>
+DEVICE:                                 wlan0
+TYPE:                                   wifi
+STATE:                                  unavailable
+CONNECTION:                             con-vpn-1
 DEVICE:                                 eth0
 TYPE:                                   ethernet
 STATE:                                  unavailable
@@ -28631,10 +28779,6 @@ DEVICE:                                 wlan1
 TYPE:                                   wifi
 STATE:                                  unavailable
 CONNECTION:                             --
-DEVICE:                                 wlan0
-TYPE:                                   wifi
-STATE:                                  unavailable
-CONNECTION:                             con-vpn-1
 
 <<<
 size: 1101
@@ -28644,6 +28788,10 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 948 bytes
 >>>
+DEVICE:                                 wlan0
+TYPE:                                   wifi
+STATE:                                  niedostępne
+CONNECTION:                             con-vpn-1
 DEVICE:                                 eth0
 TYPE:                                   ethernet
 STATE:                                  niedostępne
@@ -28660,10 +28808,6 @@ DEVICE:                                 wlan1
 TYPE:                                   wifi
 STATE:                                  niedostępne
 CONNECTION:                             --
-DEVICE:                                 wlan0
-TYPE:                                   wifi
-STATE:                                  niedostępne
-CONNECTION:                             con-vpn-1
 
 <<<
 size: 2501
@@ -28673,6 +28817,15 @@ lang: C
 returncode: 0
 stdout: 2345 bytes
 >>>
+DEVICE:                                 wlan0
+TYPE:                                   wifi
+STATE:                                  unavailable
+IP4-CONNECTIVITY:                       unknown
+IP6-CONNECTIVITY:                       unknown
+DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/3
+CONNECTION:                             con-vpn-1
+CON-UUID:                               UUID-con-vpn-1-REPLACED-REPLACED-REP
+CON-PATH:                               /org/freedesktop/NetworkManager/ActiveConnection/2
 DEVICE:                                 eth0
 TYPE:                                   ethernet
 STATE:                                  unavailable
@@ -28709,15 +28862,6 @@ DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/
 CONNECTION:                             --
 CON-UUID:                               --
 CON-PATH:                               --
-DEVICE:                                 wlan0
-TYPE:                                   wifi
-STATE:                                  unavailable
-IP4-CONNECTIVITY:                       unknown
-IP6-CONNECTIVITY:                       unknown
-DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/3
-CONNECTION:                             con-vpn-1
-CON-UUID:                               UUID-con-vpn-1-REPLACED-REPLACED-REP
-CON-PATH:                               /org/freedesktop/NetworkManager/ActiveConnection/2
 
 <<<
 size: 2526
@@ -28727,6 +28871,15 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 2360 bytes
 >>>
+DEVICE:                                 wlan0
+TYPE:                                   wifi
+STATE:                                  niedostępne
+IP4-CONNECTIVITY:                       nieznane
+IP6-CONNECTIVITY:                       nieznane
+DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/3
+CONNECTION:                             con-vpn-1
+CON-UUID:                               UUID-con-vpn-1-REPLACED-REPLACED-REP
+CON-PATH:                               /org/freedesktop/NetworkManager/ActiveConnection/2
 DEVICE:                                 eth0
 TYPE:                                   ethernet
 STATE:                                  niedostępne
@@ -28763,15 +28916,6 @@ DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/
 CONNECTION:                             --
 CON-UUID:                               --
 CON-PATH:                               --
-DEVICE:                                 wlan0
-TYPE:                                   wifi
-STATE:                                  niedostępne
-IP4-CONNECTIVITY:                       nieznane
-IP6-CONNECTIVITY:                       nieznane
-DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/3
-CONNECTION:                             con-vpn-1
-CON-UUID:                               UUID-con-vpn-1-REPLACED-REPLACED-REP
-CON-PATH:                               /org/freedesktop/NetworkManager/ActiveConnection/2
 
 <<<
 size: 8065
@@ -28781,6 +28925,31 @@ lang: C
 returncode: 0
 stdout: 7918 bytes
 >>>
+GENERAL.DEVICE:                         wlan0
+GENERAL.TYPE:                           wifi
+GENERAL.HWADDR:                         13:E0:74:85:7C:D9
+GENERAL.MTU:                            0
+GENERAL.STATE:                          20 (unavailable)
+GENERAL.CONNECTION:                     con-vpn-1
+GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
+IP4.ADDRESS[1]:                         192.168.228.18/32
+IP4.ADDRESS[2]:                         192.168.209.179/25
+IP4.GATEWAY:                            192.168.41.120
+IP4.DOMAIN[1]:                          sear4.foo2.bar
+IP4.DOMAIN[2]:                          sear4.fo.x.y
+IP4.DOMAIN[3]:                          sear4.foo1.bar
+IP4.DOMAIN[4]:                          sear4.foo4.bar
+IP4.DOMAIN[5]:                          sear4.fo.o.bar
+IP4.WINS[1]:                            192.168.120.79
+IP6.GATEWAY:                            --
+IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
+IP6.DOMAIN[1]:                          sear6.foo2.bar
+IP6.DOMAIN[2]:                          sear6.foo1.bar
+IP6.DOMAIN[3]:                          sear6.fo.x.y
+IP6.DOMAIN[4]:                          sear6.fo.o.bar
+IP6.DOMAIN[5]:                          sear6.foo3.bar
+IP6.DOMAIN[6]:                          sear6.foo4.bar
+
 GENERAL.DEVICE:                         eth0
 GENERAL.TYPE:                           ethernet
 GENERAL.HWADDR:                         AB:B7:BF:E2:48:E8
@@ -28893,31 +29062,6 @@ IP6.ROUTE[2]:                           dst = 2001:a::a976:2488:f49f:b48/106, nh
 IP6.ROUTE[3]:                           dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::
 IP6.DNS[1]:                             2001:a::2934:bd66:550d:ec19
 IP6.DOMAIN[1]:                          sear6.fo.x.y
-
-GENERAL.DEVICE:                         wlan0
-GENERAL.TYPE:                           wifi
-GENERAL.HWADDR:                         13:E0:74:85:7C:D9
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (unavailable)
-GENERAL.CONNECTION:                     con-vpn-1
-GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
-IP4.ADDRESS[1]:                         192.168.228.18/32
-IP4.ADDRESS[2]:                         192.168.209.179/25
-IP4.GATEWAY:                            192.168.41.120
-IP4.DOMAIN[1]:                          sear4.foo2.bar
-IP4.DOMAIN[2]:                          sear4.fo.x.y
-IP4.DOMAIN[3]:                          sear4.foo1.bar
-IP4.DOMAIN[4]:                          sear4.foo4.bar
-IP4.DOMAIN[5]:                          sear4.fo.o.bar
-IP4.WINS[1]:                            192.168.120.79
-IP6.GATEWAY:                            --
-IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
-IP6.DOMAIN[1]:                          sear6.foo2.bar
-IP6.DOMAIN[2]:                          sear6.foo1.bar
-IP6.DOMAIN[3]:                          sear6.fo.x.y
-IP6.DOMAIN[4]:                          sear6.fo.o.bar
-IP6.DOMAIN[5]:                          sear6.foo3.bar
-IP6.DOMAIN[6]:                          sear6.foo4.bar
 
 <<<
 size: 8096
@@ -28927,119 +29071,6 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 7939 bytes
 >>>
-GENERAL.DEVICE:                         eth0
-GENERAL.TYPE:                           ethernet
-GENERAL.HWADDR:                         AB:B7:BF:E2:48:E8
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (niedostępne)
-GENERAL.CONNECTION:                     --
-GENERAL.CON-PATH:                       --
-WIRED-PROPERTIES.CARRIER:               wyłączone
-IP4.ADDRESS[1]:                         192.168.49.34/22
-IP4.ADDRESS[2]:                         192.168.135.86/19
-IP4.GATEWAY:                            --
-IP4.DNS[1]:                             192.168.45.230
-IP4.DNS[2]:                             192.168.180.201
-IP4.DNS[3]:                             192.168.253.2
-IP4.DOMAIN[1]:                          sear4.foo2.bar
-IP4.DOMAIN[2]:                          sear4.foo1.bar
-IP4.WINS[1]:                            192.168.163.23
-IP4.WINS[2]:                            192.168.151.246
-IP6.ADDRESS[1]:                         2001:a::ed81:3d7:c2e9:df82/99
-IP6.GATEWAY:                            --
-IP6.DNS[1]:                             2001:a::2703:f06:9619:d89f
-IP6.DNS[2]:                             2001:a::3a75:3682:c683:8541
-IP6.DNS[3]:                             2001:a::584e:912:d5ee:c74f
-IP6.DOMAIN[1]:                          sear6.foo4.bar
-IP6.DOMAIN[2]:                          sear6.fo.o.bar
-
-GENERAL.DEVICE:                         eth1
-GENERAL.TYPE:                           ethernet
-GENERAL.HWADDR:                         E7:78:B1:93:2B:22
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (niedostępne)
-GENERAL.CONNECTION:                     --
-GENERAL.CON-PATH:                       --
-WIRED-PROPERTIES.CARRIER:               wyłączone
-IP4.ADDRESS[1]:                         192.168.127.210/25
-IP4.GATEWAY:                            192.168.88.4
-IP4.ROUTE[1]:                           dst = 192.168.222.35/19, nh = 192.168.170.142, mt = 3609264321
-IP4.ROUTE[2]:                           dst = 192.168.135.81/32, nh = 192.168.32.11, mt = 1316413247
-IP4.ROUTE[3]:                           dst = 192.168.24.65/26, nh = 192.168.23.163, mt = 3855574583
-IP4.DNS[1]:                             192.168.16.144
-IP4.DNS[2]:                             192.168.79.53
-IP4.DNS[3]:                             192.168.237.155
-IP4.DOMAIN[1]:                          sear4.foo4.bar
-IP4.DOMAIN[2]:                          sear4.foo3.bar
-IP4.DOMAIN[3]:                          sear4.foo1.bar
-IP4.WINS[1]:                            192.168.211.91
-IP4.WINS[2]:                            192.168.58.182
-IP4.WINS[3]:                            192.168.114.97
-IP6.ADDRESS[1]:                         2001:a::1c1:c178:169f:2b80/93
-IP6.ADDRESS[2]:                         2001:a::1f79:e0fb:87b9:3cc6/123
-IP6.GATEWAY:                            --
-IP6.ROUTE[1]:                           dst = 2001:a::3166:7ed1:e4ae:7612/123, nh = ::
-IP6.DNS[1]:                             2001:a::edda:955:dcf4:23d4
-IP6.DNS[2]:                             2001:a::109f:aa0f:fb4a:9d5a
-IP6.DNS[3]:                             2001:a::61cf:7c82:e9c0:c952
-IP6.DOMAIN[1]:                          sear6.foo1.bar
-
-GENERAL.DEVICE:                         wlan1
-GENERAL.TYPE:                           wifi
-GENERAL.HWADDR:                         21:E9:64:81:8C:A8
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (niedostępne)
-GENERAL.CONNECTION:                     --
-GENERAL.CON-PATH:                       --
-IP4.GATEWAY:                            192.168.57.160
-IP4.ROUTE[1]:                           dst = 192.168.36.106/21, nh = 192.168.199.128, mt = 979274165
-IP4.ROUTE[2]:                           dst = 192.168.238.130/19, nh = 0.0.0.0
-IP4.ROUTE[3]:                           dst = 192.168.224.39/32, nh = 192.168.148.69
-IP4.DNS[1]:                             192.168.61.83
-IP4.DOMAIN[1]:                          sear4.foo4.bar
-IP4.DOMAIN[2]:                          sear4.fo.x.y
-IP4.DOMAIN[3]:                          sear4.foo2.bar
-IP4.DOMAIN[4]:                          sear4.foo1.bar
-IP4.DOMAIN[5]:                          sear4.fo.o.bar
-IP4.DOMAIN[6]:                          sear4.foo3.bar
-IP6.ADDRESS[1]:                         2001:a::fa05:2ab4:9300:e8fe/116
-IP6.ADDRESS[2]:                         2001:a::e9cf:bd3:caba:99b3/86
-IP6.ADDRESS[3]:                         2001:a::2be6:44fa:2c95:5559/78
-IP6.GATEWAY:                            2001:a::4d70:d91a:770f:2319
-IP6.ROUTE[1]:                           dst = 2001:a::3cb2:719d:bb00:b22f/66, nh = 2001:a::81b1:58b9:7237:3511, mt = 2280277732
-IP6.ROUTE[2]:                           dst = 2001:a::986f:983c:5eb:1c7d/99, nh = ::, mt = 1204008676
-IP6.DNS[1]:                             2001:a::85e7:3d7d:53e8:50ac
-IP6.DNS[2]:                             2001:a::1c5:9cb5:e86d:25a5
-IP6.DOMAIN[1]:                          sear6.foo4.bar
-IP6.DOMAIN[2]:                          sear6.foo2.bar
-
-GENERAL.DEVICE:                         wlan1
-GENERAL.TYPE:                           wifi
-GENERAL.HWADDR:                         71:52:AD:63:5C:7C
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (niedostępne)
-GENERAL.CONNECTION:                     --
-GENERAL.CON-PATH:                       --
-IP4.ADDRESS[1]:                         192.168.97.124/29
-IP4.ADDRESS[2]:                         192.168.76.154/18
-IP4.GATEWAY:                            --
-IP4.ROUTE[1]:                           dst = 192.168.33.233/22, nh = 192.168.222.210, mt = 2810496551
-IP4.DNS[1]:                             192.168.107.109
-IP4.DOMAIN[1]:                          sear4.fo.o.bar
-IP4.DOMAIN[2]:                          sear4.fo.x.y
-IP4.DOMAIN[3]:                          sear4.foo2.bar
-IP4.DOMAIN[4]:                          sear4.foo3.bar
-IP4.DOMAIN[5]:                          sear4.foo4.bar
-IP4.WINS[1]:                            192.168.60.60
-IP4.WINS[2]:                            192.168.63.92
-IP6.ADDRESS[1]:                         2001:a::88ca:3654:96b:ab44/89
-IP6.GATEWAY:                            --
-IP6.ROUTE[1]:                           dst = 2001:a::cc8b:7c09:4673:bbb0/85, nh = ::, mt = 2821465568
-IP6.ROUTE[2]:                           dst = 2001:a::a976:2488:f49f:b48/106, nh = 2001:a::62ae:c734:fc7b:e931, mt = 2248613879
-IP6.ROUTE[3]:                           dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::
-IP6.DNS[1]:                             2001:a::2934:bd66:550d:ec19
-IP6.DOMAIN[1]:                          sear6.fo.x.y
-
 GENERAL.DEVICE:                         wlan0
 GENERAL.TYPE:                           wifi
 GENERAL.HWADDR:                         13:E0:74:85:7C:D9
@@ -29065,45 +29096,14 @@ IP6.DOMAIN[4]:                          sear6.fo.o.bar
 IP6.DOMAIN[5]:                          sear6.foo3.bar
 IP6.DOMAIN[6]:                          sear6.foo4.bar
 
-<<<
-size: 20688
-location: clients/tests/test-client.py:1050:test_004()/591
-cmd: $NMCLI --mode multiline -f all dev show
-lang: C
-returncode: 0
-stdout: 20533 bytes
->>>
 GENERAL.DEVICE:                         eth0
 GENERAL.TYPE:                           ethernet
-GENERAL.NM-TYPE:                        NMDeviceEthernet
-GENERAL.VENDOR:                         --
-GENERAL.PRODUCT:                        --
-GENERAL.DRIVER:                         virtual
-GENERAL.DRIVER-VERSION:                 --
-GENERAL.FIRMWARE-VERSION:               --
 GENERAL.HWADDR:                         AB:B7:BF:E2:48:E8
 GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (unavailable)
-GENERAL.REASON:                         0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:               0 (unknown)
-GENERAL.IP6-CONNECTIVITY:               0 (unknown)
-GENERAL.UDI:                            /sys/devices/virtual/eth0
-GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    no
-GENERAL.NM-MANAGED:                     yes
-GENERAL.AUTOCONNECT:                    yes
-GENERAL.FIRMWARE-MISSING:               no
-GENERAL.NM-PLUGIN-MISSING:              no
-GENERAL.PHYS-PORT-ID:                   --
+GENERAL.STATE:                          20 (niedostępne)
 GENERAL.CONNECTION:                     --
-GENERAL.CON-UUID:                       --
 GENERAL.CON-PATH:                       --
-GENERAL.METERED:                        unknown
-CAPABILITIES.CARRIER-DETECT:            no
-CAPABILITIES.SPEED:                     100 Mb/s
-CAPABILITIES.IS-SOFTWARE:               no
-CAPABILITIES.SRIOV:                     no
-WIRED-PROPERTIES.CARRIER:               off
+WIRED-PROPERTIES.CARRIER:               wyłączone
 IP4.ADDRESS[1]:                         192.168.49.34/22
 IP4.ADDRESS[2]:                         192.168.135.86/19
 IP4.GATEWAY:                            --
@@ -29114,8 +29114,6 @@ IP4.DOMAIN[1]:                          sear4.foo2.bar
 IP4.DOMAIN[2]:                          sear4.foo1.bar
 IP4.WINS[1]:                            192.168.163.23
 IP4.WINS[2]:                            192.168.151.246
-DHCP4.OPTION[1]:                        dhcp-4-opt-8 = val-8
-DHCP4.OPTION[2]:                        dhcp-4-opt-9 = val-9
 IP6.ADDRESS[1]:                         2001:a::ed81:3d7:c2e9:df82/99
 IP6.GATEWAY:                            --
 IP6.DNS[1]:                             2001:a::2703:f06:9619:d89f
@@ -29123,50 +29121,15 @@ IP6.DNS[2]:                             2001:a::3a75:3682:c683:8541
 IP6.DNS[3]:                             2001:a::584e:912:d5ee:c74f
 IP6.DOMAIN[1]:                          sear6.foo4.bar
 IP6.DOMAIN[2]:                          sear6.fo.o.bar
-DHCP6.OPTION[1]:                        dhcp-6-opt-0 = val-0
-DHCP6.OPTION[2]:                        dhcp-6-opt-1 = val-1
-DHCP6.OPTION[3]:                        dhcp-6-opt-2 = val-2
-DHCP6.OPTION[4]:                        dhcp-6-opt-3 = val-3
-DHCP6.OPTION[5]:                        dhcp-6-opt-4 = val-4
-DHCP6.OPTION[6]:                        dhcp-6-opt-5 = val-5
-DHCP6.OPTION[7]:                        dhcp-6-opt-6 = val-6
-DHCP6.OPTION[8]:                        dhcp-6-opt-7 = val-7
-DHCP6.OPTION[9]:                        dhcp-6-opt-8 = val-8
-DHCP6.OPTION[10]:                       dhcp-6-opt-9 = val-9
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{1}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   5fcfd6d7-1e63-3332-8826-a7eda103792d | con-1
 
 GENERAL.DEVICE:                         eth1
 GENERAL.TYPE:                           ethernet
-GENERAL.NM-TYPE:                        NMDeviceEthernet
-GENERAL.VENDOR:                         --
-GENERAL.PRODUCT:                        --
-GENERAL.DRIVER:                         virtual
-GENERAL.DRIVER-VERSION:                 --
-GENERAL.FIRMWARE-VERSION:               --
 GENERAL.HWADDR:                         E7:78:B1:93:2B:22
 GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (unavailable)
-GENERAL.REASON:                         0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:               0 (unknown)
-GENERAL.IP6-CONNECTIVITY:               0 (unknown)
-GENERAL.UDI:                            /sys/devices/virtual/eth1
-GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    no
-GENERAL.NM-MANAGED:                     yes
-GENERAL.AUTOCONNECT:                    yes
-GENERAL.FIRMWARE-MISSING:               no
-GENERAL.NM-PLUGIN-MISSING:              no
-GENERAL.PHYS-PORT-ID:                   --
+GENERAL.STATE:                          20 (niedostępne)
 GENERAL.CONNECTION:                     --
-GENERAL.CON-UUID:                       --
 GENERAL.CON-PATH:                       --
-GENERAL.METERED:                        unknown
-CAPABILITIES.CARRIER-DETECT:            no
-CAPABILITIES.SPEED:                     100 Mb/s
-CAPABILITIES.IS-SOFTWARE:               no
-CAPABILITIES.SRIOV:                     no
-WIRED-PROPERTIES.CARRIER:               off
+WIRED-PROPERTIES.CARRIER:               wyłączone
 IP4.ADDRESS[1]:                         192.168.127.210/25
 IP4.GATEWAY:                            192.168.88.4
 IP4.ROUTE[1]:                           dst = 192.168.222.35/19, nh = 192.168.170.142, mt = 3609264321
@@ -29181,15 +29144,6 @@ IP4.DOMAIN[3]:                          sear4.foo1.bar
 IP4.WINS[1]:                            192.168.211.91
 IP4.WINS[2]:                            192.168.58.182
 IP4.WINS[3]:                            192.168.114.97
-DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:                        dhcp-4-opt-1 = val-1
-DHCP4.OPTION[3]:                        dhcp-4-opt-2 = val-2
-DHCP4.OPTION[4]:                        dhcp-4-opt-3 = val-3
-DHCP4.OPTION[5]:                        dhcp-4-opt-4 = val-4
-DHCP4.OPTION[6]:                        dhcp-4-opt-5 = val-5
-DHCP4.OPTION[7]:                        dhcp-4-opt-7 = val-7
-DHCP4.OPTION[8]:                        dhcp-4-opt-8 = val-8
-DHCP4.OPTION[9]:                        dhcp-4-opt-9 = val-9
 IP6.ADDRESS[1]:                         2001:a::1c1:c178:169f:2b80/93
 IP6.ADDRESS[2]:                         2001:a::1f79:e0fb:87b9:3cc6/123
 IP6.GATEWAY:                            --
@@ -29198,61 +29152,14 @@ IP6.DNS[1]:                             2001:a::edda:955:dcf4:23d4
 IP6.DNS[2]:                             2001:a::109f:aa0f:fb4a:9d5a
 IP6.DNS[3]:                             2001:a::61cf:7c82:e9c0:c952
 IP6.DOMAIN[1]:                          sear6.foo1.bar
-DHCP6.OPTION[1]:                        dhcp-6-opt-2 = val-2
-DHCP6.OPTION[2]:                        dhcp-6-opt-5 = val-5
-DHCP6.OPTION[3]:                        dhcp-6-opt-6 = val-6
-DHCP6.OPTION[4]:                        dhcp-6-opt-8 = val-8
-DHCP6.OPTION[5]:                        dhcp-6-opt-9 = val-9
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{1}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   5fcfd6d7-1e63-3332-8826-a7eda103792d | con-1
 
 GENERAL.DEVICE:                         wlan1
 GENERAL.TYPE:                           wifi
-GENERAL.NM-TYPE:                        NMDeviceWifi
-GENERAL.VENDOR:                         --
-GENERAL.PRODUCT:                        --
-GENERAL.DRIVER:                         virtual
-GENERAL.DRIVER-VERSION:                 --
-GENERAL.FIRMWARE-VERSION:               --
 GENERAL.HWADDR:                         21:E9:64:81:8C:A8
 GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (unavailable)
-GENERAL.REASON:                         0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:               0 (unknown)
-GENERAL.IP6-CONNECTIVITY:               0 (unknown)
-GENERAL.UDI:                            /sys/devices/virtual/wlan1
-GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    no
-GENERAL.NM-MANAGED:                     yes
-GENERAL.AUTOCONNECT:                    yes
-GENERAL.FIRMWARE-MISSING:               no
-GENERAL.NM-PLUGIN-MISSING:              no
-GENERAL.PHYS-PORT-ID:                   --
+GENERAL.STATE:                          20 (niedostępne)
 GENERAL.CONNECTION:                     --
-GENERAL.CON-UUID:                       --
 GENERAL.CON-PATH:                       --
-GENERAL.METERED:                        unknown
-CAPABILITIES.CARRIER-DETECT:            no
-CAPABILITIES.SPEED:                     unknown
-CAPABILITIES.IS-SOFTWARE:               no
-CAPABILITIES.SRIOV:                     no
-WIFI-PROPERTIES.WEP:                    yes
-WIFI-PROPERTIES.WPA:                    yes
-WIFI-PROPERTIES.WPA2:                   yes
-WIFI-PROPERTIES.TKIP:                   yes
-WIFI-PROPERTIES.CCMP:                   yes
-WIFI-PROPERTIES.AP:                     yes
-WIFI-PROPERTIES.ADHOC:                  yes
-WIFI-PROPERTIES.2GHZ:                   unknown
-WIFI-PROPERTIES.5GHZ:                   unknown
-AP[1].IN-USE:                            
-AP[1].SSID:                             wlan1-ap-4
-AP[1].MODE:                             Infra
-AP[1].CHAN:                             1
-AP[1].RATE:                             54 Mbit/s
-AP[1].SIGNAL:                           48
-AP[1].BARS:                             **  
-AP[1].SECURITY:                         WPA1 WPA2
 IP4.GATEWAY:                            192.168.57.160
 IP4.ROUTE[1]:                           dst = 192.168.36.106/21, nh = 192.168.199.128, mt = 979274165
 IP4.ROUTE[2]:                           dst = 192.168.238.130/19, nh = 0.0.0.0
@@ -29264,14 +29171,6 @@ IP4.DOMAIN[3]:                          sear4.foo2.bar
 IP4.DOMAIN[4]:                          sear4.foo1.bar
 IP4.DOMAIN[5]:                          sear4.fo.o.bar
 IP4.DOMAIN[6]:                          sear4.foo3.bar
-DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:                        dhcp-4-opt-1 = val-1
-DHCP4.OPTION[3]:                        dhcp-4-opt-2 = val-2
-DHCP4.OPTION[4]:                        dhcp-4-opt-4 = val-4
-DHCP4.OPTION[5]:                        dhcp-4-opt-6 = val-6
-DHCP4.OPTION[6]:                        dhcp-4-opt-7 = val-7
-DHCP4.OPTION[7]:                        dhcp-4-opt-8 = val-8
-DHCP4.OPTION[8]:                        dhcp-4-opt-9 = val-9
 IP6.ADDRESS[1]:                         2001:a::fa05:2ab4:9300:e8fe/116
 IP6.ADDRESS[2]:                         2001:a::e9cf:bd3:caba:99b3/86
 IP6.ADDRESS[3]:                         2001:a::2be6:44fa:2c95:5559/78
@@ -29282,57 +29181,14 @@ IP6.DNS[1]:                             2001:a::85e7:3d7d:53e8:50ac
 IP6.DNS[2]:                             2001:a::1c5:9cb5:e86d:25a5
 IP6.DOMAIN[1]:                          sear6.foo4.bar
 IP6.DOMAIN[2]:                          sear6.foo2.bar
-DHCP6.OPTION[1]:                        dhcp-6-opt-0 = val-0
-DHCP6.OPTION[2]:                        dhcp-6-opt-1 = val-1
-DHCP6.OPTION[3]:                        dhcp-6-opt-2 = val-2
-DHCP6.OPTION[4]:                        dhcp-6-opt-3 = val-3
-DHCP6.OPTION[5]:                        dhcp-6-opt-4 = val-4
-DHCP6.OPTION[6]:                        dhcp-6-opt-5 = val-5
-DHCP6.OPTION[7]:                        dhcp-6-opt-6 = val-6
-DHCP6.OPTION[8]:                        dhcp-6-opt-7 = val-7
-DHCP6.OPTION[9]:                        dhcp-6-opt-9 = val-9
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
 GENERAL.DEVICE:                         wlan1
 GENERAL.TYPE:                           wifi
-GENERAL.NM-TYPE:                        NMDeviceWifi
-GENERAL.VENDOR:                         --
-GENERAL.PRODUCT:                        --
-GENERAL.DRIVER:                         virtual
-GENERAL.DRIVER-VERSION:                 --
-GENERAL.FIRMWARE-VERSION:               --
 GENERAL.HWADDR:                         71:52:AD:63:5C:7C
 GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (unavailable)
-GENERAL.REASON:                         0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:               0 (unknown)
-GENERAL.IP6-CONNECTIVITY:               0 (unknown)
-GENERAL.UDI:                            /sys/devices/virtual/wlan1
-GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    no
-GENERAL.NM-MANAGED:                     yes
-GENERAL.AUTOCONNECT:                    yes
-GENERAL.FIRMWARE-MISSING:               no
-GENERAL.NM-PLUGIN-MISSING:              no
-GENERAL.PHYS-PORT-ID:                   --
+GENERAL.STATE:                          20 (niedostępne)
 GENERAL.CONNECTION:                     --
-GENERAL.CON-UUID:                       --
 GENERAL.CON-PATH:                       --
-GENERAL.METERED:                        unknown
-CAPABILITIES.CARRIER-DETECT:            no
-CAPABILITIES.SPEED:                     unknown
-CAPABILITIES.IS-SOFTWARE:               no
-CAPABILITIES.SRIOV:                     no
-WIFI-PROPERTIES.WEP:                    yes
-WIFI-PROPERTIES.WPA:                    yes
-WIFI-PROPERTIES.WPA2:                   yes
-WIFI-PROPERTIES.TKIP:                   yes
-WIFI-PROPERTIES.CCMP:                   yes
-WIFI-PROPERTIES.AP:                     yes
-WIFI-PROPERTIES.ADHOC:                  yes
-WIFI-PROPERTIES.2GHZ:                   unknown
-WIFI-PROPERTIES.5GHZ:                   unknown
 IP4.ADDRESS[1]:                         192.168.97.124/29
 IP4.ADDRESS[2]:                         192.168.76.154/18
 IP4.GATEWAY:                            --
@@ -29345,8 +29201,6 @@ IP4.DOMAIN[4]:                          sear4.foo3.bar
 IP4.DOMAIN[5]:                          sear4.foo4.bar
 IP4.WINS[1]:                            192.168.60.60
 IP4.WINS[2]:                            192.168.63.92
-DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:                        dhcp-4-opt-5 = val-5
 IP6.ADDRESS[1]:                         2001:a::88ca:3654:96b:ab44/89
 IP6.GATEWAY:                            --
 IP6.ROUTE[1]:                           dst = 2001:a::cc8b:7c09:4673:bbb0/85, nh = ::, mt = 2821465568
@@ -29354,14 +29208,15 @@ IP6.ROUTE[2]:                           dst = 2001:a::a976:2488:f49f:b48/106, nh
 IP6.ROUTE[3]:                           dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::
 IP6.DNS[1]:                             2001:a::2934:bd66:550d:ec19
 IP6.DOMAIN[1]:                          sear6.fo.x.y
-DHCP6.OPTION[1]:                        dhcp-6-opt-2 = val-2
-DHCP6.OPTION[2]:                        dhcp-6-opt-6 = val-6
-DHCP6.OPTION[3]:                        dhcp-6-opt-7 = val-7
-DHCP6.OPTION[4]:                        dhcp-6-opt-8 = val-8
-DHCP6.OPTION[5]:                        dhcp-6-opt-9 = val-9
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
+<<<
+size: 20688
+location: clients/tests/test-client.py:1050:test_004()/591
+cmd: $NMCLI --mode multiline -f all dev show
+lang: C
+returncode: 0
+stdout: 20533 bytes
+>>>
 GENERAL.DEVICE:                         wlan0
 GENERAL.TYPE:                           wifi
 GENERAL.NM-TYPE:                        NMDeviceWifi
@@ -29454,6 +29309,295 @@ DHCP6.OPTION[5]:                        dhcp-6-opt-5 = val-5
 CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
+GENERAL.DEVICE:                         eth0
+GENERAL.TYPE:                           ethernet
+GENERAL.NM-TYPE:                        NMDeviceEthernet
+GENERAL.VENDOR:                         --
+GENERAL.PRODUCT:                        --
+GENERAL.DRIVER:                         virtual
+GENERAL.DRIVER-VERSION:                 --
+GENERAL.FIRMWARE-VERSION:               --
+GENERAL.HWADDR:                         AB:B7:BF:E2:48:E8
+GENERAL.MTU:                            0
+GENERAL.STATE:                          20 (unavailable)
+GENERAL.REASON:                         0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:               0 (unknown)
+GENERAL.IP6-CONNECTIVITY:               0 (unknown)
+GENERAL.UDI:                            /sys/devices/virtual/eth0
+GENERAL.IP-IFACE:                       --
+GENERAL.IS-SOFTWARE:                    no
+GENERAL.NM-MANAGED:                     yes
+GENERAL.AUTOCONNECT:                    yes
+GENERAL.FIRMWARE-MISSING:               no
+GENERAL.NM-PLUGIN-MISSING:              no
+GENERAL.PHYS-PORT-ID:                   --
+GENERAL.CONNECTION:                     --
+GENERAL.CON-UUID:                       --
+GENERAL.CON-PATH:                       --
+GENERAL.METERED:                        unknown
+CAPABILITIES.CARRIER-DETECT:            no
+CAPABILITIES.SPEED:                     100 Mb/s
+CAPABILITIES.IS-SOFTWARE:               no
+CAPABILITIES.SRIOV:                     no
+WIRED-PROPERTIES.CARRIER:               off
+IP4.ADDRESS[1]:                         192.168.49.34/22
+IP4.ADDRESS[2]:                         192.168.135.86/19
+IP4.GATEWAY:                            --
+IP4.DNS[1]:                             192.168.45.230
+IP4.DNS[2]:                             192.168.180.201
+IP4.DNS[3]:                             192.168.253.2
+IP4.DOMAIN[1]:                          sear4.foo2.bar
+IP4.DOMAIN[2]:                          sear4.foo1.bar
+IP4.WINS[1]:                            192.168.163.23
+IP4.WINS[2]:                            192.168.151.246
+DHCP4.OPTION[1]:                        dhcp-4-opt-8 = val-8
+DHCP4.OPTION[2]:                        dhcp-4-opt-9 = val-9
+IP6.ADDRESS[1]:                         2001:a::ed81:3d7:c2e9:df82/99
+IP6.GATEWAY:                            --
+IP6.DNS[1]:                             2001:a::2703:f06:9619:d89f
+IP6.DNS[2]:                             2001:a::3a75:3682:c683:8541
+IP6.DNS[3]:                             2001:a::584e:912:d5ee:c74f
+IP6.DOMAIN[1]:                          sear6.foo4.bar
+IP6.DOMAIN[2]:                          sear6.fo.o.bar
+DHCP6.OPTION[1]:                        dhcp-6-opt-0 = val-0
+DHCP6.OPTION[2]:                        dhcp-6-opt-1 = val-1
+DHCP6.OPTION[3]:                        dhcp-6-opt-2 = val-2
+DHCP6.OPTION[4]:                        dhcp-6-opt-3 = val-3
+DHCP6.OPTION[5]:                        dhcp-6-opt-4 = val-4
+DHCP6.OPTION[6]:                        dhcp-6-opt-5 = val-5
+DHCP6.OPTION[7]:                        dhcp-6-opt-6 = val-6
+DHCP6.OPTION[8]:                        dhcp-6-opt-7 = val-7
+DHCP6.OPTION[9]:                        dhcp-6-opt-8 = val-8
+DHCP6.OPTION[10]:                       dhcp-6-opt-9 = val-9
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{1}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   5fcfd6d7-1e63-3332-8826-a7eda103792d | con-1
+
+GENERAL.DEVICE:                         eth1
+GENERAL.TYPE:                           ethernet
+GENERAL.NM-TYPE:                        NMDeviceEthernet
+GENERAL.VENDOR:                         --
+GENERAL.PRODUCT:                        --
+GENERAL.DRIVER:                         virtual
+GENERAL.DRIVER-VERSION:                 --
+GENERAL.FIRMWARE-VERSION:               --
+GENERAL.HWADDR:                         E7:78:B1:93:2B:22
+GENERAL.MTU:                            0
+GENERAL.STATE:                          20 (unavailable)
+GENERAL.REASON:                         0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:               0 (unknown)
+GENERAL.IP6-CONNECTIVITY:               0 (unknown)
+GENERAL.UDI:                            /sys/devices/virtual/eth1
+GENERAL.IP-IFACE:                       --
+GENERAL.IS-SOFTWARE:                    no
+GENERAL.NM-MANAGED:                     yes
+GENERAL.AUTOCONNECT:                    yes
+GENERAL.FIRMWARE-MISSING:               no
+GENERAL.NM-PLUGIN-MISSING:              no
+GENERAL.PHYS-PORT-ID:                   --
+GENERAL.CONNECTION:                     --
+GENERAL.CON-UUID:                       --
+GENERAL.CON-PATH:                       --
+GENERAL.METERED:                        unknown
+CAPABILITIES.CARRIER-DETECT:            no
+CAPABILITIES.SPEED:                     100 Mb/s
+CAPABILITIES.IS-SOFTWARE:               no
+CAPABILITIES.SRIOV:                     no
+WIRED-PROPERTIES.CARRIER:               off
+IP4.ADDRESS[1]:                         192.168.127.210/25
+IP4.GATEWAY:                            192.168.88.4
+IP4.ROUTE[1]:                           dst = 192.168.222.35/19, nh = 192.168.170.142, mt = 3609264321
+IP4.ROUTE[2]:                           dst = 192.168.135.81/32, nh = 192.168.32.11, mt = 1316413247
+IP4.ROUTE[3]:                           dst = 192.168.24.65/26, nh = 192.168.23.163, mt = 3855574583
+IP4.DNS[1]:                             192.168.16.144
+IP4.DNS[2]:                             192.168.79.53
+IP4.DNS[3]:                             192.168.237.155
+IP4.DOMAIN[1]:                          sear4.foo4.bar
+IP4.DOMAIN[2]:                          sear4.foo3.bar
+IP4.DOMAIN[3]:                          sear4.foo1.bar
+IP4.WINS[1]:                            192.168.211.91
+IP4.WINS[2]:                            192.168.58.182
+IP4.WINS[3]:                            192.168.114.97
+DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:                        dhcp-4-opt-1 = val-1
+DHCP4.OPTION[3]:                        dhcp-4-opt-2 = val-2
+DHCP4.OPTION[4]:                        dhcp-4-opt-3 = val-3
+DHCP4.OPTION[5]:                        dhcp-4-opt-4 = val-4
+DHCP4.OPTION[6]:                        dhcp-4-opt-5 = val-5
+DHCP4.OPTION[7]:                        dhcp-4-opt-7 = val-7
+DHCP4.OPTION[8]:                        dhcp-4-opt-8 = val-8
+DHCP4.OPTION[9]:                        dhcp-4-opt-9 = val-9
+IP6.ADDRESS[1]:                         2001:a::1c1:c178:169f:2b80/93
+IP6.ADDRESS[2]:                         2001:a::1f79:e0fb:87b9:3cc6/123
+IP6.GATEWAY:                            --
+IP6.ROUTE[1]:                           dst = 2001:a::3166:7ed1:e4ae:7612/123, nh = ::
+IP6.DNS[1]:                             2001:a::edda:955:dcf4:23d4
+IP6.DNS[2]:                             2001:a::109f:aa0f:fb4a:9d5a
+IP6.DNS[3]:                             2001:a::61cf:7c82:e9c0:c952
+IP6.DOMAIN[1]:                          sear6.foo1.bar
+DHCP6.OPTION[1]:                        dhcp-6-opt-2 = val-2
+DHCP6.OPTION[2]:                        dhcp-6-opt-5 = val-5
+DHCP6.OPTION[3]:                        dhcp-6-opt-6 = val-6
+DHCP6.OPTION[4]:                        dhcp-6-opt-8 = val-8
+DHCP6.OPTION[5]:                        dhcp-6-opt-9 = val-9
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{1}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   5fcfd6d7-1e63-3332-8826-a7eda103792d | con-1
+
+GENERAL.DEVICE:                         wlan1
+GENERAL.TYPE:                           wifi
+GENERAL.NM-TYPE:                        NMDeviceWifi
+GENERAL.VENDOR:                         --
+GENERAL.PRODUCT:                        --
+GENERAL.DRIVER:                         virtual
+GENERAL.DRIVER-VERSION:                 --
+GENERAL.FIRMWARE-VERSION:               --
+GENERAL.HWADDR:                         21:E9:64:81:8C:A8
+GENERAL.MTU:                            0
+GENERAL.STATE:                          20 (unavailable)
+GENERAL.REASON:                         0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:               0 (unknown)
+GENERAL.IP6-CONNECTIVITY:               0 (unknown)
+GENERAL.UDI:                            /sys/devices/virtual/wlan1
+GENERAL.IP-IFACE:                       --
+GENERAL.IS-SOFTWARE:                    no
+GENERAL.NM-MANAGED:                     yes
+GENERAL.AUTOCONNECT:                    yes
+GENERAL.FIRMWARE-MISSING:               no
+GENERAL.NM-PLUGIN-MISSING:              no
+GENERAL.PHYS-PORT-ID:                   --
+GENERAL.CONNECTION:                     --
+GENERAL.CON-UUID:                       --
+GENERAL.CON-PATH:                       --
+GENERAL.METERED:                        unknown
+CAPABILITIES.CARRIER-DETECT:            no
+CAPABILITIES.SPEED:                     unknown
+CAPABILITIES.IS-SOFTWARE:               no
+CAPABILITIES.SRIOV:                     no
+WIFI-PROPERTIES.WEP:                    yes
+WIFI-PROPERTIES.WPA:                    yes
+WIFI-PROPERTIES.WPA2:                   yes
+WIFI-PROPERTIES.TKIP:                   yes
+WIFI-PROPERTIES.CCMP:                   yes
+WIFI-PROPERTIES.AP:                     yes
+WIFI-PROPERTIES.ADHOC:                  yes
+WIFI-PROPERTIES.2GHZ:                   unknown
+WIFI-PROPERTIES.5GHZ:                   unknown
+AP[1].IN-USE:                            
+AP[1].SSID:                             wlan1-ap-4
+AP[1].MODE:                             Infra
+AP[1].CHAN:                             1
+AP[1].RATE:                             54 Mbit/s
+AP[1].SIGNAL:                           48
+AP[1].BARS:                             **  
+AP[1].SECURITY:                         WPA1 WPA2
+IP4.GATEWAY:                            192.168.57.160
+IP4.ROUTE[1]:                           dst = 192.168.36.106/21, nh = 192.168.199.128, mt = 979274165
+IP4.ROUTE[2]:                           dst = 192.168.238.130/19, nh = 0.0.0.0
+IP4.ROUTE[3]:                           dst = 192.168.224.39/32, nh = 192.168.148.69
+IP4.DNS[1]:                             192.168.61.83
+IP4.DOMAIN[1]:                          sear4.foo4.bar
+IP4.DOMAIN[2]:                          sear4.fo.x.y
+IP4.DOMAIN[3]:                          sear4.foo2.bar
+IP4.DOMAIN[4]:                          sear4.foo1.bar
+IP4.DOMAIN[5]:                          sear4.fo.o.bar
+IP4.DOMAIN[6]:                          sear4.foo3.bar
+DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:                        dhcp-4-opt-1 = val-1
+DHCP4.OPTION[3]:                        dhcp-4-opt-2 = val-2
+DHCP4.OPTION[4]:                        dhcp-4-opt-4 = val-4
+DHCP4.OPTION[5]:                        dhcp-4-opt-6 = val-6
+DHCP4.OPTION[6]:                        dhcp-4-opt-7 = val-7
+DHCP4.OPTION[7]:                        dhcp-4-opt-8 = val-8
+DHCP4.OPTION[8]:                        dhcp-4-opt-9 = val-9
+IP6.ADDRESS[1]:                         2001:a::fa05:2ab4:9300:e8fe/116
+IP6.ADDRESS[2]:                         2001:a::e9cf:bd3:caba:99b3/86
+IP6.ADDRESS[3]:                         2001:a::2be6:44fa:2c95:5559/78
+IP6.GATEWAY:                            2001:a::4d70:d91a:770f:2319
+IP6.ROUTE[1]:                           dst = 2001:a::3cb2:719d:bb00:b22f/66, nh = 2001:a::81b1:58b9:7237:3511, mt = 2280277732
+IP6.ROUTE[2]:                           dst = 2001:a::986f:983c:5eb:1c7d/99, nh = ::, mt = 1204008676
+IP6.DNS[1]:                             2001:a::85e7:3d7d:53e8:50ac
+IP6.DNS[2]:                             2001:a::1c5:9cb5:e86d:25a5
+IP6.DOMAIN[1]:                          sear6.foo4.bar
+IP6.DOMAIN[2]:                          sear6.foo2.bar
+DHCP6.OPTION[1]:                        dhcp-6-opt-0 = val-0
+DHCP6.OPTION[2]:                        dhcp-6-opt-1 = val-1
+DHCP6.OPTION[3]:                        dhcp-6-opt-2 = val-2
+DHCP6.OPTION[4]:                        dhcp-6-opt-3 = val-3
+DHCP6.OPTION[5]:                        dhcp-6-opt-4 = val-4
+DHCP6.OPTION[6]:                        dhcp-6-opt-5 = val-5
+DHCP6.OPTION[7]:                        dhcp-6-opt-6 = val-6
+DHCP6.OPTION[8]:                        dhcp-6-opt-7 = val-7
+DHCP6.OPTION[9]:                        dhcp-6-opt-9 = val-9
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
+
+GENERAL.DEVICE:                         wlan1
+GENERAL.TYPE:                           wifi
+GENERAL.NM-TYPE:                        NMDeviceWifi
+GENERAL.VENDOR:                         --
+GENERAL.PRODUCT:                        --
+GENERAL.DRIVER:                         virtual
+GENERAL.DRIVER-VERSION:                 --
+GENERAL.FIRMWARE-VERSION:               --
+GENERAL.HWADDR:                         71:52:AD:63:5C:7C
+GENERAL.MTU:                            0
+GENERAL.STATE:                          20 (unavailable)
+GENERAL.REASON:                         0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:               0 (unknown)
+GENERAL.IP6-CONNECTIVITY:               0 (unknown)
+GENERAL.UDI:                            /sys/devices/virtual/wlan1
+GENERAL.IP-IFACE:                       --
+GENERAL.IS-SOFTWARE:                    no
+GENERAL.NM-MANAGED:                     yes
+GENERAL.AUTOCONNECT:                    yes
+GENERAL.FIRMWARE-MISSING:               no
+GENERAL.NM-PLUGIN-MISSING:              no
+GENERAL.PHYS-PORT-ID:                   --
+GENERAL.CONNECTION:                     --
+GENERAL.CON-UUID:                       --
+GENERAL.CON-PATH:                       --
+GENERAL.METERED:                        unknown
+CAPABILITIES.CARRIER-DETECT:            no
+CAPABILITIES.SPEED:                     unknown
+CAPABILITIES.IS-SOFTWARE:               no
+CAPABILITIES.SRIOV:                     no
+WIFI-PROPERTIES.WEP:                    yes
+WIFI-PROPERTIES.WPA:                    yes
+WIFI-PROPERTIES.WPA2:                   yes
+WIFI-PROPERTIES.TKIP:                   yes
+WIFI-PROPERTIES.CCMP:                   yes
+WIFI-PROPERTIES.AP:                     yes
+WIFI-PROPERTIES.ADHOC:                  yes
+WIFI-PROPERTIES.2GHZ:                   unknown
+WIFI-PROPERTIES.5GHZ:                   unknown
+IP4.ADDRESS[1]:                         192.168.97.124/29
+IP4.ADDRESS[2]:                         192.168.76.154/18
+IP4.GATEWAY:                            --
+IP4.ROUTE[1]:                           dst = 192.168.33.233/22, nh = 192.168.222.210, mt = 2810496551
+IP4.DNS[1]:                             192.168.107.109
+IP4.DOMAIN[1]:                          sear4.fo.o.bar
+IP4.DOMAIN[2]:                          sear4.fo.x.y
+IP4.DOMAIN[3]:                          sear4.foo2.bar
+IP4.DOMAIN[4]:                          sear4.foo3.bar
+IP4.DOMAIN[5]:                          sear4.foo4.bar
+IP4.WINS[1]:                            192.168.60.60
+IP4.WINS[2]:                            192.168.63.92
+DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:                        dhcp-4-opt-5 = val-5
+IP6.ADDRESS[1]:                         2001:a::88ca:3654:96b:ab44/89
+IP6.GATEWAY:                            --
+IP6.ROUTE[1]:                           dst = 2001:a::cc8b:7c09:4673:bbb0/85, nh = ::, mt = 2821465568
+IP6.ROUTE[2]:                           dst = 2001:a::a976:2488:f49f:b48/106, nh = 2001:a::62ae:c734:fc7b:e931, mt = 2248613879
+IP6.ROUTE[3]:                           dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::
+IP6.DNS[1]:                             2001:a::2934:bd66:550d:ec19
+IP6.DOMAIN[1]:                          sear6.fo.x.y
+DHCP6.OPTION[1]:                        dhcp-6-opt-2 = val-2
+DHCP6.OPTION[2]:                        dhcp-6-opt-6 = val-6
+DHCP6.OPTION[3]:                        dhcp-6-opt-7 = val-7
+DHCP6.OPTION[4]:                        dhcp-6-opt-8 = val-8
+DHCP6.OPTION[5]:                        dhcp-6-opt-9 = val-9
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
+
 <<<
 size: 20838
 location: clients/tests/test-client.py:1050:test_004()/592
@@ -29462,6 +29606,98 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 20673 bytes
 >>>
+GENERAL.DEVICE:                         wlan0
+GENERAL.TYPE:                           wifi
+GENERAL.NM-TYPE:                        NMDeviceWifi
+GENERAL.VENDOR:                         --
+GENERAL.PRODUCT:                        --
+GENERAL.DRIVER:                         virtual
+GENERAL.DRIVER-VERSION:                 --
+GENERAL.FIRMWARE-VERSION:               --
+GENERAL.HWADDR:                         13:E0:74:85:7C:D9
+GENERAL.MTU:                            0
+GENERAL.STATE:                          20 (niedostępne)
+GENERAL.REASON:                         0 (Nie podano przyczyny)
+GENERAL.IP4-CONNECTIVITY:               0 (nieznane)
+GENERAL.IP6-CONNECTIVITY:               0 (nieznane)
+GENERAL.UDI:                            /sys/devices/virtual/wlan0
+GENERAL.IP-IFACE:                       --
+GENERAL.IS-SOFTWARE:                    nie
+GENERAL.NM-MANAGED:                     tak
+GENERAL.AUTOCONNECT:                    tak
+GENERAL.FIRMWARE-MISSING:               nie
+GENERAL.NM-PLUGIN-MISSING:              nie
+GENERAL.PHYS-PORT-ID:                   --
+GENERAL.CONNECTION:                     con-vpn-1
+GENERAL.CON-UUID:                       UUID-con-vpn-1-REPLACED-REPLACED-REP
+GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
+GENERAL.METERED:                        nieznane
+CAPABILITIES.CARRIER-DETECT:            nie
+CAPABILITIES.SPEED:                     nieznane
+CAPABILITIES.IS-SOFTWARE:               nie
+CAPABILITIES.SRIOV:                     nie
+WIFI-PROPERTIES.WEP:                    tak
+WIFI-PROPERTIES.WPA:                    tak
+WIFI-PROPERTIES.WPA2:                   tak
+WIFI-PROPERTIES.TKIP:                   tak
+WIFI-PROPERTIES.CCMP:                   tak
+WIFI-PROPERTIES.AP:                     tak
+WIFI-PROPERTIES.ADHOC:                  tak
+WIFI-PROPERTIES.2GHZ:                   nieznane
+WIFI-PROPERTIES.5GHZ:                   nieznane
+AP[1].IN-USE:                            
+AP[1].SSID:                             wlan0-ap-2
+AP[1].MODE:                             Infrastruktura
+AP[1].CHAN:                             1
+AP[1].RATE:                             54 Mb/s
+AP[1].SIGNAL:                           92
+AP[1].BARS:                             ****
+AP[1].SECURITY:                         WPA1 WPA2
+AP[2].IN-USE:                            
+AP[2].SSID:                             wlan0-ap-1
+AP[2].MODE:                             Infrastruktura
+AP[2].CHAN:                             1
+AP[2].RATE:                             54 Mb/s
+AP[2].SIGNAL:                           81
+AP[2].BARS:                             ****
+AP[2].SECURITY:                         WPA1 WPA2
+AP[3].IN-USE:                            
+AP[3].SSID:                             wlan0-ap-3
+AP[3].MODE:                             Infrastruktura
+AP[3].CHAN:                             1
+AP[3].RATE:                             54 Mb/s
+AP[3].SIGNAL:                           55
+AP[3].BARS:                             **  
+AP[3].SECURITY:                         WPA1 WPA2
+IP4.ADDRESS[1]:                         192.168.228.18/32
+IP4.ADDRESS[2]:                         192.168.209.179/25
+IP4.GATEWAY:                            192.168.41.120
+IP4.DOMAIN[1]:                          sear4.foo2.bar
+IP4.DOMAIN[2]:                          sear4.fo.x.y
+IP4.DOMAIN[3]:                          sear4.foo1.bar
+IP4.DOMAIN[4]:                          sear4.foo4.bar
+IP4.DOMAIN[5]:                          sear4.fo.o.bar
+IP4.WINS[1]:                            192.168.120.79
+DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:                        dhcp-4-opt-2 = val-2
+DHCP4.OPTION[3]:                        dhcp-4-opt-4 = val-4
+DHCP4.OPTION[4]:                        dhcp-4-opt-7 = val-7
+IP6.GATEWAY:                            --
+IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
+IP6.DOMAIN[1]:                          sear6.foo2.bar
+IP6.DOMAIN[2]:                          sear6.foo1.bar
+IP6.DOMAIN[3]:                          sear6.fo.x.y
+IP6.DOMAIN[4]:                          sear6.fo.o.bar
+IP6.DOMAIN[5]:                          sear6.foo3.bar
+IP6.DOMAIN[6]:                          sear6.foo4.bar
+DHCP6.OPTION[1]:                        dhcp-6-opt-1 = val-1
+DHCP6.OPTION[2]:                        dhcp-6-opt-2 = val-2
+DHCP6.OPTION[3]:                        dhcp-6-opt-3 = val-3
+DHCP6.OPTION[4]:                        dhcp-6-opt-4 = val-4
+DHCP6.OPTION[5]:                        dhcp-6-opt-5 = val-5
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
+
 GENERAL.DEVICE:                         eth0
 GENERAL.TYPE:                           ethernet
 GENERAL.NM-TYPE:                        NMDeviceEthernet
@@ -29748,98 +29984,6 @@ DHCP6.OPTION[2]:                        dhcp-6-opt-6 = val-6
 DHCP6.OPTION[3]:                        dhcp-6-opt-7 = val-7
 DHCP6.OPTION[4]:                        dhcp-6-opt-8 = val-8
 DHCP6.OPTION[5]:                        dhcp-6-opt-9 = val-9
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
-
-GENERAL.DEVICE:                         wlan0
-GENERAL.TYPE:                           wifi
-GENERAL.NM-TYPE:                        NMDeviceWifi
-GENERAL.VENDOR:                         --
-GENERAL.PRODUCT:                        --
-GENERAL.DRIVER:                         virtual
-GENERAL.DRIVER-VERSION:                 --
-GENERAL.FIRMWARE-VERSION:               --
-GENERAL.HWADDR:                         13:E0:74:85:7C:D9
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (niedostępne)
-GENERAL.REASON:                         0 (Nie podano przyczyny)
-GENERAL.IP4-CONNECTIVITY:               0 (nieznane)
-GENERAL.IP6-CONNECTIVITY:               0 (nieznane)
-GENERAL.UDI:                            /sys/devices/virtual/wlan0
-GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    nie
-GENERAL.NM-MANAGED:                     tak
-GENERAL.AUTOCONNECT:                    tak
-GENERAL.FIRMWARE-MISSING:               nie
-GENERAL.NM-PLUGIN-MISSING:              nie
-GENERAL.PHYS-PORT-ID:                   --
-GENERAL.CONNECTION:                     con-vpn-1
-GENERAL.CON-UUID:                       UUID-con-vpn-1-REPLACED-REPLACED-REP
-GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
-GENERAL.METERED:                        nieznane
-CAPABILITIES.CARRIER-DETECT:            nie
-CAPABILITIES.SPEED:                     nieznane
-CAPABILITIES.IS-SOFTWARE:               nie
-CAPABILITIES.SRIOV:                     nie
-WIFI-PROPERTIES.WEP:                    tak
-WIFI-PROPERTIES.WPA:                    tak
-WIFI-PROPERTIES.WPA2:                   tak
-WIFI-PROPERTIES.TKIP:                   tak
-WIFI-PROPERTIES.CCMP:                   tak
-WIFI-PROPERTIES.AP:                     tak
-WIFI-PROPERTIES.ADHOC:                  tak
-WIFI-PROPERTIES.2GHZ:                   nieznane
-WIFI-PROPERTIES.5GHZ:                   nieznane
-AP[1].IN-USE:                            
-AP[1].SSID:                             wlan0-ap-2
-AP[1].MODE:                             Infrastruktura
-AP[1].CHAN:                             1
-AP[1].RATE:                             54 Mb/s
-AP[1].SIGNAL:                           92
-AP[1].BARS:                             ****
-AP[1].SECURITY:                         WPA1 WPA2
-AP[2].IN-USE:                            
-AP[2].SSID:                             wlan0-ap-1
-AP[2].MODE:                             Infrastruktura
-AP[2].CHAN:                             1
-AP[2].RATE:                             54 Mb/s
-AP[2].SIGNAL:                           81
-AP[2].BARS:                             ****
-AP[2].SECURITY:                         WPA1 WPA2
-AP[3].IN-USE:                            
-AP[3].SSID:                             wlan0-ap-3
-AP[3].MODE:                             Infrastruktura
-AP[3].CHAN:                             1
-AP[3].RATE:                             54 Mb/s
-AP[3].SIGNAL:                           55
-AP[3].BARS:                             **  
-AP[3].SECURITY:                         WPA1 WPA2
-IP4.ADDRESS[1]:                         192.168.228.18/32
-IP4.ADDRESS[2]:                         192.168.209.179/25
-IP4.GATEWAY:                            192.168.41.120
-IP4.DOMAIN[1]:                          sear4.foo2.bar
-IP4.DOMAIN[2]:                          sear4.fo.x.y
-IP4.DOMAIN[3]:                          sear4.foo1.bar
-IP4.DOMAIN[4]:                          sear4.foo4.bar
-IP4.DOMAIN[5]:                          sear4.fo.o.bar
-IP4.WINS[1]:                            192.168.120.79
-DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:                        dhcp-4-opt-2 = val-2
-DHCP4.OPTION[3]:                        dhcp-4-opt-4 = val-4
-DHCP4.OPTION[4]:                        dhcp-4-opt-7 = val-7
-IP6.GATEWAY:                            --
-IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
-IP6.DOMAIN[1]:                          sear6.foo2.bar
-IP6.DOMAIN[2]:                          sear6.foo1.bar
-IP6.DOMAIN[3]:                          sear6.fo.x.y
-IP6.DOMAIN[4]:                          sear6.fo.o.bar
-IP6.DOMAIN[5]:                          sear6.foo3.bar
-IP6.DOMAIN[6]:                          sear6.foo4.bar
-DHCP6.OPTION[1]:                        dhcp-6-opt-1 = val-1
-DHCP6.OPTION[2]:                        dhcp-6-opt-2 = val-2
-DHCP6.OPTION[3]:                        dhcp-6-opt-3 = val-3
-DHCP6.OPTION[4]:                        dhcp-6-opt-4 = val-4
-DHCP6.OPTION[5]:                        dhcp-6-opt-5 = val-5
 CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
@@ -30297,6 +30441,9 @@ lang: C
 returncode: 0
 stdout: 871 bytes
 >>>
+DEVICE:                                 wlan0
+TYPE:                                   wifi
+DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/3
 DEVICE:                                 eth0
 TYPE:                                   ethernet
 DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/1
@@ -30309,9 +30456,6 @@ DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/
 DEVICE:                                 wlan1
 TYPE:                                   wifi
 DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/5
-DEVICE:                                 wlan0
-TYPE:                                   wifi
-DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/3
 
 <<<
 size: 1047
@@ -30321,6 +30465,9 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 871 bytes
 >>>
+DEVICE:                                 wlan0
+TYPE:                                   wifi
+DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/3
 DEVICE:                                 eth0
 TYPE:                                   ethernet
 DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/1
@@ -30333,9 +30480,6 @@ DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/
 DEVICE:                                 wlan1
 TYPE:                                   wifi
 DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/5
-DEVICE:                                 wlan0
-TYPE:                                   wifi
-DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/3
 
 <<<
 size: 3884
@@ -30346,25 +30490,6 @@ returncode: 0
 stdout: 3722 bytes
 >>>
 NAME:                                   AP[1]
-SSID:                                   wlan1-ap-4
-SSID-HEX:                               776C616E312D61702D34
-BSSID:                                  94:2B:E8:F6:D2:86
-MODE:                                   Infra
-CHAN:                                   1
-FREQ:                                   2412 MHz
-RATE:                                   54 Mbit/s
-SIGNAL:                                 48
-BARS:                                   **  
-SECURITY:                               WPA1 WPA2
-WPA-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
-RSN-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
-DEVICE:                                 wlan1
-ACTIVE:                                 no
-IN-USE:                                  
-DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/4
-
-
-NAME:                                   AP[1]
 SSID:                                   wlan0-ap-2
 SSID-HEX:                               776C616E302D61702D32
 BSSID:                                  C0:E2:BE:E8:EF:B6
@@ -30415,6 +30540,25 @@ DEVICE:                                 wlan0
 ACTIVE:                                 no
 IN-USE:                                  
 DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/3
+
+NAME:                                   AP[1]
+SSID:                                   wlan1-ap-4
+SSID-HEX:                               776C616E312D61702D34
+BSSID:                                  94:2B:E8:F6:D2:86
+MODE:                                   Infra
+CHAN:                                   1
+FREQ:                                   2412 MHz
+RATE:                                   54 Mbit/s
+SIGNAL:                                 48
+BARS:                                   **  
+SECURITY:                               WPA1 WPA2
+WPA-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
+RSN-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
+DEVICE:                                 wlan1
+ACTIVE:                                 no
+IN-USE:                                  
+DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/4
+
 
 <<<
 size: 3942
@@ -30425,25 +30569,6 @@ returncode: 0
 stdout: 3770 bytes
 >>>
 NAME:                                   AP[1]
-SSID:                                   wlan1-ap-4
-SSID-HEX:                               776C616E312D61702D34
-BSSID:                                  94:2B:E8:F6:D2:86
-MODE:                                   Infrastruktura
-CHAN:                                   1
-FREQ:                                   2412 MHz
-RATE:                                   54 Mb/s
-SIGNAL:                                 48
-BARS:                                   **  
-SECURITY:                               WPA1 WPA2
-WPA-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
-RSN-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
-DEVICE:                                 wlan1
-ACTIVE:                                 nie
-IN-USE:                                  
-DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/4
-
-
-NAME:                                   AP[1]
 SSID:                                   wlan0-ap-2
 SSID-HEX:                               776C616E302D61702D32
 BSSID:                                  C0:E2:BE:E8:EF:B6
@@ -30494,6 +30619,25 @@ DEVICE:                                 wlan0
 ACTIVE:                                 nie
 IN-USE:                                  
 DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/3
+
+NAME:                                   AP[1]
+SSID:                                   wlan1-ap-4
+SSID-HEX:                               776C616E312D61702D34
+BSSID:                                  94:2B:E8:F6:D2:86
+MODE:                                   Infrastruktura
+CHAN:                                   1
+FREQ:                                   2412 MHz
+RATE:                                   54 Mb/s
+SIGNAL:                                 48
+BARS:                                   **  
+SECURITY:                               WPA1 WPA2
+WPA-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
+RSN-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
+DEVICE:                                 wlan1
+ACTIVE:                                 nie
+IN-USE:                                  
+DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/4
+
 
 <<<
 size: 1643
@@ -30504,16 +30648,6 @@ returncode: 0
 stdout: 1478 bytes
 >>>
 IN-USE:                                  
-SSID:                                   wlan1-ap-4
-MODE:                                   Infra
-CHAN:                                   1
-RATE:                                   54 Mbit/s
-SIGNAL:                                 48
-BARS:                                   **  
-SECURITY:                               WPA1 WPA2
-
-
-IN-USE:                                  
 SSID:                                   wlan0-ap-2
 MODE:                                   Infra
 CHAN:                                   1
@@ -30537,6 +30671,16 @@ RATE:                                   54 Mbit/s
 SIGNAL:                                 55
 BARS:                                   **  
 SECURITY:                               WPA1 WPA2
+
+IN-USE:                                  
+SSID:                                   wlan1-ap-4
+MODE:                                   Infra
+CHAN:                                   1
+RATE:                                   54 Mbit/s
+SIGNAL:                                 48
+BARS:                                   **  
+SECURITY:                               WPA1 WPA2
+
 
 <<<
 size: 1689
@@ -30547,16 +30691,6 @@ returncode: 0
 stdout: 1514 bytes
 >>>
 IN-USE:                                  
-SSID:                                   wlan1-ap-4
-MODE:                                   Infrastruktura
-CHAN:                                   1
-RATE:                                   54 Mb/s
-SIGNAL:                                 48
-BARS:                                   **  
-SECURITY:                               WPA1 WPA2
-
-
-IN-USE:                                  
 SSID:                                   wlan0-ap-2
 MODE:                                   Infrastruktura
 CHAN:                                   1
@@ -30580,6 +30714,16 @@ RATE:                                   54 Mb/s
 SIGNAL:                                 55
 BARS:                                   **  
 SECURITY:                               WPA1 WPA2
+
+IN-USE:                                  
+SSID:                                   wlan1-ap-4
+MODE:                                   Infrastruktura
+CHAN:                                   1
+RATE:                                   54 Mb/s
+SIGNAL:                                 48
+BARS:                                   **  
+SECURITY:                               WPA1 WPA2
+
 
 <<<
 size: 3997
@@ -30590,25 +30734,6 @@ returncode: 0
 stdout: 3722 bytes
 >>>
 NAME:                                   AP[1]
-SSID:                                   wlan1-ap-4
-SSID-HEX:                               776C616E312D61702D34
-BSSID:                                  94:2B:E8:F6:D2:86
-MODE:                                   Infra
-CHAN:                                   1
-FREQ:                                   2412 MHz
-RATE:                                   54 Mbit/s
-SIGNAL:                                 48
-BARS:                                   **  
-SECURITY:                               WPA1 WPA2
-WPA-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
-RSN-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
-DEVICE:                                 wlan1
-ACTIVE:                                 no
-IN-USE:                                  
-DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/4
-
-
-NAME:                                   AP[1]
 SSID:                                   wlan0-ap-2
 SSID-HEX:                               776C616E302D61702D32
 BSSID:                                  C0:E2:BE:E8:EF:B6
@@ -30659,6 +30784,25 @@ DEVICE:                                 wlan0
 ACTIVE:                                 no
 IN-USE:                                  
 DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/3
+
+NAME:                                   AP[1]
+SSID:                                   wlan1-ap-4
+SSID-HEX:                               776C616E312D61702D34
+BSSID:                                  94:2B:E8:F6:D2:86
+MODE:                                   Infra
+CHAN:                                   1
+FREQ:                                   2412 MHz
+RATE:                                   54 Mbit/s
+SIGNAL:                                 48
+BARS:                                   **  
+SECURITY:                               WPA1 WPA2
+WPA-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
+RSN-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
+DEVICE:                                 wlan1
+ACTIVE:                                 no
+IN-USE:                                  
+DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/4
+
 
 <<<
 size: 4055
@@ -30669,25 +30813,6 @@ returncode: 0
 stdout: 3770 bytes
 >>>
 NAME:                                   AP[1]
-SSID:                                   wlan1-ap-4
-SSID-HEX:                               776C616E312D61702D34
-BSSID:                                  94:2B:E8:F6:D2:86
-MODE:                                   Infrastruktura
-CHAN:                                   1
-FREQ:                                   2412 MHz
-RATE:                                   54 Mb/s
-SIGNAL:                                 48
-BARS:                                   **  
-SECURITY:                               WPA1 WPA2
-WPA-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
-RSN-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
-DEVICE:                                 wlan1
-ACTIVE:                                 nie
-IN-USE:                                  
-DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/4
-
-
-NAME:                                   AP[1]
 SSID:                                   wlan0-ap-2
 SSID-HEX:                               776C616E302D61702D32
 BSSID:                                  C0:E2:BE:E8:EF:B6
@@ -30739,13 +30864,32 @@ ACTIVE:                                 nie
 IN-USE:                                  
 DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/3
 
+NAME:                                   AP[1]
+SSID:                                   wlan1-ap-4
+SSID-HEX:                               776C616E312D61702D34
+BSSID:                                  94:2B:E8:F6:D2:86
+MODE:                                   Infrastruktura
+CHAN:                                   1
+FREQ:                                   2412 MHz
+RATE:                                   54 Mb/s
+SIGNAL:                                 48
+BARS:                                   **  
+SECURITY:                               WPA1 WPA2
+WPA-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
+RSN-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
+DEVICE:                                 wlan1
+ACTIVE:                                 nie
+IN-USE:                                  
+DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/4
+
+
 <<<
-size: 1115
+size: 1117
 location: clients/tests/test-client.py:1075:test_004()/609
 cmd: $NMCLI --mode multiline -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 930 bytes
+stdout: 932 bytes
 >>>
 NAME:                                   AP[1]
 SSID:                                   wlan0-ap-2
@@ -30765,13 +30909,15 @@ ACTIVE:                                 no
 IN-USE:                                  
 DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/2
 
+
+
 <<<
-size: 1137
+size: 1139
 location: clients/tests/test-client.py:1075:test_004()/610
 cmd: $NMCLI --mode multiline -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 942 bytes
+stdout: 944 bytes
 >>>
 NAME:                                   AP[1]
 SSID:                                   wlan0-ap-2
@@ -30791,13 +30937,15 @@ ACTIVE:                                 nie
 IN-USE:                                  
 DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/2
 
+
+
 <<<
-size: 557
+size: 559
 location: clients/tests/test-client.py:1077:test_004()/611
 cmd: $NMCLI --mode multiline -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 369 bytes
+stdout: 371 bytes
 >>>
 IN-USE:                                  
 SSID:                                   wlan0-ap-2
@@ -30808,13 +30956,15 @@ SIGNAL:                                 92
 BARS:                                   ****
 SECURITY:                               WPA1 WPA2
 
+
+
 <<<
-size: 576
+size: 578
 location: clients/tests/test-client.py:1077:test_004()/612
 cmd: $NMCLI --mode multiline -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 378 bytes
+stdout: 380 bytes
 >>>
 IN-USE:                                  
 SSID:                                   wlan0-ap-2
@@ -30825,13 +30975,15 @@ SIGNAL:                                 92
 BARS:                                   ****
 SECURITY:                               WPA1 WPA2
 
+
+
 <<<
-size: 1228
+size: 1230
 location: clients/tests/test-client.py:1080:test_004()/613
 cmd: $NMCLI --mode multiline -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 930 bytes
+stdout: 932 bytes
 >>>
 NAME:                                   AP[1]
 SSID:                                   wlan0-ap-2
@@ -30851,13 +31003,15 @@ ACTIVE:                                 no
 IN-USE:                                  
 DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/2
 
+
+
 <<<
-size: 1250
+size: 1252
 location: clients/tests/test-client.py:1080:test_004()/614
 cmd: $NMCLI --mode multiline -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 942 bytes
+stdout: 944 bytes
 >>>
 NAME:                                   AP[1]
 SSID:                                   wlan0-ap-2
@@ -30876,6 +31030,8 @@ DEVICE:                                 wlan0
 ACTIVE:                                 nie
 IN-USE:                                  
 DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/2
+
+
 
 <<<
 size: 4878
@@ -31995,6 +32151,10 @@ lang: C
 returncode: 0
 stdout: 1103 bytes
 >>>
+DEVICE:                                 [2mwlan0[0m
+TYPE:                                   [2mwifi[0m
+STATE:                                  [2munavailable[0m
+CONNECTION:                             [2mcon-vpn-1[0m
 DEVICE:                                 [2meth0[0m
 TYPE:                                   [2methernet[0m
 STATE:                                  [2munavailable[0m
@@ -32011,10 +32171,6 @@ DEVICE:                                 [2mwlan1[0m
 TYPE:                                   [2mwifi[0m
 STATE:                                  [2munavailable[0m
 CONNECTION:                             [2m--[0m
-DEVICE:                                 [2mwlan0[0m
-TYPE:                                   [2mwifi[0m
-STATE:                                  [2munavailable[0m
-CONNECTION:                             [2mcon-vpn-1[0m
 
 <<<
 size: 1274
@@ -32024,6 +32180,10 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 1108 bytes
 >>>
+DEVICE:                                 [2mwlan0[0m
+TYPE:                                   [2mwifi[0m
+STATE:                                  [2mniedostępne[0m
+CONNECTION:                             [2mcon-vpn-1[0m
 DEVICE:                                 [2meth0[0m
 TYPE:                                   [2methernet[0m
 STATE:                                  [2mniedostępne[0m
@@ -32040,10 +32200,6 @@ DEVICE:                                 [2mwlan1[0m
 TYPE:                                   [2mwifi[0m
 STATE:                                  [2mniedostępne[0m
 CONNECTION:                             [2m--[0m
-DEVICE:                                 [2mwlan0[0m
-TYPE:                                   [2mwifi[0m
-STATE:                                  [2mniedostępne[0m
-CONNECTION:                             [2mcon-vpn-1[0m
 
 <<<
 size: 2873
@@ -32053,6 +32209,15 @@ lang: C
 returncode: 0
 stdout: 2705 bytes
 >>>
+DEVICE:                                 [2mwlan0[0m
+TYPE:                                   [2mwifi[0m
+STATE:                                  [2munavailable[0m
+IP4-CONNECTIVITY:                       [2munknown[0m
+IP6-CONNECTIVITY:                       [2munknown[0m
+DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devices/3[0m
+CONNECTION:                             [2mcon-vpn-1[0m
+CON-UUID:                               [2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m
+CON-PATH:                               [2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
 DEVICE:                                 [2meth0[0m
 TYPE:                                   [2methernet[0m
 STATE:                                  [2munavailable[0m
@@ -32089,15 +32254,6 @@ DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devi
 CONNECTION:                             [2m--[0m
 CON-UUID:                               [2m--[0m
 CON-PATH:                               [2m--[0m
-DEVICE:                                 [2mwlan0[0m
-TYPE:                                   [2mwifi[0m
-STATE:                                  [2munavailable[0m
-IP4-CONNECTIVITY:                       [2munknown[0m
-IP6-CONNECTIVITY:                       [2munknown[0m
-DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devices/3[0m
-CONNECTION:                             [2mcon-vpn-1[0m
-CON-UUID:                               [2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m
-CON-PATH:                               [2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
 
 <<<
 size: 2898
@@ -32107,6 +32263,15 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 2720 bytes
 >>>
+DEVICE:                                 [2mwlan0[0m
+TYPE:                                   [2mwifi[0m
+STATE:                                  [2mniedostępne[0m
+IP4-CONNECTIVITY:                       [2mnieznane[0m
+IP6-CONNECTIVITY:                       [2mnieznane[0m
+DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devices/3[0m
+CONNECTION:                             [2mcon-vpn-1[0m
+CON-UUID:                               [2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m
+CON-PATH:                               [2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
 DEVICE:                                 [2meth0[0m
 TYPE:                                   [2methernet[0m
 STATE:                                  [2mniedostępne[0m
@@ -32143,15 +32308,6 @@ DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devi
 CONNECTION:                             [2m--[0m
 CON-UUID:                               [2m--[0m
 CON-PATH:                               [2m--[0m
-DEVICE:                                 [2mwlan0[0m
-TYPE:                                   [2mwifi[0m
-STATE:                                  [2mniedostępne[0m
-IP4-CONNECTIVITY:                       [2mnieznane[0m
-IP6-CONNECTIVITY:                       [2mnieznane[0m
-DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devices/3[0m
-CONNECTION:                             [2mcon-vpn-1[0m
-CON-UUID:                               [2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m
-CON-PATH:                               [2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
 
 <<<
 size: 8077
@@ -32161,6 +32317,31 @@ lang: C
 returncode: 0
 stdout: 7918 bytes
 >>>
+GENERAL.DEVICE:                         wlan0
+GENERAL.TYPE:                           wifi
+GENERAL.HWADDR:                         13:E0:74:85:7C:D9
+GENERAL.MTU:                            0
+GENERAL.STATE:                          20 (unavailable)
+GENERAL.CONNECTION:                     con-vpn-1
+GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
+IP4.ADDRESS[1]:                         192.168.228.18/32
+IP4.ADDRESS[2]:                         192.168.209.179/25
+IP4.GATEWAY:                            192.168.41.120
+IP4.DOMAIN[1]:                          sear4.foo2.bar
+IP4.DOMAIN[2]:                          sear4.fo.x.y
+IP4.DOMAIN[3]:                          sear4.foo1.bar
+IP4.DOMAIN[4]:                          sear4.foo4.bar
+IP4.DOMAIN[5]:                          sear4.fo.o.bar
+IP4.WINS[1]:                            192.168.120.79
+IP6.GATEWAY:                            --
+IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
+IP6.DOMAIN[1]:                          sear6.foo2.bar
+IP6.DOMAIN[2]:                          sear6.foo1.bar
+IP6.DOMAIN[3]:                          sear6.fo.x.y
+IP6.DOMAIN[4]:                          sear6.fo.o.bar
+IP6.DOMAIN[5]:                          sear6.foo3.bar
+IP6.DOMAIN[6]:                          sear6.foo4.bar
+
 GENERAL.DEVICE:                         eth0
 GENERAL.TYPE:                           ethernet
 GENERAL.HWADDR:                         AB:B7:BF:E2:48:E8
@@ -32273,31 +32454,6 @@ IP6.ROUTE[2]:                           dst = 2001:a::a976:2488:f49f:b48/106, nh
 IP6.ROUTE[3]:                           dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::
 IP6.DNS[1]:                             2001:a::2934:bd66:550d:ec19
 IP6.DOMAIN[1]:                          sear6.fo.x.y
-
-GENERAL.DEVICE:                         wlan0
-GENERAL.TYPE:                           wifi
-GENERAL.HWADDR:                         13:E0:74:85:7C:D9
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (unavailable)
-GENERAL.CONNECTION:                     con-vpn-1
-GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
-IP4.ADDRESS[1]:                         192.168.228.18/32
-IP4.ADDRESS[2]:                         192.168.209.179/25
-IP4.GATEWAY:                            192.168.41.120
-IP4.DOMAIN[1]:                          sear4.foo2.bar
-IP4.DOMAIN[2]:                          sear4.fo.x.y
-IP4.DOMAIN[3]:                          sear4.foo1.bar
-IP4.DOMAIN[4]:                          sear4.foo4.bar
-IP4.DOMAIN[5]:                          sear4.fo.o.bar
-IP4.WINS[1]:                            192.168.120.79
-IP6.GATEWAY:                            --
-IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
-IP6.DOMAIN[1]:                          sear6.foo2.bar
-IP6.DOMAIN[2]:                          sear6.foo1.bar
-IP6.DOMAIN[3]:                          sear6.fo.x.y
-IP6.DOMAIN[4]:                          sear6.fo.o.bar
-IP6.DOMAIN[5]:                          sear6.foo3.bar
-IP6.DOMAIN[6]:                          sear6.foo4.bar
 
 <<<
 size: 8108
@@ -32307,6 +32463,31 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 7939 bytes
 >>>
+GENERAL.DEVICE:                         wlan0
+GENERAL.TYPE:                           wifi
+GENERAL.HWADDR:                         13:E0:74:85:7C:D9
+GENERAL.MTU:                            0
+GENERAL.STATE:                          20 (niedostępne)
+GENERAL.CONNECTION:                     con-vpn-1
+GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
+IP4.ADDRESS[1]:                         192.168.228.18/32
+IP4.ADDRESS[2]:                         192.168.209.179/25
+IP4.GATEWAY:                            192.168.41.120
+IP4.DOMAIN[1]:                          sear4.foo2.bar
+IP4.DOMAIN[2]:                          sear4.fo.x.y
+IP4.DOMAIN[3]:                          sear4.foo1.bar
+IP4.DOMAIN[4]:                          sear4.foo4.bar
+IP4.DOMAIN[5]:                          sear4.fo.o.bar
+IP4.WINS[1]:                            192.168.120.79
+IP6.GATEWAY:                            --
+IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
+IP6.DOMAIN[1]:                          sear6.foo2.bar
+IP6.DOMAIN[2]:                          sear6.foo1.bar
+IP6.DOMAIN[3]:                          sear6.fo.x.y
+IP6.DOMAIN[4]:                          sear6.fo.o.bar
+IP6.DOMAIN[5]:                          sear6.foo3.bar
+IP6.DOMAIN[6]:                          sear6.foo4.bar
+
 GENERAL.DEVICE:                         eth0
 GENERAL.TYPE:                           ethernet
 GENERAL.HWADDR:                         AB:B7:BF:E2:48:E8
@@ -32420,13 +32601,77 @@ IP6.ROUTE[3]:                           dst = 2001:a::afb7:4449:3787:8bb4/123, n
 IP6.DNS[1]:                             2001:a::2934:bd66:550d:ec19
 IP6.DOMAIN[1]:                          sear6.fo.x.y
 
+<<<
+size: 20988
+location: clients/tests/test-client.py:1050:test_004()/637
+cmd: $NMCLI --mode multiline --color yes -f all dev show
+lang: C
+returncode: 0
+stdout: 20821 bytes
+>>>
 GENERAL.DEVICE:                         wlan0
 GENERAL.TYPE:                           wifi
+GENERAL.NM-TYPE:                        NMDeviceWifi
+GENERAL.VENDOR:                         --
+GENERAL.PRODUCT:                        --
+GENERAL.DRIVER:                         virtual
+GENERAL.DRIVER-VERSION:                 --
+GENERAL.FIRMWARE-VERSION:               --
 GENERAL.HWADDR:                         13:E0:74:85:7C:D9
 GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (niedostępne)
+GENERAL.STATE:                          20 (unavailable)
+GENERAL.REASON:                         0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:               0 (unknown)
+GENERAL.IP6-CONNECTIVITY:               0 (unknown)
+GENERAL.UDI:                            /sys/devices/virtual/wlan0
+GENERAL.IP-IFACE:                       --
+GENERAL.IS-SOFTWARE:                    no
+GENERAL.NM-MANAGED:                     yes
+GENERAL.AUTOCONNECT:                    yes
+GENERAL.FIRMWARE-MISSING:               no
+GENERAL.NM-PLUGIN-MISSING:              no
+GENERAL.PHYS-PORT-ID:                   --
 GENERAL.CONNECTION:                     con-vpn-1
+GENERAL.CON-UUID:                       UUID-con-vpn-1-REPLACED-REPLACED-REP
 GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
+GENERAL.METERED:                        unknown
+CAPABILITIES.CARRIER-DETECT:            no
+CAPABILITIES.SPEED:                     unknown
+CAPABILITIES.IS-SOFTWARE:               no
+CAPABILITIES.SRIOV:                     no
+WIFI-PROPERTIES.WEP:                    yes
+WIFI-PROPERTIES.WPA:                    yes
+WIFI-PROPERTIES.WPA2:                   yes
+WIFI-PROPERTIES.TKIP:                   yes
+WIFI-PROPERTIES.CCMP:                   yes
+WIFI-PROPERTIES.AP:                     yes
+WIFI-PROPERTIES.ADHOC:                  yes
+WIFI-PROPERTIES.2GHZ:                   unknown
+WIFI-PROPERTIES.5GHZ:                   unknown
+AP[1].IN-USE:                           [32m [0m
+AP[1].SSID:                             [32mwlan0-ap-2[0m
+AP[1].MODE:                             [32mInfra[0m
+AP[1].CHAN:                             [32m1[0m
+AP[1].RATE:                             [32m54 Mbit/s[0m
+AP[1].SIGNAL:                           [32m92[0m
+AP[1].BARS:                             [32m****[0m
+AP[1].SECURITY:                         [32mWPA1 WPA2[0m
+AP[2].IN-USE:                           [32m [0m
+AP[2].SSID:                             [32mwlan0-ap-1[0m
+AP[2].MODE:                             [32mInfra[0m
+AP[2].CHAN:                             [32m1[0m
+AP[2].RATE:                             [32m54 Mbit/s[0m
+AP[2].SIGNAL:                           [32m81[0m
+AP[2].BARS:                             [32m****[0m
+AP[2].SECURITY:                         [32mWPA1 WPA2[0m
+AP[3].IN-USE:                           [35m [0m
+AP[3].SSID:                             [35mwlan0-ap-3[0m
+AP[3].MODE:                             [35mInfra[0m
+AP[3].CHAN:                             [35m1[0m
+AP[3].RATE:                             [35m54 Mbit/s[0m
+AP[3].SIGNAL:                           [35m55[0m
+AP[3].BARS:                             [35m**  [0m
+AP[3].SECURITY:                         [35mWPA1 WPA2[0m
 IP4.ADDRESS[1]:                         192.168.228.18/32
 IP4.ADDRESS[2]:                         192.168.209.179/25
 IP4.GATEWAY:                            192.168.41.120
@@ -32436,6 +32681,10 @@ IP4.DOMAIN[3]:                          sear4.foo1.bar
 IP4.DOMAIN[4]:                          sear4.foo4.bar
 IP4.DOMAIN[5]:                          sear4.fo.o.bar
 IP4.WINS[1]:                            192.168.120.79
+DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:                        dhcp-4-opt-2 = val-2
+DHCP4.OPTION[3]:                        dhcp-4-opt-4 = val-4
+DHCP4.OPTION[4]:                        dhcp-4-opt-7 = val-7
 IP6.GATEWAY:                            --
 IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
 IP6.DOMAIN[1]:                          sear6.foo2.bar
@@ -32444,15 +32693,14 @@ IP6.DOMAIN[3]:                          sear6.fo.x.y
 IP6.DOMAIN[4]:                          sear6.fo.o.bar
 IP6.DOMAIN[5]:                          sear6.foo3.bar
 IP6.DOMAIN[6]:                          sear6.foo4.bar
+DHCP6.OPTION[1]:                        dhcp-6-opt-1 = val-1
+DHCP6.OPTION[2]:                        dhcp-6-opt-2 = val-2
+DHCP6.OPTION[3]:                        dhcp-6-opt-3 = val-3
+DHCP6.OPTION[4]:                        dhcp-6-opt-4 = val-4
+DHCP6.OPTION[5]:                        dhcp-6-opt-5 = val-5
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
-<<<
-size: 20988
-location: clients/tests/test-client.py:1050:test_004()/637
-cmd: $NMCLI --mode multiline --color yes -f all dev show
-lang: C
-returncode: 0
-stdout: 20821 bytes
->>>
 GENERAL.DEVICE:                         eth0
 GENERAL.TYPE:                           ethernet
 GENERAL.NM-TYPE:                        NMDeviceEthernet
@@ -32742,6 +32990,14 @@ DHCP6.OPTION[5]:                        dhcp-6-opt-9 = val-9
 CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
+<<<
+size: 21138
+location: clients/tests/test-client.py:1050:test_004()/638
+cmd: $NMCLI --mode multiline --color yes -f all dev show
+lang: pl_PL.UTF-8
+returncode: 0
+stdout: 20961 bytes
+>>>
 GENERAL.DEVICE:                         wlan0
 GENERAL.TYPE:                           wifi
 GENERAL.NM-TYPE:                        NMDeviceWifi
@@ -32752,56 +33008,56 @@ GENERAL.DRIVER-VERSION:                 --
 GENERAL.FIRMWARE-VERSION:               --
 GENERAL.HWADDR:                         13:E0:74:85:7C:D9
 GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (unavailable)
-GENERAL.REASON:                         0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:               0 (unknown)
-GENERAL.IP6-CONNECTIVITY:               0 (unknown)
+GENERAL.STATE:                          20 (niedostępne)
+GENERAL.REASON:                         0 (Nie podano przyczyny)
+GENERAL.IP4-CONNECTIVITY:               0 (nieznane)
+GENERAL.IP6-CONNECTIVITY:               0 (nieznane)
 GENERAL.UDI:                            /sys/devices/virtual/wlan0
 GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    no
-GENERAL.NM-MANAGED:                     yes
-GENERAL.AUTOCONNECT:                    yes
-GENERAL.FIRMWARE-MISSING:               no
-GENERAL.NM-PLUGIN-MISSING:              no
+GENERAL.IS-SOFTWARE:                    nie
+GENERAL.NM-MANAGED:                     tak
+GENERAL.AUTOCONNECT:                    tak
+GENERAL.FIRMWARE-MISSING:               nie
+GENERAL.NM-PLUGIN-MISSING:              nie
 GENERAL.PHYS-PORT-ID:                   --
 GENERAL.CONNECTION:                     con-vpn-1
 GENERAL.CON-UUID:                       UUID-con-vpn-1-REPLACED-REPLACED-REP
 GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
-GENERAL.METERED:                        unknown
-CAPABILITIES.CARRIER-DETECT:            no
-CAPABILITIES.SPEED:                     unknown
-CAPABILITIES.IS-SOFTWARE:               no
-CAPABILITIES.SRIOV:                     no
-WIFI-PROPERTIES.WEP:                    yes
-WIFI-PROPERTIES.WPA:                    yes
-WIFI-PROPERTIES.WPA2:                   yes
-WIFI-PROPERTIES.TKIP:                   yes
-WIFI-PROPERTIES.CCMP:                   yes
-WIFI-PROPERTIES.AP:                     yes
-WIFI-PROPERTIES.ADHOC:                  yes
-WIFI-PROPERTIES.2GHZ:                   unknown
-WIFI-PROPERTIES.5GHZ:                   unknown
+GENERAL.METERED:                        nieznane
+CAPABILITIES.CARRIER-DETECT:            nie
+CAPABILITIES.SPEED:                     nieznane
+CAPABILITIES.IS-SOFTWARE:               nie
+CAPABILITIES.SRIOV:                     nie
+WIFI-PROPERTIES.WEP:                    tak
+WIFI-PROPERTIES.WPA:                    tak
+WIFI-PROPERTIES.WPA2:                   tak
+WIFI-PROPERTIES.TKIP:                   tak
+WIFI-PROPERTIES.CCMP:                   tak
+WIFI-PROPERTIES.AP:                     tak
+WIFI-PROPERTIES.ADHOC:                  tak
+WIFI-PROPERTIES.2GHZ:                   nieznane
+WIFI-PROPERTIES.5GHZ:                   nieznane
 AP[1].IN-USE:                           [32m [0m
 AP[1].SSID:                             [32mwlan0-ap-2[0m
-AP[1].MODE:                             [32mInfra[0m
+AP[1].MODE:                             [32mInfrastruktura[0m
 AP[1].CHAN:                             [32m1[0m
-AP[1].RATE:                             [32m54 Mbit/s[0m
+AP[1].RATE:                             [32m54 Mb/s[0m
 AP[1].SIGNAL:                           [32m92[0m
 AP[1].BARS:                             [32m****[0m
 AP[1].SECURITY:                         [32mWPA1 WPA2[0m
 AP[2].IN-USE:                           [32m [0m
 AP[2].SSID:                             [32mwlan0-ap-1[0m
-AP[2].MODE:                             [32mInfra[0m
+AP[2].MODE:                             [32mInfrastruktura[0m
 AP[2].CHAN:                             [32m1[0m
-AP[2].RATE:                             [32m54 Mbit/s[0m
+AP[2].RATE:                             [32m54 Mb/s[0m
 AP[2].SIGNAL:                           [32m81[0m
 AP[2].BARS:                             [32m****[0m
 AP[2].SECURITY:                         [32mWPA1 WPA2[0m
 AP[3].IN-USE:                           [35m [0m
 AP[3].SSID:                             [35mwlan0-ap-3[0m
-AP[3].MODE:                             [35mInfra[0m
+AP[3].MODE:                             [35mInfrastruktura[0m
 AP[3].CHAN:                             [35m1[0m
-AP[3].RATE:                             [35m54 Mbit/s[0m
+AP[3].RATE:                             [35m54 Mb/s[0m
 AP[3].SIGNAL:                           [35m55[0m
 AP[3].BARS:                             [35m**  [0m
 AP[3].SECURITY:                         [35mWPA1 WPA2[0m
@@ -32834,14 +33090,6 @@ DHCP6.OPTION[5]:                        dhcp-6-opt-5 = val-5
 CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
-<<<
-size: 21138
-location: clients/tests/test-client.py:1050:test_004()/638
-cmd: $NMCLI --mode multiline --color yes -f all dev show
-lang: pl_PL.UTF-8
-returncode: 0
-stdout: 20961 bytes
->>>
 GENERAL.DEVICE:                         eth0
 GENERAL.TYPE:                           ethernet
 GENERAL.NM-TYPE:                        NMDeviceEthernet
@@ -33128,98 +33376,6 @@ DHCP6.OPTION[2]:                        dhcp-6-opt-6 = val-6
 DHCP6.OPTION[3]:                        dhcp-6-opt-7 = val-7
 DHCP6.OPTION[4]:                        dhcp-6-opt-8 = val-8
 DHCP6.OPTION[5]:                        dhcp-6-opt-9 = val-9
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
-
-GENERAL.DEVICE:                         wlan0
-GENERAL.TYPE:                           wifi
-GENERAL.NM-TYPE:                        NMDeviceWifi
-GENERAL.VENDOR:                         --
-GENERAL.PRODUCT:                        --
-GENERAL.DRIVER:                         virtual
-GENERAL.DRIVER-VERSION:                 --
-GENERAL.FIRMWARE-VERSION:               --
-GENERAL.HWADDR:                         13:E0:74:85:7C:D9
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (niedostępne)
-GENERAL.REASON:                         0 (Nie podano przyczyny)
-GENERAL.IP4-CONNECTIVITY:               0 (nieznane)
-GENERAL.IP6-CONNECTIVITY:               0 (nieznane)
-GENERAL.UDI:                            /sys/devices/virtual/wlan0
-GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    nie
-GENERAL.NM-MANAGED:                     tak
-GENERAL.AUTOCONNECT:                    tak
-GENERAL.FIRMWARE-MISSING:               nie
-GENERAL.NM-PLUGIN-MISSING:              nie
-GENERAL.PHYS-PORT-ID:                   --
-GENERAL.CONNECTION:                     con-vpn-1
-GENERAL.CON-UUID:                       UUID-con-vpn-1-REPLACED-REPLACED-REP
-GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
-GENERAL.METERED:                        nieznane
-CAPABILITIES.CARRIER-DETECT:            nie
-CAPABILITIES.SPEED:                     nieznane
-CAPABILITIES.IS-SOFTWARE:               nie
-CAPABILITIES.SRIOV:                     nie
-WIFI-PROPERTIES.WEP:                    tak
-WIFI-PROPERTIES.WPA:                    tak
-WIFI-PROPERTIES.WPA2:                   tak
-WIFI-PROPERTIES.TKIP:                   tak
-WIFI-PROPERTIES.CCMP:                   tak
-WIFI-PROPERTIES.AP:                     tak
-WIFI-PROPERTIES.ADHOC:                  tak
-WIFI-PROPERTIES.2GHZ:                   nieznane
-WIFI-PROPERTIES.5GHZ:                   nieznane
-AP[1].IN-USE:                           [32m [0m
-AP[1].SSID:                             [32mwlan0-ap-2[0m
-AP[1].MODE:                             [32mInfrastruktura[0m
-AP[1].CHAN:                             [32m1[0m
-AP[1].RATE:                             [32m54 Mb/s[0m
-AP[1].SIGNAL:                           [32m92[0m
-AP[1].BARS:                             [32m****[0m
-AP[1].SECURITY:                         [32mWPA1 WPA2[0m
-AP[2].IN-USE:                           [32m [0m
-AP[2].SSID:                             [32mwlan0-ap-1[0m
-AP[2].MODE:                             [32mInfrastruktura[0m
-AP[2].CHAN:                             [32m1[0m
-AP[2].RATE:                             [32m54 Mb/s[0m
-AP[2].SIGNAL:                           [32m81[0m
-AP[2].BARS:                             [32m****[0m
-AP[2].SECURITY:                         [32mWPA1 WPA2[0m
-AP[3].IN-USE:                           [35m [0m
-AP[3].SSID:                             [35mwlan0-ap-3[0m
-AP[3].MODE:                             [35mInfrastruktura[0m
-AP[3].CHAN:                             [35m1[0m
-AP[3].RATE:                             [35m54 Mb/s[0m
-AP[3].SIGNAL:                           [35m55[0m
-AP[3].BARS:                             [35m**  [0m
-AP[3].SECURITY:                         [35mWPA1 WPA2[0m
-IP4.ADDRESS[1]:                         192.168.228.18/32
-IP4.ADDRESS[2]:                         192.168.209.179/25
-IP4.GATEWAY:                            192.168.41.120
-IP4.DOMAIN[1]:                          sear4.foo2.bar
-IP4.DOMAIN[2]:                          sear4.fo.x.y
-IP4.DOMAIN[3]:                          sear4.foo1.bar
-IP4.DOMAIN[4]:                          sear4.foo4.bar
-IP4.DOMAIN[5]:                          sear4.fo.o.bar
-IP4.WINS[1]:                            192.168.120.79
-DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:                        dhcp-4-opt-2 = val-2
-DHCP4.OPTION[3]:                        dhcp-4-opt-4 = val-4
-DHCP4.OPTION[4]:                        dhcp-4-opt-7 = val-7
-IP6.GATEWAY:                            --
-IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
-IP6.DOMAIN[1]:                          sear6.foo2.bar
-IP6.DOMAIN[2]:                          sear6.foo1.bar
-IP6.DOMAIN[3]:                          sear6.fo.x.y
-IP6.DOMAIN[4]:                          sear6.fo.o.bar
-IP6.DOMAIN[5]:                          sear6.foo3.bar
-IP6.DOMAIN[6]:                          sear6.foo4.bar
-DHCP6.OPTION[1]:                        dhcp-6-opt-1 = val-1
-DHCP6.OPTION[2]:                        dhcp-6-opt-2 = val-2
-DHCP6.OPTION[3]:                        dhcp-6-opt-3 = val-3
-DHCP6.OPTION[4]:                        dhcp-6-opt-4 = val-4
-DHCP6.OPTION[5]:                        dhcp-6-opt-5 = val-5
 CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
@@ -33677,6 +33833,9 @@ lang: C
 returncode: 0
 stdout: 991 bytes
 >>>
+DEVICE:                                 [2mwlan0[0m
+TYPE:                                   [2mwifi[0m
+DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devices/3[0m
 DEVICE:                                 [2meth0[0m
 TYPE:                                   [2methernet[0m
 DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devices/1[0m
@@ -33689,9 +33848,6 @@ DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devi
 DEVICE:                                 [2mwlan1[0m
 TYPE:                                   [2mwifi[0m
 DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devices/5[0m
-DEVICE:                                 [2mwlan0[0m
-TYPE:                                   [2mwifi[0m
-DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devices/3[0m
 
 <<<
 size: 1179
@@ -33701,6 +33857,9 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 991 bytes
 >>>
+DEVICE:                                 [2mwlan0[0m
+TYPE:                                   [2mwifi[0m
+DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devices/3[0m
 DEVICE:                                 [2meth0[0m
 TYPE:                                   [2methernet[0m
 DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devices/1[0m
@@ -33713,9 +33872,6 @@ DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devi
 DEVICE:                                 [2mwlan1[0m
 TYPE:                                   [2mwifi[0m
 DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devices/5[0m
-DEVICE:                                 [2mwlan0[0m
-TYPE:                                   [2mwifi[0m
-DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devices/3[0m
 
 <<<
 size: 4508
@@ -33725,25 +33881,6 @@ lang: C
 returncode: 0
 stdout: 4334 bytes
 >>>
-NAME:                                   [35mAP[1][0m
-SSID:                                   [35mwlan1-ap-4[0m
-SSID-HEX:                               [35m776C616E312D61702D34[0m
-BSSID:                                  [35m94:2B:E8:F6:D2:86[0m
-MODE:                                   [35mInfra[0m
-CHAN:                                   [35m1[0m
-FREQ:                                   [35m2412 MHz[0m
-RATE:                                   [35m54 Mbit/s[0m
-SIGNAL:                                 [35m48[0m
-BARS:                                   [35m**  [0m
-SECURITY:                               [35mWPA1 WPA2[0m
-WPA-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
-RSN-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
-DEVICE:                                 [35mwlan1[0m
-ACTIVE:                                 [35mno[0m
-IN-USE:                                 [35m [0m
-DBUS-PATH:                              [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
-
-
 NAME:                                   [32mAP[1][0m
 SSID:                                   [32mwlan0-ap-2[0m
 SSID-HEX:                               [32m776C616E302D61702D32[0m
@@ -33795,6 +33932,25 @@ DEVICE:                                 [35mwlan0[0m
 ACTIVE:                                 [35mno[0m
 IN-USE:                                 [35m [0m
 DBUS-PATH:                              [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m
+
+NAME:                                   [35mAP[1][0m
+SSID:                                   [35mwlan1-ap-4[0m
+SSID-HEX:                               [35m776C616E312D61702D34[0m
+BSSID:                                  [35m94:2B:E8:F6:D2:86[0m
+MODE:                                   [35mInfra[0m
+CHAN:                                   [35m1[0m
+FREQ:                                   [35m2412 MHz[0m
+RATE:                                   [35m54 Mbit/s[0m
+SIGNAL:                                 [35m48[0m
+BARS:                                   [35m**  [0m
+SECURITY:                               [35mWPA1 WPA2[0m
+WPA-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
+RSN-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
+DEVICE:                                 [35mwlan1[0m
+ACTIVE:                                 [35mno[0m
+IN-USE:                                 [35m [0m
+DBUS-PATH:                              [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
+
 
 <<<
 size: 4566
@@ -33804,25 +33960,6 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 4382 bytes
 >>>
-NAME:                                   [35mAP[1][0m
-SSID:                                   [35mwlan1-ap-4[0m
-SSID-HEX:                               [35m776C616E312D61702D34[0m
-BSSID:                                  [35m94:2B:E8:F6:D2:86[0m
-MODE:                                   [35mInfrastruktura[0m
-CHAN:                                   [35m1[0m
-FREQ:                                   [35m2412 MHz[0m
-RATE:                                   [35m54 Mb/s[0m
-SIGNAL:                                 [35m48[0m
-BARS:                                   [35m**  [0m
-SECURITY:                               [35mWPA1 WPA2[0m
-WPA-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
-RSN-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
-DEVICE:                                 [35mwlan1[0m
-ACTIVE:                                 [35mnie[0m
-IN-USE:                                 [35m [0m
-DBUS-PATH:                              [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
-
-
 NAME:                                   [32mAP[1][0m
 SSID:                                   [32mwlan0-ap-2[0m
 SSID-HEX:                               [32m776C616E302D61702D32[0m
@@ -33874,6 +34011,25 @@ DEVICE:                                 [35mwlan0[0m
 ACTIVE:                                 [35mnie[0m
 IN-USE:                                 [35m [0m
 DBUS-PATH:                              [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m
+
+NAME:                                   [35mAP[1][0m
+SSID:                                   [35mwlan1-ap-4[0m
+SSID-HEX:                               [35m776C616E312D61702D34[0m
+BSSID:                                  [35m94:2B:E8:F6:D2:86[0m
+MODE:                                   [35mInfrastruktura[0m
+CHAN:                                   [35m1[0m
+FREQ:                                   [35m2412 MHz[0m
+RATE:                                   [35m54 Mb/s[0m
+SIGNAL:                                 [35m48[0m
+BARS:                                   [35m**  [0m
+SECURITY:                               [35mWPA1 WPA2[0m
+WPA-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
+RSN-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
+DEVICE:                                 [35mwlan1[0m
+ACTIVE:                                 [35mnie[0m
+IN-USE:                                 [35m [0m
+DBUS-PATH:                              [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
+
 
 <<<
 size: 1943
@@ -33883,16 +34039,6 @@ lang: C
 returncode: 0
 stdout: 1766 bytes
 >>>
-IN-USE:                                 [35m [0m
-SSID:                                   [35mwlan1-ap-4[0m
-MODE:                                   [35mInfra[0m
-CHAN:                                   [35m1[0m
-RATE:                                   [35m54 Mbit/s[0m
-SIGNAL:                                 [35m48[0m
-BARS:                                   [35m**  [0m
-SECURITY:                               [35mWPA1 WPA2[0m
-
-
 IN-USE:                                 [32m [0m
 SSID:                                   [32mwlan0-ap-2[0m
 MODE:                                   [32mInfra[0m
@@ -33917,6 +34063,16 @@ RATE:                                   [35m54 Mbit/s[0m
 SIGNAL:                                 [35m55[0m
 BARS:                                   [35m**  [0m
 SECURITY:                               [35mWPA1 WPA2[0m
+
+IN-USE:                                 [35m [0m
+SSID:                                   [35mwlan1-ap-4[0m
+MODE:                                   [35mInfra[0m
+CHAN:                                   [35m1[0m
+RATE:                                   [35m54 Mbit/s[0m
+SIGNAL:                                 [35m48[0m
+BARS:                                   [35m**  [0m
+SECURITY:                               [35mWPA1 WPA2[0m
+
 
 <<<
 size: 1989
@@ -33926,16 +34082,6 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 1802 bytes
 >>>
-IN-USE:                                 [35m [0m
-SSID:                                   [35mwlan1-ap-4[0m
-MODE:                                   [35mInfrastruktura[0m
-CHAN:                                   [35m1[0m
-RATE:                                   [35m54 Mb/s[0m
-SIGNAL:                                 [35m48[0m
-BARS:                                   [35m**  [0m
-SECURITY:                               [35mWPA1 WPA2[0m
-
-
 IN-USE:                                 [32m [0m
 SSID:                                   [32mwlan0-ap-2[0m
 MODE:                                   [32mInfrastruktura[0m
@@ -33960,6 +34106,16 @@ RATE:                                   [35m54 Mb/s[0m
 SIGNAL:                                 [35m55[0m
 BARS:                                   [35m**  [0m
 SECURITY:                               [35mWPA1 WPA2[0m
+
+IN-USE:                                 [35m [0m
+SSID:                                   [35mwlan1-ap-4[0m
+MODE:                                   [35mInfrastruktura[0m
+CHAN:                                   [35m1[0m
+RATE:                                   [35m54 Mb/s[0m
+SIGNAL:                                 [35m48[0m
+BARS:                                   [35m**  [0m
+SECURITY:                               [35mWPA1 WPA2[0m
+
 
 <<<
 size: 4621
@@ -33969,25 +34125,6 @@ lang: C
 returncode: 0
 stdout: 4334 bytes
 >>>
-NAME:                                   [35mAP[1][0m
-SSID:                                   [35mwlan1-ap-4[0m
-SSID-HEX:                               [35m776C616E312D61702D34[0m
-BSSID:                                  [35m94:2B:E8:F6:D2:86[0m
-MODE:                                   [35mInfra[0m
-CHAN:                                   [35m1[0m
-FREQ:                                   [35m2412 MHz[0m
-RATE:                                   [35m54 Mbit/s[0m
-SIGNAL:                                 [35m48[0m
-BARS:                                   [35m**  [0m
-SECURITY:                               [35mWPA1 WPA2[0m
-WPA-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
-RSN-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
-DEVICE:                                 [35mwlan1[0m
-ACTIVE:                                 [35mno[0m
-IN-USE:                                 [35m [0m
-DBUS-PATH:                              [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
-
-
 NAME:                                   [32mAP[1][0m
 SSID:                                   [32mwlan0-ap-2[0m
 SSID-HEX:                               [32m776C616E302D61702D32[0m
@@ -34039,6 +34176,25 @@ DEVICE:                                 [35mwlan0[0m
 ACTIVE:                                 [35mno[0m
 IN-USE:                                 [35m [0m
 DBUS-PATH:                              [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m
+
+NAME:                                   [35mAP[1][0m
+SSID:                                   [35mwlan1-ap-4[0m
+SSID-HEX:                               [35m776C616E312D61702D34[0m
+BSSID:                                  [35m94:2B:E8:F6:D2:86[0m
+MODE:                                   [35mInfra[0m
+CHAN:                                   [35m1[0m
+FREQ:                                   [35m2412 MHz[0m
+RATE:                                   [35m54 Mbit/s[0m
+SIGNAL:                                 [35m48[0m
+BARS:                                   [35m**  [0m
+SECURITY:                               [35mWPA1 WPA2[0m
+WPA-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
+RSN-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
+DEVICE:                                 [35mwlan1[0m
+ACTIVE:                                 [35mno[0m
+IN-USE:                                 [35m [0m
+DBUS-PATH:                              [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
+
 
 <<<
 size: 4679
@@ -34048,25 +34204,6 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 4382 bytes
 >>>
-NAME:                                   [35mAP[1][0m
-SSID:                                   [35mwlan1-ap-4[0m
-SSID-HEX:                               [35m776C616E312D61702D34[0m
-BSSID:                                  [35m94:2B:E8:F6:D2:86[0m
-MODE:                                   [35mInfrastruktura[0m
-CHAN:                                   [35m1[0m
-FREQ:                                   [35m2412 MHz[0m
-RATE:                                   [35m54 Mb/s[0m
-SIGNAL:                                 [35m48[0m
-BARS:                                   [35m**  [0m
-SECURITY:                               [35mWPA1 WPA2[0m
-WPA-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
-RSN-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
-DEVICE:                                 [35mwlan1[0m
-ACTIVE:                                 [35mnie[0m
-IN-USE:                                 [35m [0m
-DBUS-PATH:                              [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
-
-
 NAME:                                   [32mAP[1][0m
 SSID:                                   [32mwlan0-ap-2[0m
 SSID-HEX:                               [32m776C616E302D61702D32[0m
@@ -34119,13 +34256,32 @@ ACTIVE:                                 [35mnie[0m
 IN-USE:                                 [35m [0m
 DBUS-PATH:                              [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m
 
+NAME:                                   [35mAP[1][0m
+SSID:                                   [35mwlan1-ap-4[0m
+SSID-HEX:                               [35m776C616E312D61702D34[0m
+BSSID:                                  [35m94:2B:E8:F6:D2:86[0m
+MODE:                                   [35mInfrastruktura[0m
+CHAN:                                   [35m1[0m
+FREQ:                                   [35m2412 MHz[0m
+RATE:                                   [35m54 Mb/s[0m
+SIGNAL:                                 [35m48[0m
+BARS:                                   [35m**  [0m
+SECURITY:                               [35mWPA1 WPA2[0m
+WPA-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
+RSN-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
+DEVICE:                                 [35mwlan1[0m
+ACTIVE:                                 [35mnie[0m
+IN-USE:                                 [35m [0m
+DBUS-PATH:                              [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
+
+
 <<<
-size: 1281
+size: 1283
 location: clients/tests/test-client.py:1075:test_004()/655
 cmd: $NMCLI --mode multiline --color yes -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 1083 bytes
+stdout: 1085 bytes
 >>>
 NAME:                                   [32mAP[1][0m
 SSID:                                   [32mwlan0-ap-2[0m
@@ -34145,13 +34301,15 @@ ACTIVE:                                 [32mno[0m
 IN-USE:                                 [32m [0m
 DBUS-PATH:                              [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
 
+
+
 <<<
-size: 1303
+size: 1305
 location: clients/tests/test-client.py:1075:test_004()/656
 cmd: $NMCLI --mode multiline --color yes -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 1095 bytes
+stdout: 1097 bytes
 >>>
 NAME:                                   [32mAP[1][0m
 SSID:                                   [32mwlan0-ap-2[0m
@@ -34171,13 +34329,15 @@ ACTIVE:                                 [32mnie[0m
 IN-USE:                                 [32m [0m
 DBUS-PATH:                              [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
 
+
+
 <<<
-size: 641
+size: 643
 location: clients/tests/test-client.py:1077:test_004()/657
 cmd: $NMCLI --mode multiline --color yes -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 441 bytes
+stdout: 443 bytes
 >>>
 IN-USE:                                 [32m [0m
 SSID:                                   [32mwlan0-ap-2[0m
@@ -34188,13 +34348,15 @@ SIGNAL:                                 [32m92[0m
 BARS:                                   [32m****[0m
 SECURITY:                               [32mWPA1 WPA2[0m
 
+
+
 <<<
-size: 660
+size: 662
 location: clients/tests/test-client.py:1077:test_004()/658
 cmd: $NMCLI --mode multiline --color yes -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 450 bytes
+stdout: 452 bytes
 >>>
 IN-USE:                                 [32m [0m
 SSID:                                   [32mwlan0-ap-2[0m
@@ -34205,13 +34367,15 @@ SIGNAL:                                 [32m92[0m
 BARS:                                   [32m****[0m
 SECURITY:                               [32mWPA1 WPA2[0m
 
+
+
 <<<
-size: 1394
+size: 1396
 location: clients/tests/test-client.py:1080:test_004()/659
 cmd: $NMCLI --mode multiline --color yes -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 1083 bytes
+stdout: 1085 bytes
 >>>
 NAME:                                   [32mAP[1][0m
 SSID:                                   [32mwlan0-ap-2[0m
@@ -34231,13 +34395,15 @@ ACTIVE:                                 [32mno[0m
 IN-USE:                                 [32m [0m
 DBUS-PATH:                              [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
 
+
+
 <<<
-size: 1416
+size: 1418
 location: clients/tests/test-client.py:1080:test_004()/660
 cmd: $NMCLI --mode multiline --color yes -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 1095 bytes
+stdout: 1097 bytes
 >>>
 NAME:                                   [32mAP[1][0m
 SSID:                                   [32mwlan0-ap-2[0m
@@ -34256,6 +34422,8 @@ DEVICE:                                 [32mwlan0[0m
 ACTIVE:                                 [32mnie[0m
 IN-USE:                                 [32m [0m
 DBUS-PATH:                              [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
+
+
 
 <<<
 size: 5106
@@ -35462,6 +35630,11 @@ stdout: 1552 bytes
 ===============================================================================
                                Status of devices
 ===============================================================================
+DEVICE:                                 wlan0
+TYPE:                                   wifi
+STATE:                                  unavailable
+CONNECTION:                             con-vpn-1
+-------------------------------------------------------------------------------
 DEVICE:                                 eth0
 TYPE:                                   ethernet
 STATE:                                  unavailable
@@ -35481,11 +35654,6 @@ DEVICE:                                 wlan1
 TYPE:                                   wifi
 STATE:                                  unavailable
 CONNECTION:                             --
--------------------------------------------------------------------------------
-DEVICE:                                 wlan0
-TYPE:                                   wifi
-STATE:                                  unavailable
-CONNECTION:                             con-vpn-1
 -------------------------------------------------------------------------------
 
 <<<
@@ -35499,6 +35667,11 @@ stdout: 1557 bytes
 ===============================================================================
                                 Stan urządzenia
 ===============================================================================
+DEVICE:                                 wlan0
+TYPE:                                   wifi
+STATE:                                  niedostępne
+CONNECTION:                             con-vpn-1
+-------------------------------------------------------------------------------
 DEVICE:                                 eth0
 TYPE:                                   ethernet
 STATE:                                  niedostępne
@@ -35518,11 +35691,6 @@ DEVICE:                                 wlan1
 TYPE:                                   wifi
 STATE:                                  niedostępne
 CONNECTION:                             --
--------------------------------------------------------------------------------
-DEVICE:                                 wlan0
-TYPE:                                   wifi
-STATE:                                  niedostępne
-CONNECTION:                             con-vpn-1
 -------------------------------------------------------------------------------
 
 <<<
@@ -35536,6 +35704,16 @@ stdout: 2954 bytes
 ===============================================================================
                                Status of devices
 ===============================================================================
+DEVICE:                                 wlan0
+TYPE:                                   wifi
+STATE:                                  unavailable
+IP4-CONNECTIVITY:                       unknown
+IP6-CONNECTIVITY:                       unknown
+DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/3
+CONNECTION:                             con-vpn-1
+CON-UUID:                               UUID-con-vpn-1-REPLACED-REPLACED-REP
+CON-PATH:                               /org/freedesktop/NetworkManager/ActiveConnection/2
+-------------------------------------------------------------------------------
 DEVICE:                                 eth0
 TYPE:                                   ethernet
 STATE:                                  unavailable
@@ -35575,16 +35753,6 @@ DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/
 CONNECTION:                             --
 CON-UUID:                               --
 CON-PATH:                               --
--------------------------------------------------------------------------------
-DEVICE:                                 wlan0
-TYPE:                                   wifi
-STATE:                                  unavailable
-IP4-CONNECTIVITY:                       unknown
-IP6-CONNECTIVITY:                       unknown
-DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/3
-CONNECTION:                             con-vpn-1
-CON-UUID:                               UUID-con-vpn-1-REPLACED-REPLACED-REP
-CON-PATH:                               /org/freedesktop/NetworkManager/ActiveConnection/2
 -------------------------------------------------------------------------------
 
 <<<
@@ -35598,6 +35766,16 @@ stdout: 2969 bytes
 ===============================================================================
                                 Stan urządzenia
 ===============================================================================
+DEVICE:                                 wlan0
+TYPE:                                   wifi
+STATE:                                  niedostępne
+IP4-CONNECTIVITY:                       nieznane
+IP6-CONNECTIVITY:                       nieznane
+DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/3
+CONNECTION:                             con-vpn-1
+CON-UUID:                               UUID-con-vpn-1-REPLACED-REPLACED-REP
+CON-PATH:                               /org/freedesktop/NetworkManager/ActiveConnection/2
+-------------------------------------------------------------------------------
 DEVICE:                                 eth0
 TYPE:                                   ethernet
 STATE:                                  niedostępne
@@ -35638,16 +35816,6 @@ CONNECTION:                             --
 CON-UUID:                               --
 CON-PATH:                               --
 -------------------------------------------------------------------------------
-DEVICE:                                 wlan0
-TYPE:                                   wifi
-STATE:                                  niedostępne
-IP4-CONNECTIVITY:                       nieznane
-IP6-CONNECTIVITY:                       nieznane
-DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/3
-CONNECTION:                             con-vpn-1
-CON-UUID:                               UUID-con-vpn-1-REPLACED-REPLACED-REP
-CON-PATH:                               /org/freedesktop/NetworkManager/ActiveConnection/2
--------------------------------------------------------------------------------
 
 <<<
 size: 12890
@@ -35657,6 +35825,43 @@ lang: C
 returncode: 0
 stdout: 12733 bytes
 >>>
+===============================================================================
+                            Device details (wlan0)
+===============================================================================
+GENERAL.DEVICE:                         wlan0
+-------------------------------------------------------------------------------
+GENERAL.TYPE:                           wifi
+-------------------------------------------------------------------------------
+GENERAL.HWADDR:                         13:E0:74:85:7C:D9
+-------------------------------------------------------------------------------
+GENERAL.MTU:                            0
+-------------------------------------------------------------------------------
+GENERAL.STATE:                          20 (unavailable)
+-------------------------------------------------------------------------------
+GENERAL.CONNECTION:                     con-vpn-1
+-------------------------------------------------------------------------------
+GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
+-------------------------------------------------------------------------------
+IP4.ADDRESS[1]:                         192.168.228.18/32
+IP4.ADDRESS[2]:                         192.168.209.179/25
+IP4.GATEWAY:                            192.168.41.120
+IP4.DOMAIN[1]:                          sear4.foo2.bar
+IP4.DOMAIN[2]:                          sear4.fo.x.y
+IP4.DOMAIN[3]:                          sear4.foo1.bar
+IP4.DOMAIN[4]:                          sear4.foo4.bar
+IP4.DOMAIN[5]:                          sear4.fo.o.bar
+IP4.WINS[1]:                            192.168.120.79
+-------------------------------------------------------------------------------
+IP6.GATEWAY:                            --
+IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
+IP6.DOMAIN[1]:                          sear6.foo2.bar
+IP6.DOMAIN[2]:                          sear6.foo1.bar
+IP6.DOMAIN[3]:                          sear6.fo.x.y
+IP6.DOMAIN[4]:                          sear6.fo.o.bar
+IP6.DOMAIN[5]:                          sear6.foo3.bar
+IP6.DOMAIN[6]:                          sear6.foo4.bar
+-------------------------------------------------------------------------------
+
 ===============================================================================
                              Device details (eth0)
 ===============================================================================
@@ -35820,8 +36025,16 @@ IP6.DNS[1]:                             2001:a::2934:bd66:550d:ec19
 IP6.DOMAIN[1]:                          sear6.fo.x.y
 -------------------------------------------------------------------------------
 
+<<<
+size: 12954
+location: clients/tests/test-client.py:1047:test_004()/682
+cmd: $NMCLI --mode multiline --pretty dev show
+lang: pl_PL.UTF-8
+returncode: 0
+stdout: 12787 bytes
+>>>
 ===============================================================================
-                            Device details (wlan0)
+                        Informacje o urządzeniu (wlan0)
 ===============================================================================
 GENERAL.DEVICE:                         wlan0
 -------------------------------------------------------------------------------
@@ -35831,7 +36044,7 @@ GENERAL.HWADDR:                         13:E0:74:85:7C:D9
 -------------------------------------------------------------------------------
 GENERAL.MTU:                            0
 -------------------------------------------------------------------------------
-GENERAL.STATE:                          20 (unavailable)
+GENERAL.STATE:                          20 (niedostępne)
 -------------------------------------------------------------------------------
 GENERAL.CONNECTION:                     con-vpn-1
 -------------------------------------------------------------------------------
@@ -35857,14 +36070,6 @@ IP6.DOMAIN[5]:                          sear6.foo3.bar
 IP6.DOMAIN[6]:                          sear6.foo4.bar
 -------------------------------------------------------------------------------
 
-<<<
-size: 12954
-location: clients/tests/test-client.py:1047:test_004()/682
-cmd: $NMCLI --mode multiline --pretty dev show
-lang: pl_PL.UTF-8
-returncode: 0
-stdout: 12787 bytes
->>>
 ===============================================================================
                         Informacje o urządzeniu (eth0)
 ===============================================================================
@@ -36028,43 +36233,6 @@ IP6.DNS[1]:                             2001:a::2934:bd66:550d:ec19
 IP6.DOMAIN[1]:                          sear6.fo.x.y
 -------------------------------------------------------------------------------
 
-===============================================================================
-                        Informacje o urządzeniu (wlan0)
-===============================================================================
-GENERAL.DEVICE:                         wlan0
--------------------------------------------------------------------------------
-GENERAL.TYPE:                           wifi
--------------------------------------------------------------------------------
-GENERAL.HWADDR:                         13:E0:74:85:7C:D9
--------------------------------------------------------------------------------
-GENERAL.MTU:                            0
--------------------------------------------------------------------------------
-GENERAL.STATE:                          20 (niedostępne)
--------------------------------------------------------------------------------
-GENERAL.CONNECTION:                     con-vpn-1
--------------------------------------------------------------------------------
-GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
--------------------------------------------------------------------------------
-IP4.ADDRESS[1]:                         192.168.228.18/32
-IP4.ADDRESS[2]:                         192.168.209.179/25
-IP4.GATEWAY:                            192.168.41.120
-IP4.DOMAIN[1]:                          sear4.foo2.bar
-IP4.DOMAIN[2]:                          sear4.fo.x.y
-IP4.DOMAIN[3]:                          sear4.foo1.bar
-IP4.DOMAIN[4]:                          sear4.foo4.bar
-IP4.DOMAIN[5]:                          sear4.fo.o.bar
-IP4.WINS[1]:                            192.168.120.79
--------------------------------------------------------------------------------
-IP6.GATEWAY:                            --
-IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
-IP6.DOMAIN[1]:                          sear6.foo2.bar
-IP6.DOMAIN[2]:                          sear6.foo1.bar
-IP6.DOMAIN[3]:                          sear6.fo.x.y
-IP6.DOMAIN[4]:                          sear6.fo.o.bar
-IP6.DOMAIN[5]:                          sear6.foo3.bar
-IP6.DOMAIN[6]:                          sear6.foo4.bar
--------------------------------------------------------------------------------
-
 <<<
 size: 25272
 location: clients/tests/test-client.py:1050:test_004()/683
@@ -36073,340 +36241,6 @@ lang: C
 returncode: 0
 stdout: 25108 bytes
 >>>
-===============================================================================
-                             Device details (eth0)
-===============================================================================
-GENERAL.DEVICE:                         eth0
-GENERAL.TYPE:                           ethernet
-GENERAL.NM-TYPE:                        NMDeviceEthernet
-GENERAL.VENDOR:                         --
-GENERAL.PRODUCT:                        --
-GENERAL.DRIVER:                         virtual
-GENERAL.DRIVER-VERSION:                 --
-GENERAL.FIRMWARE-VERSION:               --
-GENERAL.HWADDR:                         AB:B7:BF:E2:48:E8
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (unavailable)
-GENERAL.REASON:                         0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:               0 (unknown)
-GENERAL.IP6-CONNECTIVITY:               0 (unknown)
-GENERAL.UDI:                            /sys/devices/virtual/eth0
-GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    no
-GENERAL.NM-MANAGED:                     yes
-GENERAL.AUTOCONNECT:                    yes
-GENERAL.FIRMWARE-MISSING:               no
-GENERAL.NM-PLUGIN-MISSING:              no
-GENERAL.PHYS-PORT-ID:                   --
-GENERAL.CONNECTION:                     --
-GENERAL.CON-UUID:                       --
-GENERAL.CON-PATH:                       --
-GENERAL.METERED:                        unknown
--------------------------------------------------------------------------------
-CAPABILITIES.CARRIER-DETECT:            no
-CAPABILITIES.SPEED:                     100 Mb/s
-CAPABILITIES.IS-SOFTWARE:               no
-CAPABILITIES.SRIOV:                     no
--------------------------------------------------------------------------------
-WIRED-PROPERTIES.CARRIER:               off
--------------------------------------------------------------------------------
-IP4.ADDRESS[1]:                         192.168.49.34/22
-IP4.ADDRESS[2]:                         192.168.135.86/19
-IP4.GATEWAY:                            --
-IP4.DNS[1]:                             192.168.45.230
-IP4.DNS[2]:                             192.168.180.201
-IP4.DNS[3]:                             192.168.253.2
-IP4.DOMAIN[1]:                          sear4.foo2.bar
-IP4.DOMAIN[2]:                          sear4.foo1.bar
-IP4.WINS[1]:                            192.168.163.23
-IP4.WINS[2]:                            192.168.151.246
--------------------------------------------------------------------------------
-DHCP4.OPTION[1]:                        dhcp-4-opt-8 = val-8
-DHCP4.OPTION[2]:                        dhcp-4-opt-9 = val-9
--------------------------------------------------------------------------------
-IP6.ADDRESS[1]:                         2001:a::ed81:3d7:c2e9:df82/99
-IP6.GATEWAY:                            --
-IP6.DNS[1]:                             2001:a::2703:f06:9619:d89f
-IP6.DNS[2]:                             2001:a::3a75:3682:c683:8541
-IP6.DNS[3]:                             2001:a::584e:912:d5ee:c74f
-IP6.DOMAIN[1]:                          sear6.foo4.bar
-IP6.DOMAIN[2]:                          sear6.fo.o.bar
--------------------------------------------------------------------------------
-DHCP6.OPTION[1]:                        dhcp-6-opt-0 = val-0
-DHCP6.OPTION[2]:                        dhcp-6-opt-1 = val-1
-DHCP6.OPTION[3]:                        dhcp-6-opt-2 = val-2
-DHCP6.OPTION[4]:                        dhcp-6-opt-3 = val-3
-DHCP6.OPTION[5]:                        dhcp-6-opt-4 = val-4
-DHCP6.OPTION[6]:                        dhcp-6-opt-5 = val-5
-DHCP6.OPTION[7]:                        dhcp-6-opt-6 = val-6
-DHCP6.OPTION[8]:                        dhcp-6-opt-7 = val-7
-DHCP6.OPTION[9]:                        dhcp-6-opt-8 = val-8
-DHCP6.OPTION[10]:                       dhcp-6-opt-9 = val-9
--------------------------------------------------------------------------------
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{1}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   5fcfd6d7-1e63-3332-8826-a7eda103792d | con-1
--------------------------------------------------------------------------------
-
-===============================================================================
-                             Device details (eth1)
-===============================================================================
-GENERAL.DEVICE:                         eth1
-GENERAL.TYPE:                           ethernet
-GENERAL.NM-TYPE:                        NMDeviceEthernet
-GENERAL.VENDOR:                         --
-GENERAL.PRODUCT:                        --
-GENERAL.DRIVER:                         virtual
-GENERAL.DRIVER-VERSION:                 --
-GENERAL.FIRMWARE-VERSION:               --
-GENERAL.HWADDR:                         E7:78:B1:93:2B:22
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (unavailable)
-GENERAL.REASON:                         0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:               0 (unknown)
-GENERAL.IP6-CONNECTIVITY:               0 (unknown)
-GENERAL.UDI:                            /sys/devices/virtual/eth1
-GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    no
-GENERAL.NM-MANAGED:                     yes
-GENERAL.AUTOCONNECT:                    yes
-GENERAL.FIRMWARE-MISSING:               no
-GENERAL.NM-PLUGIN-MISSING:              no
-GENERAL.PHYS-PORT-ID:                   --
-GENERAL.CONNECTION:                     --
-GENERAL.CON-UUID:                       --
-GENERAL.CON-PATH:                       --
-GENERAL.METERED:                        unknown
--------------------------------------------------------------------------------
-CAPABILITIES.CARRIER-DETECT:            no
-CAPABILITIES.SPEED:                     100 Mb/s
-CAPABILITIES.IS-SOFTWARE:               no
-CAPABILITIES.SRIOV:                     no
--------------------------------------------------------------------------------
-WIRED-PROPERTIES.CARRIER:               off
--------------------------------------------------------------------------------
-IP4.ADDRESS[1]:                         192.168.127.210/25
-IP4.GATEWAY:                            192.168.88.4
-IP4.ROUTE[1]:                           dst = 192.168.222.35/19, nh = 192.168.170.142, mt = 3609264321
-IP4.ROUTE[2]:                           dst = 192.168.135.81/32, nh = 192.168.32.11, mt = 1316413247
-IP4.ROUTE[3]:                           dst = 192.168.24.65/26, nh = 192.168.23.163, mt = 3855574583
-IP4.DNS[1]:                             192.168.16.144
-IP4.DNS[2]:                             192.168.79.53
-IP4.DNS[3]:                             192.168.237.155
-IP4.DOMAIN[1]:                          sear4.foo4.bar
-IP4.DOMAIN[2]:                          sear4.foo3.bar
-IP4.DOMAIN[3]:                          sear4.foo1.bar
-IP4.WINS[1]:                            192.168.211.91
-IP4.WINS[2]:                            192.168.58.182
-IP4.WINS[3]:                            192.168.114.97
--------------------------------------------------------------------------------
-DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:                        dhcp-4-opt-1 = val-1
-DHCP4.OPTION[3]:                        dhcp-4-opt-2 = val-2
-DHCP4.OPTION[4]:                        dhcp-4-opt-3 = val-3
-DHCP4.OPTION[5]:                        dhcp-4-opt-4 = val-4
-DHCP4.OPTION[6]:                        dhcp-4-opt-5 = val-5
-DHCP4.OPTION[7]:                        dhcp-4-opt-7 = val-7
-DHCP4.OPTION[8]:                        dhcp-4-opt-8 = val-8
-DHCP4.OPTION[9]:                        dhcp-4-opt-9 = val-9
--------------------------------------------------------------------------------
-IP6.ADDRESS[1]:                         2001:a::1c1:c178:169f:2b80/93
-IP6.ADDRESS[2]:                         2001:a::1f79:e0fb:87b9:3cc6/123
-IP6.GATEWAY:                            --
-IP6.ROUTE[1]:                           dst = 2001:a::3166:7ed1:e4ae:7612/123, nh = ::
-IP6.DNS[1]:                             2001:a::edda:955:dcf4:23d4
-IP6.DNS[2]:                             2001:a::109f:aa0f:fb4a:9d5a
-IP6.DNS[3]:                             2001:a::61cf:7c82:e9c0:c952
-IP6.DOMAIN[1]:                          sear6.foo1.bar
--------------------------------------------------------------------------------
-DHCP6.OPTION[1]:                        dhcp-6-opt-2 = val-2
-DHCP6.OPTION[2]:                        dhcp-6-opt-5 = val-5
-DHCP6.OPTION[3]:                        dhcp-6-opt-6 = val-6
-DHCP6.OPTION[4]:                        dhcp-6-opt-8 = val-8
-DHCP6.OPTION[5]:                        dhcp-6-opt-9 = val-9
--------------------------------------------------------------------------------
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{1}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   5fcfd6d7-1e63-3332-8826-a7eda103792d | con-1
--------------------------------------------------------------------------------
-
-===============================================================================
-                            Device details (wlan1)
-===============================================================================
-GENERAL.DEVICE:                         wlan1
-GENERAL.TYPE:                           wifi
-GENERAL.NM-TYPE:                        NMDeviceWifi
-GENERAL.VENDOR:                         --
-GENERAL.PRODUCT:                        --
-GENERAL.DRIVER:                         virtual
-GENERAL.DRIVER-VERSION:                 --
-GENERAL.FIRMWARE-VERSION:               --
-GENERAL.HWADDR:                         21:E9:64:81:8C:A8
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (unavailable)
-GENERAL.REASON:                         0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:               0 (unknown)
-GENERAL.IP6-CONNECTIVITY:               0 (unknown)
-GENERAL.UDI:                            /sys/devices/virtual/wlan1
-GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    no
-GENERAL.NM-MANAGED:                     yes
-GENERAL.AUTOCONNECT:                    yes
-GENERAL.FIRMWARE-MISSING:               no
-GENERAL.NM-PLUGIN-MISSING:              no
-GENERAL.PHYS-PORT-ID:                   --
-GENERAL.CONNECTION:                     --
-GENERAL.CON-UUID:                       --
-GENERAL.CON-PATH:                       --
-GENERAL.METERED:                        unknown
--------------------------------------------------------------------------------
-CAPABILITIES.CARRIER-DETECT:            no
-CAPABILITIES.SPEED:                     unknown
-CAPABILITIES.IS-SOFTWARE:               no
-CAPABILITIES.SRIOV:                     no
--------------------------------------------------------------------------------
-WIFI-PROPERTIES.WEP:                    yes
-WIFI-PROPERTIES.WPA:                    yes
-WIFI-PROPERTIES.WPA2:                   yes
-WIFI-PROPERTIES.TKIP:                   yes
-WIFI-PROPERTIES.CCMP:                   yes
-WIFI-PROPERTIES.AP:                     yes
-WIFI-PROPERTIES.ADHOC:                  yes
-WIFI-PROPERTIES.2GHZ:                   unknown
-WIFI-PROPERTIES.5GHZ:                   unknown
--------------------------------------------------------------------------------
-AP[1].IN-USE:                            
-AP[1].SSID:                             wlan1-ap-4
-AP[1].MODE:                             Infra
-AP[1].CHAN:                             1
-AP[1].RATE:                             54 Mbit/s
-AP[1].SIGNAL:                           48
-AP[1].BARS:                             **  
-AP[1].SECURITY:                         WPA1 WPA2
--------------------------------------------------------------------------------
-IP4.GATEWAY:                            192.168.57.160
-IP4.ROUTE[1]:                           dst = 192.168.36.106/21, nh = 192.168.199.128, mt = 979274165
-IP4.ROUTE[2]:                           dst = 192.168.238.130/19, nh = 0.0.0.0
-IP4.ROUTE[3]:                           dst = 192.168.224.39/32, nh = 192.168.148.69
-IP4.DNS[1]:                             192.168.61.83
-IP4.DOMAIN[1]:                          sear4.foo4.bar
-IP4.DOMAIN[2]:                          sear4.fo.x.y
-IP4.DOMAIN[3]:                          sear4.foo2.bar
-IP4.DOMAIN[4]:                          sear4.foo1.bar
-IP4.DOMAIN[5]:                          sear4.fo.o.bar
-IP4.DOMAIN[6]:                          sear4.foo3.bar
--------------------------------------------------------------------------------
-DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:                        dhcp-4-opt-1 = val-1
-DHCP4.OPTION[3]:                        dhcp-4-opt-2 = val-2
-DHCP4.OPTION[4]:                        dhcp-4-opt-4 = val-4
-DHCP4.OPTION[5]:                        dhcp-4-opt-6 = val-6
-DHCP4.OPTION[6]:                        dhcp-4-opt-7 = val-7
-DHCP4.OPTION[7]:                        dhcp-4-opt-8 = val-8
-DHCP4.OPTION[8]:                        dhcp-4-opt-9 = val-9
--------------------------------------------------------------------------------
-IP6.ADDRESS[1]:                         2001:a::fa05:2ab4:9300:e8fe/116
-IP6.ADDRESS[2]:                         2001:a::e9cf:bd3:caba:99b3/86
-IP6.ADDRESS[3]:                         2001:a::2be6:44fa:2c95:5559/78
-IP6.GATEWAY:                            2001:a::4d70:d91a:770f:2319
-IP6.ROUTE[1]:                           dst = 2001:a::3cb2:719d:bb00:b22f/66, nh = 2001:a::81b1:58b9:7237:3511, mt = 2280277732
-IP6.ROUTE[2]:                           dst = 2001:a::986f:983c:5eb:1c7d/99, nh = ::, mt = 1204008676
-IP6.DNS[1]:                             2001:a::85e7:3d7d:53e8:50ac
-IP6.DNS[2]:                             2001:a::1c5:9cb5:e86d:25a5
-IP6.DOMAIN[1]:                          sear6.foo4.bar
-IP6.DOMAIN[2]:                          sear6.foo2.bar
--------------------------------------------------------------------------------
-DHCP6.OPTION[1]:                        dhcp-6-opt-0 = val-0
-DHCP6.OPTION[2]:                        dhcp-6-opt-1 = val-1
-DHCP6.OPTION[3]:                        dhcp-6-opt-2 = val-2
-DHCP6.OPTION[4]:                        dhcp-6-opt-3 = val-3
-DHCP6.OPTION[5]:                        dhcp-6-opt-4 = val-4
-DHCP6.OPTION[6]:                        dhcp-6-opt-5 = val-5
-DHCP6.OPTION[7]:                        dhcp-6-opt-6 = val-6
-DHCP6.OPTION[8]:                        dhcp-6-opt-7 = val-7
-DHCP6.OPTION[9]:                        dhcp-6-opt-9 = val-9
--------------------------------------------------------------------------------
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
--------------------------------------------------------------------------------
-
-===============================================================================
-                            Device details (wlan1)
-===============================================================================
-GENERAL.DEVICE:                         wlan1
-GENERAL.TYPE:                           wifi
-GENERAL.NM-TYPE:                        NMDeviceWifi
-GENERAL.VENDOR:                         --
-GENERAL.PRODUCT:                        --
-GENERAL.DRIVER:                         virtual
-GENERAL.DRIVER-VERSION:                 --
-GENERAL.FIRMWARE-VERSION:               --
-GENERAL.HWADDR:                         71:52:AD:63:5C:7C
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (unavailable)
-GENERAL.REASON:                         0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:               0 (unknown)
-GENERAL.IP6-CONNECTIVITY:               0 (unknown)
-GENERAL.UDI:                            /sys/devices/virtual/wlan1
-GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    no
-GENERAL.NM-MANAGED:                     yes
-GENERAL.AUTOCONNECT:                    yes
-GENERAL.FIRMWARE-MISSING:               no
-GENERAL.NM-PLUGIN-MISSING:              no
-GENERAL.PHYS-PORT-ID:                   --
-GENERAL.CONNECTION:                     --
-GENERAL.CON-UUID:                       --
-GENERAL.CON-PATH:                       --
-GENERAL.METERED:                        unknown
--------------------------------------------------------------------------------
-CAPABILITIES.CARRIER-DETECT:            no
-CAPABILITIES.SPEED:                     unknown
-CAPABILITIES.IS-SOFTWARE:               no
-CAPABILITIES.SRIOV:                     no
--------------------------------------------------------------------------------
-WIFI-PROPERTIES.WEP:                    yes
-WIFI-PROPERTIES.WPA:                    yes
-WIFI-PROPERTIES.WPA2:                   yes
-WIFI-PROPERTIES.TKIP:                   yes
-WIFI-PROPERTIES.CCMP:                   yes
-WIFI-PROPERTIES.AP:                     yes
-WIFI-PROPERTIES.ADHOC:                  yes
-WIFI-PROPERTIES.2GHZ:                   unknown
-WIFI-PROPERTIES.5GHZ:                   unknown
--------------------------------------------------------------------------------
-IP4.ADDRESS[1]:                         192.168.97.124/29
-IP4.ADDRESS[2]:                         192.168.76.154/18
-IP4.GATEWAY:                            --
-IP4.ROUTE[1]:                           dst = 192.168.33.233/22, nh = 192.168.222.210, mt = 2810496551
-IP4.DNS[1]:                             192.168.107.109
-IP4.DOMAIN[1]:                          sear4.fo.o.bar
-IP4.DOMAIN[2]:                          sear4.fo.x.y
-IP4.DOMAIN[3]:                          sear4.foo2.bar
-IP4.DOMAIN[4]:                          sear4.foo3.bar
-IP4.DOMAIN[5]:                          sear4.foo4.bar
-IP4.WINS[1]:                            192.168.60.60
-IP4.WINS[2]:                            192.168.63.92
--------------------------------------------------------------------------------
-DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:                        dhcp-4-opt-5 = val-5
--------------------------------------------------------------------------------
-IP6.ADDRESS[1]:                         2001:a::88ca:3654:96b:ab44/89
-IP6.GATEWAY:                            --
-IP6.ROUTE[1]:                           dst = 2001:a::cc8b:7c09:4673:bbb0/85, nh = ::, mt = 2821465568
-IP6.ROUTE[2]:                           dst = 2001:a::a976:2488:f49f:b48/106, nh = 2001:a::62ae:c734:fc7b:e931, mt = 2248613879
-IP6.ROUTE[3]:                           dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::
-IP6.DNS[1]:                             2001:a::2934:bd66:550d:ec19
-IP6.DOMAIN[1]:                          sear6.fo.x.y
--------------------------------------------------------------------------------
-DHCP6.OPTION[1]:                        dhcp-6-opt-2 = val-2
-DHCP6.OPTION[2]:                        dhcp-6-opt-6 = val-6
-DHCP6.OPTION[3]:                        dhcp-6-opt-7 = val-7
-DHCP6.OPTION[4]:                        dhcp-6-opt-8 = val-8
-DHCP6.OPTION[5]:                        dhcp-6-opt-9 = val-9
--------------------------------------------------------------------------------
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
--------------------------------------------------------------------------------
-
 ===============================================================================
                             Device details (wlan0)
 ===============================================================================
@@ -36513,6 +36347,340 @@ CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 -------------------------------------------------------------------------------
 
+===============================================================================
+                             Device details (eth0)
+===============================================================================
+GENERAL.DEVICE:                         eth0
+GENERAL.TYPE:                           ethernet
+GENERAL.NM-TYPE:                        NMDeviceEthernet
+GENERAL.VENDOR:                         --
+GENERAL.PRODUCT:                        --
+GENERAL.DRIVER:                         virtual
+GENERAL.DRIVER-VERSION:                 --
+GENERAL.FIRMWARE-VERSION:               --
+GENERAL.HWADDR:                         AB:B7:BF:E2:48:E8
+GENERAL.MTU:                            0
+GENERAL.STATE:                          20 (unavailable)
+GENERAL.REASON:                         0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:               0 (unknown)
+GENERAL.IP6-CONNECTIVITY:               0 (unknown)
+GENERAL.UDI:                            /sys/devices/virtual/eth0
+GENERAL.IP-IFACE:                       --
+GENERAL.IS-SOFTWARE:                    no
+GENERAL.NM-MANAGED:                     yes
+GENERAL.AUTOCONNECT:                    yes
+GENERAL.FIRMWARE-MISSING:               no
+GENERAL.NM-PLUGIN-MISSING:              no
+GENERAL.PHYS-PORT-ID:                   --
+GENERAL.CONNECTION:                     --
+GENERAL.CON-UUID:                       --
+GENERAL.CON-PATH:                       --
+GENERAL.METERED:                        unknown
+-------------------------------------------------------------------------------
+CAPABILITIES.CARRIER-DETECT:            no
+CAPABILITIES.SPEED:                     100 Mb/s
+CAPABILITIES.IS-SOFTWARE:               no
+CAPABILITIES.SRIOV:                     no
+-------------------------------------------------------------------------------
+WIRED-PROPERTIES.CARRIER:               off
+-------------------------------------------------------------------------------
+IP4.ADDRESS[1]:                         192.168.49.34/22
+IP4.ADDRESS[2]:                         192.168.135.86/19
+IP4.GATEWAY:                            --
+IP4.DNS[1]:                             192.168.45.230
+IP4.DNS[2]:                             192.168.180.201
+IP4.DNS[3]:                             192.168.253.2
+IP4.DOMAIN[1]:                          sear4.foo2.bar
+IP4.DOMAIN[2]:                          sear4.foo1.bar
+IP4.WINS[1]:                            192.168.163.23
+IP4.WINS[2]:                            192.168.151.246
+-------------------------------------------------------------------------------
+DHCP4.OPTION[1]:                        dhcp-4-opt-8 = val-8
+DHCP4.OPTION[2]:                        dhcp-4-opt-9 = val-9
+-------------------------------------------------------------------------------
+IP6.ADDRESS[1]:                         2001:a::ed81:3d7:c2e9:df82/99
+IP6.GATEWAY:                            --
+IP6.DNS[1]:                             2001:a::2703:f06:9619:d89f
+IP6.DNS[2]:                             2001:a::3a75:3682:c683:8541
+IP6.DNS[3]:                             2001:a::584e:912:d5ee:c74f
+IP6.DOMAIN[1]:                          sear6.foo4.bar
+IP6.DOMAIN[2]:                          sear6.fo.o.bar
+-------------------------------------------------------------------------------
+DHCP6.OPTION[1]:                        dhcp-6-opt-0 = val-0
+DHCP6.OPTION[2]:                        dhcp-6-opt-1 = val-1
+DHCP6.OPTION[3]:                        dhcp-6-opt-2 = val-2
+DHCP6.OPTION[4]:                        dhcp-6-opt-3 = val-3
+DHCP6.OPTION[5]:                        dhcp-6-opt-4 = val-4
+DHCP6.OPTION[6]:                        dhcp-6-opt-5 = val-5
+DHCP6.OPTION[7]:                        dhcp-6-opt-6 = val-6
+DHCP6.OPTION[8]:                        dhcp-6-opt-7 = val-7
+DHCP6.OPTION[9]:                        dhcp-6-opt-8 = val-8
+DHCP6.OPTION[10]:                       dhcp-6-opt-9 = val-9
+-------------------------------------------------------------------------------
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{1}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   5fcfd6d7-1e63-3332-8826-a7eda103792d | con-1
+-------------------------------------------------------------------------------
+
+===============================================================================
+                             Device details (eth1)
+===============================================================================
+GENERAL.DEVICE:                         eth1
+GENERAL.TYPE:                           ethernet
+GENERAL.NM-TYPE:                        NMDeviceEthernet
+GENERAL.VENDOR:                         --
+GENERAL.PRODUCT:                        --
+GENERAL.DRIVER:                         virtual
+GENERAL.DRIVER-VERSION:                 --
+GENERAL.FIRMWARE-VERSION:               --
+GENERAL.HWADDR:                         E7:78:B1:93:2B:22
+GENERAL.MTU:                            0
+GENERAL.STATE:                          20 (unavailable)
+GENERAL.REASON:                         0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:               0 (unknown)
+GENERAL.IP6-CONNECTIVITY:               0 (unknown)
+GENERAL.UDI:                            /sys/devices/virtual/eth1
+GENERAL.IP-IFACE:                       --
+GENERAL.IS-SOFTWARE:                    no
+GENERAL.NM-MANAGED:                     yes
+GENERAL.AUTOCONNECT:                    yes
+GENERAL.FIRMWARE-MISSING:               no
+GENERAL.NM-PLUGIN-MISSING:              no
+GENERAL.PHYS-PORT-ID:                   --
+GENERAL.CONNECTION:                     --
+GENERAL.CON-UUID:                       --
+GENERAL.CON-PATH:                       --
+GENERAL.METERED:                        unknown
+-------------------------------------------------------------------------------
+CAPABILITIES.CARRIER-DETECT:            no
+CAPABILITIES.SPEED:                     100 Mb/s
+CAPABILITIES.IS-SOFTWARE:               no
+CAPABILITIES.SRIOV:                     no
+-------------------------------------------------------------------------------
+WIRED-PROPERTIES.CARRIER:               off
+-------------------------------------------------------------------------------
+IP4.ADDRESS[1]:                         192.168.127.210/25
+IP4.GATEWAY:                            192.168.88.4
+IP4.ROUTE[1]:                           dst = 192.168.222.35/19, nh = 192.168.170.142, mt = 3609264321
+IP4.ROUTE[2]:                           dst = 192.168.135.81/32, nh = 192.168.32.11, mt = 1316413247
+IP4.ROUTE[3]:                           dst = 192.168.24.65/26, nh = 192.168.23.163, mt = 3855574583
+IP4.DNS[1]:                             192.168.16.144
+IP4.DNS[2]:                             192.168.79.53
+IP4.DNS[3]:                             192.168.237.155
+IP4.DOMAIN[1]:                          sear4.foo4.bar
+IP4.DOMAIN[2]:                          sear4.foo3.bar
+IP4.DOMAIN[3]:                          sear4.foo1.bar
+IP4.WINS[1]:                            192.168.211.91
+IP4.WINS[2]:                            192.168.58.182
+IP4.WINS[3]:                            192.168.114.97
+-------------------------------------------------------------------------------
+DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:                        dhcp-4-opt-1 = val-1
+DHCP4.OPTION[3]:                        dhcp-4-opt-2 = val-2
+DHCP4.OPTION[4]:                        dhcp-4-opt-3 = val-3
+DHCP4.OPTION[5]:                        dhcp-4-opt-4 = val-4
+DHCP4.OPTION[6]:                        dhcp-4-opt-5 = val-5
+DHCP4.OPTION[7]:                        dhcp-4-opt-7 = val-7
+DHCP4.OPTION[8]:                        dhcp-4-opt-8 = val-8
+DHCP4.OPTION[9]:                        dhcp-4-opt-9 = val-9
+-------------------------------------------------------------------------------
+IP6.ADDRESS[1]:                         2001:a::1c1:c178:169f:2b80/93
+IP6.ADDRESS[2]:                         2001:a::1f79:e0fb:87b9:3cc6/123
+IP6.GATEWAY:                            --
+IP6.ROUTE[1]:                           dst = 2001:a::3166:7ed1:e4ae:7612/123, nh = ::
+IP6.DNS[1]:                             2001:a::edda:955:dcf4:23d4
+IP6.DNS[2]:                             2001:a::109f:aa0f:fb4a:9d5a
+IP6.DNS[3]:                             2001:a::61cf:7c82:e9c0:c952
+IP6.DOMAIN[1]:                          sear6.foo1.bar
+-------------------------------------------------------------------------------
+DHCP6.OPTION[1]:                        dhcp-6-opt-2 = val-2
+DHCP6.OPTION[2]:                        dhcp-6-opt-5 = val-5
+DHCP6.OPTION[3]:                        dhcp-6-opt-6 = val-6
+DHCP6.OPTION[4]:                        dhcp-6-opt-8 = val-8
+DHCP6.OPTION[5]:                        dhcp-6-opt-9 = val-9
+-------------------------------------------------------------------------------
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{1}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   5fcfd6d7-1e63-3332-8826-a7eda103792d | con-1
+-------------------------------------------------------------------------------
+
+===============================================================================
+                            Device details (wlan1)
+===============================================================================
+GENERAL.DEVICE:                         wlan1
+GENERAL.TYPE:                           wifi
+GENERAL.NM-TYPE:                        NMDeviceWifi
+GENERAL.VENDOR:                         --
+GENERAL.PRODUCT:                        --
+GENERAL.DRIVER:                         virtual
+GENERAL.DRIVER-VERSION:                 --
+GENERAL.FIRMWARE-VERSION:               --
+GENERAL.HWADDR:                         21:E9:64:81:8C:A8
+GENERAL.MTU:                            0
+GENERAL.STATE:                          20 (unavailable)
+GENERAL.REASON:                         0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:               0 (unknown)
+GENERAL.IP6-CONNECTIVITY:               0 (unknown)
+GENERAL.UDI:                            /sys/devices/virtual/wlan1
+GENERAL.IP-IFACE:                       --
+GENERAL.IS-SOFTWARE:                    no
+GENERAL.NM-MANAGED:                     yes
+GENERAL.AUTOCONNECT:                    yes
+GENERAL.FIRMWARE-MISSING:               no
+GENERAL.NM-PLUGIN-MISSING:              no
+GENERAL.PHYS-PORT-ID:                   --
+GENERAL.CONNECTION:                     --
+GENERAL.CON-UUID:                       --
+GENERAL.CON-PATH:                       --
+GENERAL.METERED:                        unknown
+-------------------------------------------------------------------------------
+CAPABILITIES.CARRIER-DETECT:            no
+CAPABILITIES.SPEED:                     unknown
+CAPABILITIES.IS-SOFTWARE:               no
+CAPABILITIES.SRIOV:                     no
+-------------------------------------------------------------------------------
+WIFI-PROPERTIES.WEP:                    yes
+WIFI-PROPERTIES.WPA:                    yes
+WIFI-PROPERTIES.WPA2:                   yes
+WIFI-PROPERTIES.TKIP:                   yes
+WIFI-PROPERTIES.CCMP:                   yes
+WIFI-PROPERTIES.AP:                     yes
+WIFI-PROPERTIES.ADHOC:                  yes
+WIFI-PROPERTIES.2GHZ:                   unknown
+WIFI-PROPERTIES.5GHZ:                   unknown
+-------------------------------------------------------------------------------
+AP[1].IN-USE:                            
+AP[1].SSID:                             wlan1-ap-4
+AP[1].MODE:                             Infra
+AP[1].CHAN:                             1
+AP[1].RATE:                             54 Mbit/s
+AP[1].SIGNAL:                           48
+AP[1].BARS:                             **  
+AP[1].SECURITY:                         WPA1 WPA2
+-------------------------------------------------------------------------------
+IP4.GATEWAY:                            192.168.57.160
+IP4.ROUTE[1]:                           dst = 192.168.36.106/21, nh = 192.168.199.128, mt = 979274165
+IP4.ROUTE[2]:                           dst = 192.168.238.130/19, nh = 0.0.0.0
+IP4.ROUTE[3]:                           dst = 192.168.224.39/32, nh = 192.168.148.69
+IP4.DNS[1]:                             192.168.61.83
+IP4.DOMAIN[1]:                          sear4.foo4.bar
+IP4.DOMAIN[2]:                          sear4.fo.x.y
+IP4.DOMAIN[3]:                          sear4.foo2.bar
+IP4.DOMAIN[4]:                          sear4.foo1.bar
+IP4.DOMAIN[5]:                          sear4.fo.o.bar
+IP4.DOMAIN[6]:                          sear4.foo3.bar
+-------------------------------------------------------------------------------
+DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:                        dhcp-4-opt-1 = val-1
+DHCP4.OPTION[3]:                        dhcp-4-opt-2 = val-2
+DHCP4.OPTION[4]:                        dhcp-4-opt-4 = val-4
+DHCP4.OPTION[5]:                        dhcp-4-opt-6 = val-6
+DHCP4.OPTION[6]:                        dhcp-4-opt-7 = val-7
+DHCP4.OPTION[7]:                        dhcp-4-opt-8 = val-8
+DHCP4.OPTION[8]:                        dhcp-4-opt-9 = val-9
+-------------------------------------------------------------------------------
+IP6.ADDRESS[1]:                         2001:a::fa05:2ab4:9300:e8fe/116
+IP6.ADDRESS[2]:                         2001:a::e9cf:bd3:caba:99b3/86
+IP6.ADDRESS[3]:                         2001:a::2be6:44fa:2c95:5559/78
+IP6.GATEWAY:                            2001:a::4d70:d91a:770f:2319
+IP6.ROUTE[1]:                           dst = 2001:a::3cb2:719d:bb00:b22f/66, nh = 2001:a::81b1:58b9:7237:3511, mt = 2280277732
+IP6.ROUTE[2]:                           dst = 2001:a::986f:983c:5eb:1c7d/99, nh = ::, mt = 1204008676
+IP6.DNS[1]:                             2001:a::85e7:3d7d:53e8:50ac
+IP6.DNS[2]:                             2001:a::1c5:9cb5:e86d:25a5
+IP6.DOMAIN[1]:                          sear6.foo4.bar
+IP6.DOMAIN[2]:                          sear6.foo2.bar
+-------------------------------------------------------------------------------
+DHCP6.OPTION[1]:                        dhcp-6-opt-0 = val-0
+DHCP6.OPTION[2]:                        dhcp-6-opt-1 = val-1
+DHCP6.OPTION[3]:                        dhcp-6-opt-2 = val-2
+DHCP6.OPTION[4]:                        dhcp-6-opt-3 = val-3
+DHCP6.OPTION[5]:                        dhcp-6-opt-4 = val-4
+DHCP6.OPTION[6]:                        dhcp-6-opt-5 = val-5
+DHCP6.OPTION[7]:                        dhcp-6-opt-6 = val-6
+DHCP6.OPTION[8]:                        dhcp-6-opt-7 = val-7
+DHCP6.OPTION[9]:                        dhcp-6-opt-9 = val-9
+-------------------------------------------------------------------------------
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
+-------------------------------------------------------------------------------
+
+===============================================================================
+                            Device details (wlan1)
+===============================================================================
+GENERAL.DEVICE:                         wlan1
+GENERAL.TYPE:                           wifi
+GENERAL.NM-TYPE:                        NMDeviceWifi
+GENERAL.VENDOR:                         --
+GENERAL.PRODUCT:                        --
+GENERAL.DRIVER:                         virtual
+GENERAL.DRIVER-VERSION:                 --
+GENERAL.FIRMWARE-VERSION:               --
+GENERAL.HWADDR:                         71:52:AD:63:5C:7C
+GENERAL.MTU:                            0
+GENERAL.STATE:                          20 (unavailable)
+GENERAL.REASON:                         0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:               0 (unknown)
+GENERAL.IP6-CONNECTIVITY:               0 (unknown)
+GENERAL.UDI:                            /sys/devices/virtual/wlan1
+GENERAL.IP-IFACE:                       --
+GENERAL.IS-SOFTWARE:                    no
+GENERAL.NM-MANAGED:                     yes
+GENERAL.AUTOCONNECT:                    yes
+GENERAL.FIRMWARE-MISSING:               no
+GENERAL.NM-PLUGIN-MISSING:              no
+GENERAL.PHYS-PORT-ID:                   --
+GENERAL.CONNECTION:                     --
+GENERAL.CON-UUID:                       --
+GENERAL.CON-PATH:                       --
+GENERAL.METERED:                        unknown
+-------------------------------------------------------------------------------
+CAPABILITIES.CARRIER-DETECT:            no
+CAPABILITIES.SPEED:                     unknown
+CAPABILITIES.IS-SOFTWARE:               no
+CAPABILITIES.SRIOV:                     no
+-------------------------------------------------------------------------------
+WIFI-PROPERTIES.WEP:                    yes
+WIFI-PROPERTIES.WPA:                    yes
+WIFI-PROPERTIES.WPA2:                   yes
+WIFI-PROPERTIES.TKIP:                   yes
+WIFI-PROPERTIES.CCMP:                   yes
+WIFI-PROPERTIES.AP:                     yes
+WIFI-PROPERTIES.ADHOC:                  yes
+WIFI-PROPERTIES.2GHZ:                   unknown
+WIFI-PROPERTIES.5GHZ:                   unknown
+-------------------------------------------------------------------------------
+IP4.ADDRESS[1]:                         192.168.97.124/29
+IP4.ADDRESS[2]:                         192.168.76.154/18
+IP4.GATEWAY:                            --
+IP4.ROUTE[1]:                           dst = 192.168.33.233/22, nh = 192.168.222.210, mt = 2810496551
+IP4.DNS[1]:                             192.168.107.109
+IP4.DOMAIN[1]:                          sear4.fo.o.bar
+IP4.DOMAIN[2]:                          sear4.fo.x.y
+IP4.DOMAIN[3]:                          sear4.foo2.bar
+IP4.DOMAIN[4]:                          sear4.foo3.bar
+IP4.DOMAIN[5]:                          sear4.foo4.bar
+IP4.WINS[1]:                            192.168.60.60
+IP4.WINS[2]:                            192.168.63.92
+-------------------------------------------------------------------------------
+DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:                        dhcp-4-opt-5 = val-5
+-------------------------------------------------------------------------------
+IP6.ADDRESS[1]:                         2001:a::88ca:3654:96b:ab44/89
+IP6.GATEWAY:                            --
+IP6.ROUTE[1]:                           dst = 2001:a::cc8b:7c09:4673:bbb0/85, nh = ::, mt = 2821465568
+IP6.ROUTE[2]:                           dst = 2001:a::a976:2488:f49f:b48/106, nh = 2001:a::62ae:c734:fc7b:e931, mt = 2248613879
+IP6.ROUTE[3]:                           dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::
+IP6.DNS[1]:                             2001:a::2934:bd66:550d:ec19
+IP6.DOMAIN[1]:                          sear6.fo.x.y
+-------------------------------------------------------------------------------
+DHCP6.OPTION[1]:                        dhcp-6-opt-2 = val-2
+DHCP6.OPTION[2]:                        dhcp-6-opt-6 = val-6
+DHCP6.OPTION[3]:                        dhcp-6-opt-7 = val-7
+DHCP6.OPTION[4]:                        dhcp-6-opt-8 = val-8
+DHCP6.OPTION[5]:                        dhcp-6-opt-9 = val-9
+-------------------------------------------------------------------------------
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
+-------------------------------------------------------------------------------
+
 <<<
 size: 25455
 location: clients/tests/test-client.py:1050:test_004()/684
@@ -36521,6 +36689,112 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 25281 bytes
 >>>
+===============================================================================
+                        Informacje o urządzeniu (wlan0)
+===============================================================================
+GENERAL.DEVICE:                         wlan0
+GENERAL.TYPE:                           wifi
+GENERAL.NM-TYPE:                        NMDeviceWifi
+GENERAL.VENDOR:                         --
+GENERAL.PRODUCT:                        --
+GENERAL.DRIVER:                         virtual
+GENERAL.DRIVER-VERSION:                 --
+GENERAL.FIRMWARE-VERSION:               --
+GENERAL.HWADDR:                         13:E0:74:85:7C:D9
+GENERAL.MTU:                            0
+GENERAL.STATE:                          20 (niedostępne)
+GENERAL.REASON:                         0 (Nie podano przyczyny)
+GENERAL.IP4-CONNECTIVITY:               0 (nieznane)
+GENERAL.IP6-CONNECTIVITY:               0 (nieznane)
+GENERAL.UDI:                            /sys/devices/virtual/wlan0
+GENERAL.IP-IFACE:                       --
+GENERAL.IS-SOFTWARE:                    nie
+GENERAL.NM-MANAGED:                     tak
+GENERAL.AUTOCONNECT:                    tak
+GENERAL.FIRMWARE-MISSING:               nie
+GENERAL.NM-PLUGIN-MISSING:              nie
+GENERAL.PHYS-PORT-ID:                   --
+GENERAL.CONNECTION:                     con-vpn-1
+GENERAL.CON-UUID:                       UUID-con-vpn-1-REPLACED-REPLACED-REP
+GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
+GENERAL.METERED:                        nieznane
+-------------------------------------------------------------------------------
+CAPABILITIES.CARRIER-DETECT:            nie
+CAPABILITIES.SPEED:                     nieznane
+CAPABILITIES.IS-SOFTWARE:               nie
+CAPABILITIES.SRIOV:                     nie
+-------------------------------------------------------------------------------
+WIFI-PROPERTIES.WEP:                    tak
+WIFI-PROPERTIES.WPA:                    tak
+WIFI-PROPERTIES.WPA2:                   tak
+WIFI-PROPERTIES.TKIP:                   tak
+WIFI-PROPERTIES.CCMP:                   tak
+WIFI-PROPERTIES.AP:                     tak
+WIFI-PROPERTIES.ADHOC:                  tak
+WIFI-PROPERTIES.2GHZ:                   nieznane
+WIFI-PROPERTIES.5GHZ:                   nieznane
+-------------------------------------------------------------------------------
+AP[1].IN-USE:                            
+AP[1].SSID:                             wlan0-ap-2
+AP[1].MODE:                             Infrastruktura
+AP[1].CHAN:                             1
+AP[1].RATE:                             54 Mb/s
+AP[1].SIGNAL:                           92
+AP[1].BARS:                             ****
+AP[1].SECURITY:                         WPA1 WPA2
+-------------------------------------------------------------------------------
+AP[2].IN-USE:                            
+AP[2].SSID:                             wlan0-ap-1
+AP[2].MODE:                             Infrastruktura
+AP[2].CHAN:                             1
+AP[2].RATE:                             54 Mb/s
+AP[2].SIGNAL:                           81
+AP[2].BARS:                             ****
+AP[2].SECURITY:                         WPA1 WPA2
+-------------------------------------------------------------------------------
+AP[3].IN-USE:                            
+AP[3].SSID:                             wlan0-ap-3
+AP[3].MODE:                             Infrastruktura
+AP[3].CHAN:                             1
+AP[3].RATE:                             54 Mb/s
+AP[3].SIGNAL:                           55
+AP[3].BARS:                             **  
+AP[3].SECURITY:                         WPA1 WPA2
+-------------------------------------------------------------------------------
+IP4.ADDRESS[1]:                         192.168.228.18/32
+IP4.ADDRESS[2]:                         192.168.209.179/25
+IP4.GATEWAY:                            192.168.41.120
+IP4.DOMAIN[1]:                          sear4.foo2.bar
+IP4.DOMAIN[2]:                          sear4.fo.x.y
+IP4.DOMAIN[3]:                          sear4.foo1.bar
+IP4.DOMAIN[4]:                          sear4.foo4.bar
+IP4.DOMAIN[5]:                          sear4.fo.o.bar
+IP4.WINS[1]:                            192.168.120.79
+-------------------------------------------------------------------------------
+DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:                        dhcp-4-opt-2 = val-2
+DHCP4.OPTION[3]:                        dhcp-4-opt-4 = val-4
+DHCP4.OPTION[4]:                        dhcp-4-opt-7 = val-7
+-------------------------------------------------------------------------------
+IP6.GATEWAY:                            --
+IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
+IP6.DOMAIN[1]:                          sear6.foo2.bar
+IP6.DOMAIN[2]:                          sear6.foo1.bar
+IP6.DOMAIN[3]:                          sear6.fo.x.y
+IP6.DOMAIN[4]:                          sear6.fo.o.bar
+IP6.DOMAIN[5]:                          sear6.foo3.bar
+IP6.DOMAIN[6]:                          sear6.foo4.bar
+-------------------------------------------------------------------------------
+DHCP6.OPTION[1]:                        dhcp-6-opt-1 = val-1
+DHCP6.OPTION[2]:                        dhcp-6-opt-2 = val-2
+DHCP6.OPTION[3]:                        dhcp-6-opt-3 = val-3
+DHCP6.OPTION[4]:                        dhcp-6-opt-4 = val-4
+DHCP6.OPTION[5]:                        dhcp-6-opt-5 = val-5
+-------------------------------------------------------------------------------
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
+-------------------------------------------------------------------------------
+
 ===============================================================================
                         Informacje o urządzeniu (eth0)
 ===============================================================================
@@ -36850,112 +37124,6 @@ DHCP6.OPTION[2]:                        dhcp-6-opt-6 = val-6
 DHCP6.OPTION[3]:                        dhcp-6-opt-7 = val-7
 DHCP6.OPTION[4]:                        dhcp-6-opt-8 = val-8
 DHCP6.OPTION[5]:                        dhcp-6-opt-9 = val-9
--------------------------------------------------------------------------------
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
--------------------------------------------------------------------------------
-
-===============================================================================
-                        Informacje o urządzeniu (wlan0)
-===============================================================================
-GENERAL.DEVICE:                         wlan0
-GENERAL.TYPE:                           wifi
-GENERAL.NM-TYPE:                        NMDeviceWifi
-GENERAL.VENDOR:                         --
-GENERAL.PRODUCT:                        --
-GENERAL.DRIVER:                         virtual
-GENERAL.DRIVER-VERSION:                 --
-GENERAL.FIRMWARE-VERSION:               --
-GENERAL.HWADDR:                         13:E0:74:85:7C:D9
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (niedostępne)
-GENERAL.REASON:                         0 (Nie podano przyczyny)
-GENERAL.IP4-CONNECTIVITY:               0 (nieznane)
-GENERAL.IP6-CONNECTIVITY:               0 (nieznane)
-GENERAL.UDI:                            /sys/devices/virtual/wlan0
-GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    nie
-GENERAL.NM-MANAGED:                     tak
-GENERAL.AUTOCONNECT:                    tak
-GENERAL.FIRMWARE-MISSING:               nie
-GENERAL.NM-PLUGIN-MISSING:              nie
-GENERAL.PHYS-PORT-ID:                   --
-GENERAL.CONNECTION:                     con-vpn-1
-GENERAL.CON-UUID:                       UUID-con-vpn-1-REPLACED-REPLACED-REP
-GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
-GENERAL.METERED:                        nieznane
--------------------------------------------------------------------------------
-CAPABILITIES.CARRIER-DETECT:            nie
-CAPABILITIES.SPEED:                     nieznane
-CAPABILITIES.IS-SOFTWARE:               nie
-CAPABILITIES.SRIOV:                     nie
--------------------------------------------------------------------------------
-WIFI-PROPERTIES.WEP:                    tak
-WIFI-PROPERTIES.WPA:                    tak
-WIFI-PROPERTIES.WPA2:                   tak
-WIFI-PROPERTIES.TKIP:                   tak
-WIFI-PROPERTIES.CCMP:                   tak
-WIFI-PROPERTIES.AP:                     tak
-WIFI-PROPERTIES.ADHOC:                  tak
-WIFI-PROPERTIES.2GHZ:                   nieznane
-WIFI-PROPERTIES.5GHZ:                   nieznane
--------------------------------------------------------------------------------
-AP[1].IN-USE:                            
-AP[1].SSID:                             wlan0-ap-2
-AP[1].MODE:                             Infrastruktura
-AP[1].CHAN:                             1
-AP[1].RATE:                             54 Mb/s
-AP[1].SIGNAL:                           92
-AP[1].BARS:                             ****
-AP[1].SECURITY:                         WPA1 WPA2
--------------------------------------------------------------------------------
-AP[2].IN-USE:                            
-AP[2].SSID:                             wlan0-ap-1
-AP[2].MODE:                             Infrastruktura
-AP[2].CHAN:                             1
-AP[2].RATE:                             54 Mb/s
-AP[2].SIGNAL:                           81
-AP[2].BARS:                             ****
-AP[2].SECURITY:                         WPA1 WPA2
--------------------------------------------------------------------------------
-AP[3].IN-USE:                            
-AP[3].SSID:                             wlan0-ap-3
-AP[3].MODE:                             Infrastruktura
-AP[3].CHAN:                             1
-AP[3].RATE:                             54 Mb/s
-AP[3].SIGNAL:                           55
-AP[3].BARS:                             **  
-AP[3].SECURITY:                         WPA1 WPA2
--------------------------------------------------------------------------------
-IP4.ADDRESS[1]:                         192.168.228.18/32
-IP4.ADDRESS[2]:                         192.168.209.179/25
-IP4.GATEWAY:                            192.168.41.120
-IP4.DOMAIN[1]:                          sear4.foo2.bar
-IP4.DOMAIN[2]:                          sear4.fo.x.y
-IP4.DOMAIN[3]:                          sear4.foo1.bar
-IP4.DOMAIN[4]:                          sear4.foo4.bar
-IP4.DOMAIN[5]:                          sear4.fo.o.bar
-IP4.WINS[1]:                            192.168.120.79
--------------------------------------------------------------------------------
-DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:                        dhcp-4-opt-2 = val-2
-DHCP4.OPTION[3]:                        dhcp-4-opt-4 = val-4
-DHCP4.OPTION[4]:                        dhcp-4-opt-7 = val-7
--------------------------------------------------------------------------------
-IP6.GATEWAY:                            --
-IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
-IP6.DOMAIN[1]:                          sear6.foo2.bar
-IP6.DOMAIN[2]:                          sear6.foo1.bar
-IP6.DOMAIN[3]:                          sear6.fo.x.y
-IP6.DOMAIN[4]:                          sear6.fo.o.bar
-IP6.DOMAIN[5]:                          sear6.foo3.bar
-IP6.DOMAIN[6]:                          sear6.foo4.bar
--------------------------------------------------------------------------------
-DHCP6.OPTION[1]:                        dhcp-6-opt-1 = val-1
-DHCP6.OPTION[2]:                        dhcp-6-opt-2 = val-2
-DHCP6.OPTION[3]:                        dhcp-6-opt-3 = val-3
-DHCP6.OPTION[4]:                        dhcp-6-opt-4 = val-4
-DHCP6.OPTION[5]:                        dhcp-6-opt-5 = val-5
 -------------------------------------------------------------------------------
 CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
@@ -37494,6 +37662,10 @@ stdout: 1480 bytes
 ===============================================================================
                                Status of devices
 ===============================================================================
+DEVICE:                                 wlan0
+TYPE:                                   wifi
+DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/3
+-------------------------------------------------------------------------------
 DEVICE:                                 eth0
 TYPE:                                   ethernet
 DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/1
@@ -37509,10 +37681,6 @@ DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/
 DEVICE:                                 wlan1
 TYPE:                                   wifi
 DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/5
--------------------------------------------------------------------------------
-DEVICE:                                 wlan0
-TYPE:                                   wifi
-DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/3
 -------------------------------------------------------------------------------
 
 <<<
@@ -37526,6 +37694,10 @@ stdout: 1480 bytes
 ===============================================================================
                                 Stan urządzenia
 ===============================================================================
+DEVICE:                                 wlan0
+TYPE:                                   wifi
+DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/3
+-------------------------------------------------------------------------------
 DEVICE:                                 eth0
 TYPE:                                   ethernet
 DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/1
@@ -37542,10 +37714,6 @@ DEVICE:                                 wlan1
 TYPE:                                   wifi
 DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/5
 -------------------------------------------------------------------------------
-DEVICE:                                 wlan0
-TYPE:                                   wifi
-DBUS-PATH:                              /org/freedesktop/NetworkManager/Devices/3
--------------------------------------------------------------------------------
 
 <<<
 size: 4849
@@ -37556,32 +37724,6 @@ returncode: 0
 stdout: 4678 bytes
 >>>
 ===============================================================================
-                            Wi-Fi scan list (wlan1)
-===============================================================================
-NAME:                                   AP[1]
-SSID:                                   wlan1-ap-4
-SSID-HEX:                               776C616E312D61702D34
-BSSID:                                  94:2B:E8:F6:D2:86
-MODE:                                   Infra
-CHAN:                                   1
-FREQ:                                   2412 MHz
-RATE:                                   54 Mbit/s
-SIGNAL:                                 48
-BARS:                                   **  
-SECURITY:                               WPA1 WPA2
-WPA-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
-RSN-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
-DEVICE:                                 wlan1
-ACTIVE:                                 no
-IN-USE:                                  
-DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/4
--------------------------------------------------------------------------------
-
-===============================================================================
-                            Wi-Fi scan list (wlan1)
-===============================================================================
-
-===============================================================================
                             Wi-Fi scan list (wlan0)
 ===============================================================================
 NAME:                                   AP[1]
@@ -37638,6 +37780,32 @@ ACTIVE:                                 no
 IN-USE:                                  
 DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/3
 -------------------------------------------------------------------------------
+
+===============================================================================
+                            Wi-Fi scan list (wlan1)
+===============================================================================
+NAME:                                   AP[1]
+SSID:                                   wlan1-ap-4
+SSID-HEX:                               776C616E312D61702D34
+BSSID:                                  94:2B:E8:F6:D2:86
+MODE:                                   Infra
+CHAN:                                   1
+FREQ:                                   2412 MHz
+RATE:                                   54 Mbit/s
+SIGNAL:                                 48
+BARS:                                   **  
+SECURITY:                               WPA1 WPA2
+WPA-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
+RSN-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
+DEVICE:                                 wlan1
+ACTIVE:                                 no
+IN-USE:                                  
+DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/4
+-------------------------------------------------------------------------------
+
+===============================================================================
+                            Wi-Fi scan list (wlan1)
+===============================================================================
 
 <<<
 size: 4925
@@ -37648,32 +37816,6 @@ returncode: 0
 stdout: 4744 bytes
 >>>
 ===============================================================================
-                     Lista skanowania sieci Wi-Fi (wlan1)
-===============================================================================
-NAME:                                   AP[1]
-SSID:                                   wlan1-ap-4
-SSID-HEX:                               776C616E312D61702D34
-BSSID:                                  94:2B:E8:F6:D2:86
-MODE:                                   Infrastruktura
-CHAN:                                   1
-FREQ:                                   2412 MHz
-RATE:                                   54 Mb/s
-SIGNAL:                                 48
-BARS:                                   **  
-SECURITY:                               WPA1 WPA2
-WPA-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
-RSN-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
-DEVICE:                                 wlan1
-ACTIVE:                                 nie
-IN-USE:                                  
-DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/4
--------------------------------------------------------------------------------
-
-===============================================================================
-                     Lista skanowania sieci Wi-Fi (wlan1)
-===============================================================================
-
-===============================================================================
                      Lista skanowania sieci Wi-Fi (wlan0)
 ===============================================================================
 NAME:                                   AP[1]
@@ -37730,6 +37872,32 @@ ACTIVE:                                 nie
 IN-USE:                                  
 DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/3
 -------------------------------------------------------------------------------
+
+===============================================================================
+                     Lista skanowania sieci Wi-Fi (wlan1)
+===============================================================================
+NAME:                                   AP[1]
+SSID:                                   wlan1-ap-4
+SSID-HEX:                               776C616E312D61702D34
+BSSID:                                  94:2B:E8:F6:D2:86
+MODE:                                   Infrastruktura
+CHAN:                                   1
+FREQ:                                   2412 MHz
+RATE:                                   54 Mb/s
+SIGNAL:                                 48
+BARS:                                   **  
+SECURITY:                               WPA1 WPA2
+WPA-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
+RSN-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
+DEVICE:                                 wlan1
+ACTIVE:                                 nie
+IN-USE:                                  
+DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/4
+-------------------------------------------------------------------------------
+
+===============================================================================
+                     Lista skanowania sieci Wi-Fi (wlan1)
+===============================================================================
 
 <<<
 size: 2608
@@ -37740,23 +37908,6 @@ returncode: 0
 stdout: 2434 bytes
 >>>
 ===============================================================================
-                            Wi-Fi scan list (wlan1)
-===============================================================================
-IN-USE:                                  
-SSID:                                   wlan1-ap-4
-MODE:                                   Infra
-CHAN:                                   1
-RATE:                                   54 Mbit/s
-SIGNAL:                                 48
-BARS:                                   **  
-SECURITY:                               WPA1 WPA2
--------------------------------------------------------------------------------
-
-===============================================================================
-                            Wi-Fi scan list (wlan1)
-===============================================================================
-
-===============================================================================
                             Wi-Fi scan list (wlan0)
 ===============================================================================
 IN-USE:                                  
@@ -37786,6 +37937,23 @@ SIGNAL:                                 55
 BARS:                                   **  
 SECURITY:                               WPA1 WPA2
 -------------------------------------------------------------------------------
+
+===============================================================================
+                            Wi-Fi scan list (wlan1)
+===============================================================================
+IN-USE:                                  
+SSID:                                   wlan1-ap-4
+MODE:                                   Infra
+CHAN:                                   1
+RATE:                                   54 Mbit/s
+SIGNAL:                                 48
+BARS:                                   **  
+SECURITY:                               WPA1 WPA2
+-------------------------------------------------------------------------------
+
+===============================================================================
+                            Wi-Fi scan list (wlan1)
+===============================================================================
 
 <<<
 size: 2672
@@ -37796,23 +37964,6 @@ returncode: 0
 stdout: 2488 bytes
 >>>
 ===============================================================================
-                     Lista skanowania sieci Wi-Fi (wlan1)
-===============================================================================
-IN-USE:                                  
-SSID:                                   wlan1-ap-4
-MODE:                                   Infrastruktura
-CHAN:                                   1
-RATE:                                   54 Mb/s
-SIGNAL:                                 48
-BARS:                                   **  
-SECURITY:                               WPA1 WPA2
--------------------------------------------------------------------------------
-
-===============================================================================
-                     Lista skanowania sieci Wi-Fi (wlan1)
-===============================================================================
-
-===============================================================================
                      Lista skanowania sieci Wi-Fi (wlan0)
 ===============================================================================
 IN-USE:                                  
@@ -37842,6 +37993,23 @@ SIGNAL:                                 55
 BARS:                                   **  
 SECURITY:                               WPA1 WPA2
 -------------------------------------------------------------------------------
+
+===============================================================================
+                     Lista skanowania sieci Wi-Fi (wlan1)
+===============================================================================
+IN-USE:                                  
+SSID:                                   wlan1-ap-4
+MODE:                                   Infrastruktura
+CHAN:                                   1
+RATE:                                   54 Mb/s
+SIGNAL:                                 48
+BARS:                                   **  
+SECURITY:                               WPA1 WPA2
+-------------------------------------------------------------------------------
+
+===============================================================================
+                     Lista skanowania sieci Wi-Fi (wlan1)
+===============================================================================
 
 <<<
 size: 4962
@@ -37852,32 +38020,6 @@ returncode: 0
 stdout: 4678 bytes
 >>>
 ===============================================================================
-                            Wi-Fi scan list (wlan1)
-===============================================================================
-NAME:                                   AP[1]
-SSID:                                   wlan1-ap-4
-SSID-HEX:                               776C616E312D61702D34
-BSSID:                                  94:2B:E8:F6:D2:86
-MODE:                                   Infra
-CHAN:                                   1
-FREQ:                                   2412 MHz
-RATE:                                   54 Mbit/s
-SIGNAL:                                 48
-BARS:                                   **  
-SECURITY:                               WPA1 WPA2
-WPA-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
-RSN-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
-DEVICE:                                 wlan1
-ACTIVE:                                 no
-IN-USE:                                  
-DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/4
--------------------------------------------------------------------------------
-
-===============================================================================
-                            Wi-Fi scan list (wlan1)
-===============================================================================
-
-===============================================================================
                             Wi-Fi scan list (wlan0)
 ===============================================================================
 NAME:                                   AP[1]
@@ -37934,6 +38076,32 @@ ACTIVE:                                 no
 IN-USE:                                  
 DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/3
 -------------------------------------------------------------------------------
+
+===============================================================================
+                            Wi-Fi scan list (wlan1)
+===============================================================================
+NAME:                                   AP[1]
+SSID:                                   wlan1-ap-4
+SSID-HEX:                               776C616E312D61702D34
+BSSID:                                  94:2B:E8:F6:D2:86
+MODE:                                   Infra
+CHAN:                                   1
+FREQ:                                   2412 MHz
+RATE:                                   54 Mbit/s
+SIGNAL:                                 48
+BARS:                                   **  
+SECURITY:                               WPA1 WPA2
+WPA-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
+RSN-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
+DEVICE:                                 wlan1
+ACTIVE:                                 no
+IN-USE:                                  
+DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/4
+-------------------------------------------------------------------------------
+
+===============================================================================
+                            Wi-Fi scan list (wlan1)
+===============================================================================
 
 <<<
 size: 5038
@@ -37944,32 +38112,6 @@ returncode: 0
 stdout: 4744 bytes
 >>>
 ===============================================================================
-                     Lista skanowania sieci Wi-Fi (wlan1)
-===============================================================================
-NAME:                                   AP[1]
-SSID:                                   wlan1-ap-4
-SSID-HEX:                               776C616E312D61702D34
-BSSID:                                  94:2B:E8:F6:D2:86
-MODE:                                   Infrastruktura
-CHAN:                                   1
-FREQ:                                   2412 MHz
-RATE:                                   54 Mb/s
-SIGNAL:                                 48
-BARS:                                   **  
-SECURITY:                               WPA1 WPA2
-WPA-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
-RSN-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
-DEVICE:                                 wlan1
-ACTIVE:                                 nie
-IN-USE:                                  
-DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/4
--------------------------------------------------------------------------------
-
-===============================================================================
-                     Lista skanowania sieci Wi-Fi (wlan1)
-===============================================================================
-
-===============================================================================
                      Lista skanowania sieci Wi-Fi (wlan0)
 ===============================================================================
 NAME:                                   AP[1]
@@ -38027,13 +38169,39 @@ IN-USE:
 DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/3
 -------------------------------------------------------------------------------
 
+===============================================================================
+                     Lista skanowania sieci Wi-Fi (wlan1)
+===============================================================================
+NAME:                                   AP[1]
+SSID:                                   wlan1-ap-4
+SSID-HEX:                               776C616E312D61702D34
+BSSID:                                  94:2B:E8:F6:D2:86
+MODE:                                   Infrastruktura
+CHAN:                                   1
+FREQ:                                   2412 MHz
+RATE:                                   54 Mb/s
+SIGNAL:                                 48
+BARS:                                   **  
+SECURITY:                               WPA1 WPA2
+WPA-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
+RSN-FLAGS:                              pair_tkip pair_ccmp group_tkip group_ccmp psk
+DEVICE:                                 wlan1
+ACTIVE:                                 nie
+IN-USE:                                  
+DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/4
+-------------------------------------------------------------------------------
+
+===============================================================================
+                     Lista skanowania sieci Wi-Fi (wlan1)
+===============================================================================
+
 <<<
-size: 1417
+size: 1419
 location: clients/tests/test-client.py:1075:test_004()/701
 cmd: $NMCLI --mode multiline --pretty -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 1222 bytes
+stdout: 1224 bytes
 >>>
 ===============================================================================
                             Wi-Fi scan list (wlan0)
@@ -38057,13 +38225,15 @@ IN-USE:
 DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/2
 -------------------------------------------------------------------------------
 
+
+
 <<<
-size: 1445
+size: 1447
 location: clients/tests/test-client.py:1075:test_004()/702
 cmd: $NMCLI --mode multiline --pretty -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 1240 bytes
+stdout: 1242 bytes
 >>>
 ===============================================================================
                      Lista skanowania sieci Wi-Fi (wlan0)
@@ -38087,13 +38257,15 @@ IN-USE:
 DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/2
 -------------------------------------------------------------------------------
 
+
+
 <<<
-size: 858
+size: 860
 location: clients/tests/test-client.py:1077:test_004()/703
 cmd: $NMCLI --mode multiline --pretty -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 661 bytes
+stdout: 663 bytes
 >>>
 ===============================================================================
                             Wi-Fi scan list (wlan0)
@@ -38108,13 +38280,15 @@ BARS:                                   ****
 SECURITY:                               WPA1 WPA2
 -------------------------------------------------------------------------------
 
+
+
 <<<
-size: 883
+size: 885
 location: clients/tests/test-client.py:1077:test_004()/704
 cmd: $NMCLI --mode multiline --pretty -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 676 bytes
+stdout: 678 bytes
 >>>
 ===============================================================================
                      Lista skanowania sieci Wi-Fi (wlan0)
@@ -38129,13 +38303,15 @@ BARS:                                   ****
 SECURITY:                               WPA1 WPA2
 -------------------------------------------------------------------------------
 
+
+
 <<<
-size: 1530
+size: 1532
 location: clients/tests/test-client.py:1080:test_004()/705
 cmd: $NMCLI --mode multiline --pretty -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 1222 bytes
+stdout: 1224 bytes
 >>>
 ===============================================================================
                             Wi-Fi scan list (wlan0)
@@ -38159,13 +38335,15 @@ IN-USE:
 DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/2
 -------------------------------------------------------------------------------
 
+
+
 <<<
-size: 1558
+size: 1560
 location: clients/tests/test-client.py:1080:test_004()/706
 cmd: $NMCLI --mode multiline --pretty -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 1240 bytes
+stdout: 1242 bytes
 >>>
 ===============================================================================
                      Lista skanowania sieci Wi-Fi (wlan0)
@@ -38188,6 +38366,8 @@ ACTIVE:                                 nie
 IN-USE:                                  
 DBUS-PATH:                              /org/freedesktop/NetworkManager/AccessPoint/2
 -------------------------------------------------------------------------------
+
+
 
 <<<
 size: 5978
@@ -39474,6 +39654,11 @@ stdout: 1712 bytes
 ===============================================================================
                                Status of devices
 ===============================================================================
+DEVICE:                                 [2mwlan0[0m
+TYPE:                                   [2mwifi[0m
+STATE:                                  [2munavailable[0m
+CONNECTION:                             [2mcon-vpn-1[0m
+-------------------------------------------------------------------------------
 DEVICE:                                 [2meth0[0m
 TYPE:                                   [2methernet[0m
 STATE:                                  [2munavailable[0m
@@ -39493,11 +39678,6 @@ DEVICE:                                 [2mwlan1[0m
 TYPE:                                   [2mwifi[0m
 STATE:                                  [2munavailable[0m
 CONNECTION:                             [2m--[0m
--------------------------------------------------------------------------------
-DEVICE:                                 [2mwlan0[0m
-TYPE:                                   [2mwifi[0m
-STATE:                                  [2munavailable[0m
-CONNECTION:                             [2mcon-vpn-1[0m
 -------------------------------------------------------------------------------
 
 <<<
@@ -39511,6 +39691,11 @@ stdout: 1717 bytes
 ===============================================================================
                                 Stan urządzenia
 ===============================================================================
+DEVICE:                                 [2mwlan0[0m
+TYPE:                                   [2mwifi[0m
+STATE:                                  [2mniedostępne[0m
+CONNECTION:                             [2mcon-vpn-1[0m
+-------------------------------------------------------------------------------
 DEVICE:                                 [2meth0[0m
 TYPE:                                   [2methernet[0m
 STATE:                                  [2mniedostępne[0m
@@ -39530,11 +39715,6 @@ DEVICE:                                 [2mwlan1[0m
 TYPE:                                   [2mwifi[0m
 STATE:                                  [2mniedostępne[0m
 CONNECTION:                             [2m--[0m
--------------------------------------------------------------------------------
-DEVICE:                                 [2mwlan0[0m
-TYPE:                                   [2mwifi[0m
-STATE:                                  [2mniedostępne[0m
-CONNECTION:                             [2mcon-vpn-1[0m
 -------------------------------------------------------------------------------
 
 <<<
@@ -39548,6 +39728,16 @@ stdout: 3314 bytes
 ===============================================================================
                                Status of devices
 ===============================================================================
+DEVICE:                                 [2mwlan0[0m
+TYPE:                                   [2mwifi[0m
+STATE:                                  [2munavailable[0m
+IP4-CONNECTIVITY:                       [2munknown[0m
+IP6-CONNECTIVITY:                       [2munknown[0m
+DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devices/3[0m
+CONNECTION:                             [2mcon-vpn-1[0m
+CON-UUID:                               [2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m
+CON-PATH:                               [2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
+-------------------------------------------------------------------------------
 DEVICE:                                 [2meth0[0m
 TYPE:                                   [2methernet[0m
 STATE:                                  [2munavailable[0m
@@ -39587,16 +39777,6 @@ DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devi
 CONNECTION:                             [2m--[0m
 CON-UUID:                               [2m--[0m
 CON-PATH:                               [2m--[0m
--------------------------------------------------------------------------------
-DEVICE:                                 [2mwlan0[0m
-TYPE:                                   [2mwifi[0m
-STATE:                                  [2munavailable[0m
-IP4-CONNECTIVITY:                       [2munknown[0m
-IP6-CONNECTIVITY:                       [2munknown[0m
-DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devices/3[0m
-CONNECTION:                             [2mcon-vpn-1[0m
-CON-UUID:                               [2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m
-CON-PATH:                               [2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
 -------------------------------------------------------------------------------
 
 <<<
@@ -39610,6 +39790,16 @@ stdout: 3329 bytes
 ===============================================================================
                                 Stan urządzenia
 ===============================================================================
+DEVICE:                                 [2mwlan0[0m
+TYPE:                                   [2mwifi[0m
+STATE:                                  [2mniedostępne[0m
+IP4-CONNECTIVITY:                       [2mnieznane[0m
+IP6-CONNECTIVITY:                       [2mnieznane[0m
+DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devices/3[0m
+CONNECTION:                             [2mcon-vpn-1[0m
+CON-UUID:                               [2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m
+CON-PATH:                               [2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
+-------------------------------------------------------------------------------
 DEVICE:                                 [2meth0[0m
 TYPE:                                   [2methernet[0m
 STATE:                                  [2mniedostępne[0m
@@ -39650,16 +39840,6 @@ CONNECTION:                             [2m--[0m
 CON-UUID:                               [2m--[0m
 CON-PATH:                               [2m--[0m
 -------------------------------------------------------------------------------
-DEVICE:                                 [2mwlan0[0m
-TYPE:                                   [2mwifi[0m
-STATE:                                  [2mniedostępne[0m
-IP4-CONNECTIVITY:                       [2mnieznane[0m
-IP6-CONNECTIVITY:                       [2mnieznane[0m
-DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devices/3[0m
-CONNECTION:                             [2mcon-vpn-1[0m
-CON-UUID:                               [2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m
-CON-PATH:                               [2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
--------------------------------------------------------------------------------
 
 <<<
 size: 12902
@@ -39669,6 +39849,43 @@ lang: C
 returncode: 0
 stdout: 12733 bytes
 >>>
+===============================================================================
+                            Device details (wlan0)
+===============================================================================
+GENERAL.DEVICE:                         wlan0
+-------------------------------------------------------------------------------
+GENERAL.TYPE:                           wifi
+-------------------------------------------------------------------------------
+GENERAL.HWADDR:                         13:E0:74:85:7C:D9
+-------------------------------------------------------------------------------
+GENERAL.MTU:                            0
+-------------------------------------------------------------------------------
+GENERAL.STATE:                          20 (unavailable)
+-------------------------------------------------------------------------------
+GENERAL.CONNECTION:                     con-vpn-1
+-------------------------------------------------------------------------------
+GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
+-------------------------------------------------------------------------------
+IP4.ADDRESS[1]:                         192.168.228.18/32
+IP4.ADDRESS[2]:                         192.168.209.179/25
+IP4.GATEWAY:                            192.168.41.120
+IP4.DOMAIN[1]:                          sear4.foo2.bar
+IP4.DOMAIN[2]:                          sear4.fo.x.y
+IP4.DOMAIN[3]:                          sear4.foo1.bar
+IP4.DOMAIN[4]:                          sear4.foo4.bar
+IP4.DOMAIN[5]:                          sear4.fo.o.bar
+IP4.WINS[1]:                            192.168.120.79
+-------------------------------------------------------------------------------
+IP6.GATEWAY:                            --
+IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
+IP6.DOMAIN[1]:                          sear6.foo2.bar
+IP6.DOMAIN[2]:                          sear6.foo1.bar
+IP6.DOMAIN[3]:                          sear6.fo.x.y
+IP6.DOMAIN[4]:                          sear6.fo.o.bar
+IP6.DOMAIN[5]:                          sear6.foo3.bar
+IP6.DOMAIN[6]:                          sear6.foo4.bar
+-------------------------------------------------------------------------------
+
 ===============================================================================
                              Device details (eth0)
 ===============================================================================
@@ -39832,8 +40049,16 @@ IP6.DNS[1]:                             2001:a::2934:bd66:550d:ec19
 IP6.DOMAIN[1]:                          sear6.fo.x.y
 -------------------------------------------------------------------------------
 
+<<<
+size: 12966
+location: clients/tests/test-client.py:1047:test_004()/728
+cmd: $NMCLI --mode multiline --pretty --color yes dev show
+lang: pl_PL.UTF-8
+returncode: 0
+stdout: 12787 bytes
+>>>
 ===============================================================================
-                            Device details (wlan0)
+                        Informacje o urządzeniu (wlan0)
 ===============================================================================
 GENERAL.DEVICE:                         wlan0
 -------------------------------------------------------------------------------
@@ -39843,7 +40068,7 @@ GENERAL.HWADDR:                         13:E0:74:85:7C:D9
 -------------------------------------------------------------------------------
 GENERAL.MTU:                            0
 -------------------------------------------------------------------------------
-GENERAL.STATE:                          20 (unavailable)
+GENERAL.STATE:                          20 (niedostępne)
 -------------------------------------------------------------------------------
 GENERAL.CONNECTION:                     con-vpn-1
 -------------------------------------------------------------------------------
@@ -39869,14 +40094,6 @@ IP6.DOMAIN[5]:                          sear6.foo3.bar
 IP6.DOMAIN[6]:                          sear6.foo4.bar
 -------------------------------------------------------------------------------
 
-<<<
-size: 12966
-location: clients/tests/test-client.py:1047:test_004()/728
-cmd: $NMCLI --mode multiline --pretty --color yes dev show
-lang: pl_PL.UTF-8
-returncode: 0
-stdout: 12787 bytes
->>>
 ===============================================================================
                         Informacje o urządzeniu (eth0)
 ===============================================================================
@@ -40040,22 +40257,85 @@ IP6.DNS[1]:                             2001:a::2934:bd66:550d:ec19
 IP6.DOMAIN[1]:                          sear6.fo.x.y
 -------------------------------------------------------------------------------
 
+<<<
+size: 25572
+location: clients/tests/test-client.py:1050:test_004()/729
+cmd: $NMCLI --mode multiline --pretty --color yes -f all dev show
+lang: C
+returncode: 0
+stdout: 25396 bytes
+>>>
 ===============================================================================
-                        Informacje o urządzeniu (wlan0)
+                            Device details (wlan0)
 ===============================================================================
 GENERAL.DEVICE:                         wlan0
--------------------------------------------------------------------------------
 GENERAL.TYPE:                           wifi
--------------------------------------------------------------------------------
+GENERAL.NM-TYPE:                        NMDeviceWifi
+GENERAL.VENDOR:                         --
+GENERAL.PRODUCT:                        --
+GENERAL.DRIVER:                         virtual
+GENERAL.DRIVER-VERSION:                 --
+GENERAL.FIRMWARE-VERSION:               --
 GENERAL.HWADDR:                         13:E0:74:85:7C:D9
--------------------------------------------------------------------------------
 GENERAL.MTU:                            0
--------------------------------------------------------------------------------
-GENERAL.STATE:                          20 (niedostępne)
--------------------------------------------------------------------------------
+GENERAL.STATE:                          20 (unavailable)
+GENERAL.REASON:                         0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:               0 (unknown)
+GENERAL.IP6-CONNECTIVITY:               0 (unknown)
+GENERAL.UDI:                            /sys/devices/virtual/wlan0
+GENERAL.IP-IFACE:                       --
+GENERAL.IS-SOFTWARE:                    no
+GENERAL.NM-MANAGED:                     yes
+GENERAL.AUTOCONNECT:                    yes
+GENERAL.FIRMWARE-MISSING:               no
+GENERAL.NM-PLUGIN-MISSING:              no
+GENERAL.PHYS-PORT-ID:                   --
 GENERAL.CONNECTION:                     con-vpn-1
--------------------------------------------------------------------------------
+GENERAL.CON-UUID:                       UUID-con-vpn-1-REPLACED-REPLACED-REP
 GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
+GENERAL.METERED:                        unknown
+-------------------------------------------------------------------------------
+CAPABILITIES.CARRIER-DETECT:            no
+CAPABILITIES.SPEED:                     unknown
+CAPABILITIES.IS-SOFTWARE:               no
+CAPABILITIES.SRIOV:                     no
+-------------------------------------------------------------------------------
+WIFI-PROPERTIES.WEP:                    yes
+WIFI-PROPERTIES.WPA:                    yes
+WIFI-PROPERTIES.WPA2:                   yes
+WIFI-PROPERTIES.TKIP:                   yes
+WIFI-PROPERTIES.CCMP:                   yes
+WIFI-PROPERTIES.AP:                     yes
+WIFI-PROPERTIES.ADHOC:                  yes
+WIFI-PROPERTIES.2GHZ:                   unknown
+WIFI-PROPERTIES.5GHZ:                   unknown
+-------------------------------------------------------------------------------
+AP[1].IN-USE:                           [32m [0m
+AP[1].SSID:                             [32mwlan0-ap-2[0m
+AP[1].MODE:                             [32mInfra[0m
+AP[1].CHAN:                             [32m1[0m
+AP[1].RATE:                             [32m54 Mbit/s[0m
+AP[1].SIGNAL:                           [32m92[0m
+AP[1].BARS:                             [32m****[0m
+AP[1].SECURITY:                         [32mWPA1 WPA2[0m
+-------------------------------------------------------------------------------
+AP[2].IN-USE:                           [32m [0m
+AP[2].SSID:                             [32mwlan0-ap-1[0m
+AP[2].MODE:                             [32mInfra[0m
+AP[2].CHAN:                             [32m1[0m
+AP[2].RATE:                             [32m54 Mbit/s[0m
+AP[2].SIGNAL:                           [32m81[0m
+AP[2].BARS:                             [32m****[0m
+AP[2].SECURITY:                         [32mWPA1 WPA2[0m
+-------------------------------------------------------------------------------
+AP[3].IN-USE:                           [35m [0m
+AP[3].SSID:                             [35mwlan0-ap-3[0m
+AP[3].MODE:                             [35mInfra[0m
+AP[3].CHAN:                             [35m1[0m
+AP[3].RATE:                             [35m54 Mbit/s[0m
+AP[3].SIGNAL:                           [35m55[0m
+AP[3].BARS:                             [35m**  [0m
+AP[3].SECURITY:                         [35mWPA1 WPA2[0m
 -------------------------------------------------------------------------------
 IP4.ADDRESS[1]:                         192.168.228.18/32
 IP4.ADDRESS[2]:                         192.168.209.179/25
@@ -40067,6 +40347,11 @@ IP4.DOMAIN[4]:                          sear4.foo4.bar
 IP4.DOMAIN[5]:                          sear4.fo.o.bar
 IP4.WINS[1]:                            192.168.120.79
 -------------------------------------------------------------------------------
+DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:                        dhcp-4-opt-2 = val-2
+DHCP4.OPTION[3]:                        dhcp-4-opt-4 = val-4
+DHCP4.OPTION[4]:                        dhcp-4-opt-7 = val-7
+-------------------------------------------------------------------------------
 IP6.GATEWAY:                            --
 IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
 IP6.DOMAIN[1]:                          sear6.foo2.bar
@@ -40076,15 +40361,16 @@ IP6.DOMAIN[4]:                          sear6.fo.o.bar
 IP6.DOMAIN[5]:                          sear6.foo3.bar
 IP6.DOMAIN[6]:                          sear6.foo4.bar
 -------------------------------------------------------------------------------
+DHCP6.OPTION[1]:                        dhcp-6-opt-1 = val-1
+DHCP6.OPTION[2]:                        dhcp-6-opt-2 = val-2
+DHCP6.OPTION[3]:                        dhcp-6-opt-3 = val-3
+DHCP6.OPTION[4]:                        dhcp-6-opt-4 = val-4
+DHCP6.OPTION[5]:                        dhcp-6-opt-5 = val-5
+-------------------------------------------------------------------------------
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
+-------------------------------------------------------------------------------
 
-<<<
-size: 25572
-location: clients/tests/test-client.py:1050:test_004()/729
-cmd: $NMCLI --mode multiline --pretty --color yes -f all dev show
-lang: C
-returncode: 0
-stdout: 25396 bytes
->>>
 ===============================================================================
                              Device details (eth0)
 ===============================================================================
@@ -40419,8 +40705,16 @@ CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 -------------------------------------------------------------------------------
 
+<<<
+size: 25755
+location: clients/tests/test-client.py:1050:test_004()/730
+cmd: $NMCLI --mode multiline --pretty --color yes -f all dev show
+lang: pl_PL.UTF-8
+returncode: 0
+stdout: 25569 bytes
+>>>
 ===============================================================================
-                            Device details (wlan0)
+                        Informacje o urządzeniu (wlan0)
 ===============================================================================
 GENERAL.DEVICE:                         wlan0
 GENERAL.TYPE:                           wifi
@@ -40432,61 +40726,61 @@ GENERAL.DRIVER-VERSION:                 --
 GENERAL.FIRMWARE-VERSION:               --
 GENERAL.HWADDR:                         13:E0:74:85:7C:D9
 GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (unavailable)
-GENERAL.REASON:                         0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:               0 (unknown)
-GENERAL.IP6-CONNECTIVITY:               0 (unknown)
+GENERAL.STATE:                          20 (niedostępne)
+GENERAL.REASON:                         0 (Nie podano przyczyny)
+GENERAL.IP4-CONNECTIVITY:               0 (nieznane)
+GENERAL.IP6-CONNECTIVITY:               0 (nieznane)
 GENERAL.UDI:                            /sys/devices/virtual/wlan0
 GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    no
-GENERAL.NM-MANAGED:                     yes
-GENERAL.AUTOCONNECT:                    yes
-GENERAL.FIRMWARE-MISSING:               no
-GENERAL.NM-PLUGIN-MISSING:              no
+GENERAL.IS-SOFTWARE:                    nie
+GENERAL.NM-MANAGED:                     tak
+GENERAL.AUTOCONNECT:                    tak
+GENERAL.FIRMWARE-MISSING:               nie
+GENERAL.NM-PLUGIN-MISSING:              nie
 GENERAL.PHYS-PORT-ID:                   --
 GENERAL.CONNECTION:                     con-vpn-1
 GENERAL.CON-UUID:                       UUID-con-vpn-1-REPLACED-REPLACED-REP
 GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
-GENERAL.METERED:                        unknown
+GENERAL.METERED:                        nieznane
 -------------------------------------------------------------------------------
-CAPABILITIES.CARRIER-DETECT:            no
-CAPABILITIES.SPEED:                     unknown
-CAPABILITIES.IS-SOFTWARE:               no
-CAPABILITIES.SRIOV:                     no
+CAPABILITIES.CARRIER-DETECT:            nie
+CAPABILITIES.SPEED:                     nieznane
+CAPABILITIES.IS-SOFTWARE:               nie
+CAPABILITIES.SRIOV:                     nie
 -------------------------------------------------------------------------------
-WIFI-PROPERTIES.WEP:                    yes
-WIFI-PROPERTIES.WPA:                    yes
-WIFI-PROPERTIES.WPA2:                   yes
-WIFI-PROPERTIES.TKIP:                   yes
-WIFI-PROPERTIES.CCMP:                   yes
-WIFI-PROPERTIES.AP:                     yes
-WIFI-PROPERTIES.ADHOC:                  yes
-WIFI-PROPERTIES.2GHZ:                   unknown
-WIFI-PROPERTIES.5GHZ:                   unknown
+WIFI-PROPERTIES.WEP:                    tak
+WIFI-PROPERTIES.WPA:                    tak
+WIFI-PROPERTIES.WPA2:                   tak
+WIFI-PROPERTIES.TKIP:                   tak
+WIFI-PROPERTIES.CCMP:                   tak
+WIFI-PROPERTIES.AP:                     tak
+WIFI-PROPERTIES.ADHOC:                  tak
+WIFI-PROPERTIES.2GHZ:                   nieznane
+WIFI-PROPERTIES.5GHZ:                   nieznane
 -------------------------------------------------------------------------------
 AP[1].IN-USE:                           [32m [0m
 AP[1].SSID:                             [32mwlan0-ap-2[0m
-AP[1].MODE:                             [32mInfra[0m
+AP[1].MODE:                             [32mInfrastruktura[0m
 AP[1].CHAN:                             [32m1[0m
-AP[1].RATE:                             [32m54 Mbit/s[0m
+AP[1].RATE:                             [32m54 Mb/s[0m
 AP[1].SIGNAL:                           [32m92[0m
 AP[1].BARS:                             [32m****[0m
 AP[1].SECURITY:                         [32mWPA1 WPA2[0m
 -------------------------------------------------------------------------------
 AP[2].IN-USE:                           [32m [0m
 AP[2].SSID:                             [32mwlan0-ap-1[0m
-AP[2].MODE:                             [32mInfra[0m
+AP[2].MODE:                             [32mInfrastruktura[0m
 AP[2].CHAN:                             [32m1[0m
-AP[2].RATE:                             [32m54 Mbit/s[0m
+AP[2].RATE:                             [32m54 Mb/s[0m
 AP[2].SIGNAL:                           [32m81[0m
 AP[2].BARS:                             [32m****[0m
 AP[2].SECURITY:                         [32mWPA1 WPA2[0m
 -------------------------------------------------------------------------------
 AP[3].IN-USE:                           [35m [0m
 AP[3].SSID:                             [35mwlan0-ap-3[0m
-AP[3].MODE:                             [35mInfra[0m
+AP[3].MODE:                             [35mInfrastruktura[0m
 AP[3].CHAN:                             [35m1[0m
-AP[3].RATE:                             [35m54 Mbit/s[0m
+AP[3].RATE:                             [35m54 Mb/s[0m
 AP[3].SIGNAL:                           [35m55[0m
 AP[3].BARS:                             [35m**  [0m
 AP[3].SECURITY:                         [35mWPA1 WPA2[0m
@@ -40525,14 +40819,6 @@ CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 -------------------------------------------------------------------------------
 
-<<<
-size: 25755
-location: clients/tests/test-client.py:1050:test_004()/730
-cmd: $NMCLI --mode multiline --pretty --color yes -f all dev show
-lang: pl_PL.UTF-8
-returncode: 0
-stdout: 25569 bytes
->>>
 ===============================================================================
                         Informacje o urządzeniu (eth0)
 ===============================================================================
@@ -40862,112 +41148,6 @@ DHCP6.OPTION[2]:                        dhcp-6-opt-6 = val-6
 DHCP6.OPTION[3]:                        dhcp-6-opt-7 = val-7
 DHCP6.OPTION[4]:                        dhcp-6-opt-8 = val-8
 DHCP6.OPTION[5]:                        dhcp-6-opt-9 = val-9
--------------------------------------------------------------------------------
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
--------------------------------------------------------------------------------
-
-===============================================================================
-                        Informacje o urządzeniu (wlan0)
-===============================================================================
-GENERAL.DEVICE:                         wlan0
-GENERAL.TYPE:                           wifi
-GENERAL.NM-TYPE:                        NMDeviceWifi
-GENERAL.VENDOR:                         --
-GENERAL.PRODUCT:                        --
-GENERAL.DRIVER:                         virtual
-GENERAL.DRIVER-VERSION:                 --
-GENERAL.FIRMWARE-VERSION:               --
-GENERAL.HWADDR:                         13:E0:74:85:7C:D9
-GENERAL.MTU:                            0
-GENERAL.STATE:                          20 (niedostępne)
-GENERAL.REASON:                         0 (Nie podano przyczyny)
-GENERAL.IP4-CONNECTIVITY:               0 (nieznane)
-GENERAL.IP6-CONNECTIVITY:               0 (nieznane)
-GENERAL.UDI:                            /sys/devices/virtual/wlan0
-GENERAL.IP-IFACE:                       --
-GENERAL.IS-SOFTWARE:                    nie
-GENERAL.NM-MANAGED:                     tak
-GENERAL.AUTOCONNECT:                    tak
-GENERAL.FIRMWARE-MISSING:               nie
-GENERAL.NM-PLUGIN-MISSING:              nie
-GENERAL.PHYS-PORT-ID:                   --
-GENERAL.CONNECTION:                     con-vpn-1
-GENERAL.CON-UUID:                       UUID-con-vpn-1-REPLACED-REPLACED-REP
-GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/2
-GENERAL.METERED:                        nieznane
--------------------------------------------------------------------------------
-CAPABILITIES.CARRIER-DETECT:            nie
-CAPABILITIES.SPEED:                     nieznane
-CAPABILITIES.IS-SOFTWARE:               nie
-CAPABILITIES.SRIOV:                     nie
--------------------------------------------------------------------------------
-WIFI-PROPERTIES.WEP:                    tak
-WIFI-PROPERTIES.WPA:                    tak
-WIFI-PROPERTIES.WPA2:                   tak
-WIFI-PROPERTIES.TKIP:                   tak
-WIFI-PROPERTIES.CCMP:                   tak
-WIFI-PROPERTIES.AP:                     tak
-WIFI-PROPERTIES.ADHOC:                  tak
-WIFI-PROPERTIES.2GHZ:                   nieznane
-WIFI-PROPERTIES.5GHZ:                   nieznane
--------------------------------------------------------------------------------
-AP[1].IN-USE:                           [32m [0m
-AP[1].SSID:                             [32mwlan0-ap-2[0m
-AP[1].MODE:                             [32mInfrastruktura[0m
-AP[1].CHAN:                             [32m1[0m
-AP[1].RATE:                             [32m54 Mb/s[0m
-AP[1].SIGNAL:                           [32m92[0m
-AP[1].BARS:                             [32m****[0m
-AP[1].SECURITY:                         [32mWPA1 WPA2[0m
--------------------------------------------------------------------------------
-AP[2].IN-USE:                           [32m [0m
-AP[2].SSID:                             [32mwlan0-ap-1[0m
-AP[2].MODE:                             [32mInfrastruktura[0m
-AP[2].CHAN:                             [32m1[0m
-AP[2].RATE:                             [32m54 Mb/s[0m
-AP[2].SIGNAL:                           [32m81[0m
-AP[2].BARS:                             [32m****[0m
-AP[2].SECURITY:                         [32mWPA1 WPA2[0m
--------------------------------------------------------------------------------
-AP[3].IN-USE:                           [35m [0m
-AP[3].SSID:                             [35mwlan0-ap-3[0m
-AP[3].MODE:                             [35mInfrastruktura[0m
-AP[3].CHAN:                             [35m1[0m
-AP[3].RATE:                             [35m54 Mb/s[0m
-AP[3].SIGNAL:                           [35m55[0m
-AP[3].BARS:                             [35m**  [0m
-AP[3].SECURITY:                         [35mWPA1 WPA2[0m
--------------------------------------------------------------------------------
-IP4.ADDRESS[1]:                         192.168.228.18/32
-IP4.ADDRESS[2]:                         192.168.209.179/25
-IP4.GATEWAY:                            192.168.41.120
-IP4.DOMAIN[1]:                          sear4.foo2.bar
-IP4.DOMAIN[2]:                          sear4.fo.x.y
-IP4.DOMAIN[3]:                          sear4.foo1.bar
-IP4.DOMAIN[4]:                          sear4.foo4.bar
-IP4.DOMAIN[5]:                          sear4.fo.o.bar
-IP4.WINS[1]:                            192.168.120.79
--------------------------------------------------------------------------------
-DHCP4.OPTION[1]:                        dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:                        dhcp-4-opt-2 = val-2
-DHCP4.OPTION[3]:                        dhcp-4-opt-4 = val-4
-DHCP4.OPTION[4]:                        dhcp-4-opt-7 = val-7
--------------------------------------------------------------------------------
-IP6.GATEWAY:                            --
-IP6.ROUTE[1]:                           dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
-IP6.DOMAIN[1]:                          sear6.foo2.bar
-IP6.DOMAIN[2]:                          sear6.foo1.bar
-IP6.DOMAIN[3]:                          sear6.fo.x.y
-IP6.DOMAIN[4]:                          sear6.fo.o.bar
-IP6.DOMAIN[5]:                          sear6.foo3.bar
-IP6.DOMAIN[6]:                          sear6.foo4.bar
--------------------------------------------------------------------------------
-DHCP6.OPTION[1]:                        dhcp-6-opt-1 = val-1
-DHCP6.OPTION[2]:                        dhcp-6-opt-2 = val-2
-DHCP6.OPTION[3]:                        dhcp-6-opt-3 = val-3
-DHCP6.OPTION[4]:                        dhcp-6-opt-4 = val-4
-DHCP6.OPTION[5]:                        dhcp-6-opt-5 = val-5
 -------------------------------------------------------------------------------
 CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/Connection/{2}
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
@@ -41506,6 +41686,10 @@ stdout: 1600 bytes
 ===============================================================================
                                Status of devices
 ===============================================================================
+DEVICE:                                 [2mwlan0[0m
+TYPE:                                   [2mwifi[0m
+DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devices/3[0m
+-------------------------------------------------------------------------------
 DEVICE:                                 [2meth0[0m
 TYPE:                                   [2methernet[0m
 DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devices/1[0m
@@ -41521,10 +41705,6 @@ DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devi
 DEVICE:                                 [2mwlan1[0m
 TYPE:                                   [2mwifi[0m
 DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devices/5[0m
--------------------------------------------------------------------------------
-DEVICE:                                 [2mwlan0[0m
-TYPE:                                   [2mwifi[0m
-DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devices/3[0m
 -------------------------------------------------------------------------------
 
 <<<
@@ -41538,6 +41718,10 @@ stdout: 1600 bytes
 ===============================================================================
                                 Stan urządzenia
 ===============================================================================
+DEVICE:                                 [2mwlan0[0m
+TYPE:                                   [2mwifi[0m
+DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devices/3[0m
+-------------------------------------------------------------------------------
 DEVICE:                                 [2meth0[0m
 TYPE:                                   [2methernet[0m
 DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devices/1[0m
@@ -41554,10 +41738,6 @@ DEVICE:                                 [2mwlan1[0m
 TYPE:                                   [2mwifi[0m
 DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devices/5[0m
 -------------------------------------------------------------------------------
-DEVICE:                                 [2mwlan0[0m
-TYPE:                                   [2mwifi[0m
-DBUS-PATH:                              [2m/org/freedesktop/NetworkManager/Devices/3[0m
--------------------------------------------------------------------------------
 
 <<<
 size: 5473
@@ -41568,32 +41748,6 @@ returncode: 0
 stdout: 5290 bytes
 >>>
 ===============================================================================
-                            Wi-Fi scan list (wlan1)
-===============================================================================
-NAME:                                   [35mAP[1][0m
-SSID:                                   [35mwlan1-ap-4[0m
-SSID-HEX:                               [35m776C616E312D61702D34[0m
-BSSID:                                  [35m94:2B:E8:F6:D2:86[0m
-MODE:                                   [35mInfra[0m
-CHAN:                                   [35m1[0m
-FREQ:                                   [35m2412 MHz[0m
-RATE:                                   [35m54 Mbit/s[0m
-SIGNAL:                                 [35m48[0m
-BARS:                                   [35m**  [0m
-SECURITY:                               [35mWPA1 WPA2[0m
-WPA-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
-RSN-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
-DEVICE:                                 [35mwlan1[0m
-ACTIVE:                                 [35mno[0m
-IN-USE:                                 [35m [0m
-DBUS-PATH:                              [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
--------------------------------------------------------------------------------
-
-===============================================================================
-                            Wi-Fi scan list (wlan1)
-===============================================================================
-
-===============================================================================
                             Wi-Fi scan list (wlan0)
 ===============================================================================
 NAME:                                   [32mAP[1][0m
@@ -41650,6 +41804,32 @@ ACTIVE:                                 [35mno[0m
 IN-USE:                                 [35m [0m
 DBUS-PATH:                              [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m
 -------------------------------------------------------------------------------
+
+===============================================================================
+                            Wi-Fi scan list (wlan1)
+===============================================================================
+NAME:                                   [35mAP[1][0m
+SSID:                                   [35mwlan1-ap-4[0m
+SSID-HEX:                               [35m776C616E312D61702D34[0m
+BSSID:                                  [35m94:2B:E8:F6:D2:86[0m
+MODE:                                   [35mInfra[0m
+CHAN:                                   [35m1[0m
+FREQ:                                   [35m2412 MHz[0m
+RATE:                                   [35m54 Mbit/s[0m
+SIGNAL:                                 [35m48[0m
+BARS:                                   [35m**  [0m
+SECURITY:                               [35mWPA1 WPA2[0m
+WPA-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
+RSN-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
+DEVICE:                                 [35mwlan1[0m
+ACTIVE:                                 [35mno[0m
+IN-USE:                                 [35m [0m
+DBUS-PATH:                              [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
+-------------------------------------------------------------------------------
+
+===============================================================================
+                            Wi-Fi scan list (wlan1)
+===============================================================================
 
 <<<
 size: 5549
@@ -41660,32 +41840,6 @@ returncode: 0
 stdout: 5356 bytes
 >>>
 ===============================================================================
-                     Lista skanowania sieci Wi-Fi (wlan1)
-===============================================================================
-NAME:                                   [35mAP[1][0m
-SSID:                                   [35mwlan1-ap-4[0m
-SSID-HEX:                               [35m776C616E312D61702D34[0m
-BSSID:                                  [35m94:2B:E8:F6:D2:86[0m
-MODE:                                   [35mInfrastruktura[0m
-CHAN:                                   [35m1[0m
-FREQ:                                   [35m2412 MHz[0m
-RATE:                                   [35m54 Mb/s[0m
-SIGNAL:                                 [35m48[0m
-BARS:                                   [35m**  [0m
-SECURITY:                               [35mWPA1 WPA2[0m
-WPA-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
-RSN-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
-DEVICE:                                 [35mwlan1[0m
-ACTIVE:                                 [35mnie[0m
-IN-USE:                                 [35m [0m
-DBUS-PATH:                              [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
--------------------------------------------------------------------------------
-
-===============================================================================
-                     Lista skanowania sieci Wi-Fi (wlan1)
-===============================================================================
-
-===============================================================================
                      Lista skanowania sieci Wi-Fi (wlan0)
 ===============================================================================
 NAME:                                   [32mAP[1][0m
@@ -41742,6 +41896,32 @@ ACTIVE:                                 [35mnie[0m
 IN-USE:                                 [35m [0m
 DBUS-PATH:                              [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m
 -------------------------------------------------------------------------------
+
+===============================================================================
+                     Lista skanowania sieci Wi-Fi (wlan1)
+===============================================================================
+NAME:                                   [35mAP[1][0m
+SSID:                                   [35mwlan1-ap-4[0m
+SSID-HEX:                               [35m776C616E312D61702D34[0m
+BSSID:                                  [35m94:2B:E8:F6:D2:86[0m
+MODE:                                   [35mInfrastruktura[0m
+CHAN:                                   [35m1[0m
+FREQ:                                   [35m2412 MHz[0m
+RATE:                                   [35m54 Mb/s[0m
+SIGNAL:                                 [35m48[0m
+BARS:                                   [35m**  [0m
+SECURITY:                               [35mWPA1 WPA2[0m
+WPA-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
+RSN-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
+DEVICE:                                 [35mwlan1[0m
+ACTIVE:                                 [35mnie[0m
+IN-USE:                                 [35m [0m
+DBUS-PATH:                              [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
+-------------------------------------------------------------------------------
+
+===============================================================================
+                     Lista skanowania sieci Wi-Fi (wlan1)
+===============================================================================
 
 <<<
 size: 2908
@@ -41752,23 +41932,6 @@ returncode: 0
 stdout: 2722 bytes
 >>>
 ===============================================================================
-                            Wi-Fi scan list (wlan1)
-===============================================================================
-IN-USE:                                 [35m [0m
-SSID:                                   [35mwlan1-ap-4[0m
-MODE:                                   [35mInfra[0m
-CHAN:                                   [35m1[0m
-RATE:                                   [35m54 Mbit/s[0m
-SIGNAL:                                 [35m48[0m
-BARS:                                   [35m**  [0m
-SECURITY:                               [35mWPA1 WPA2[0m
--------------------------------------------------------------------------------
-
-===============================================================================
-                            Wi-Fi scan list (wlan1)
-===============================================================================
-
-===============================================================================
                             Wi-Fi scan list (wlan0)
 ===============================================================================
 IN-USE:                                 [32m [0m
@@ -41798,6 +41961,23 @@ SIGNAL:                                 [35m55[0m
 BARS:                                   [35m**  [0m
 SECURITY:                               [35mWPA1 WPA2[0m
 -------------------------------------------------------------------------------
+
+===============================================================================
+                            Wi-Fi scan list (wlan1)
+===============================================================================
+IN-USE:                                 [35m [0m
+SSID:                                   [35mwlan1-ap-4[0m
+MODE:                                   [35mInfra[0m
+CHAN:                                   [35m1[0m
+RATE:                                   [35m54 Mbit/s[0m
+SIGNAL:                                 [35m48[0m
+BARS:                                   [35m**  [0m
+SECURITY:                               [35mWPA1 WPA2[0m
+-------------------------------------------------------------------------------
+
+===============================================================================
+                            Wi-Fi scan list (wlan1)
+===============================================================================
 
 <<<
 size: 2972
@@ -41808,23 +41988,6 @@ returncode: 0
 stdout: 2776 bytes
 >>>
 ===============================================================================
-                     Lista skanowania sieci Wi-Fi (wlan1)
-===============================================================================
-IN-USE:                                 [35m [0m
-SSID:                                   [35mwlan1-ap-4[0m
-MODE:                                   [35mInfrastruktura[0m
-CHAN:                                   [35m1[0m
-RATE:                                   [35m54 Mb/s[0m
-SIGNAL:                                 [35m48[0m
-BARS:                                   [35m**  [0m
-SECURITY:                               [35mWPA1 WPA2[0m
--------------------------------------------------------------------------------
-
-===============================================================================
-                     Lista skanowania sieci Wi-Fi (wlan1)
-===============================================================================
-
-===============================================================================
                      Lista skanowania sieci Wi-Fi (wlan0)
 ===============================================================================
 IN-USE:                                 [32m [0m
@@ -41854,6 +42017,23 @@ SIGNAL:                                 [35m55[0m
 BARS:                                   [35m**  [0m
 SECURITY:                               [35mWPA1 WPA2[0m
 -------------------------------------------------------------------------------
+
+===============================================================================
+                     Lista skanowania sieci Wi-Fi (wlan1)
+===============================================================================
+IN-USE:                                 [35m [0m
+SSID:                                   [35mwlan1-ap-4[0m
+MODE:                                   [35mInfrastruktura[0m
+CHAN:                                   [35m1[0m
+RATE:                                   [35m54 Mb/s[0m
+SIGNAL:                                 [35m48[0m
+BARS:                                   [35m**  [0m
+SECURITY:                               [35mWPA1 WPA2[0m
+-------------------------------------------------------------------------------
+
+===============================================================================
+                     Lista skanowania sieci Wi-Fi (wlan1)
+===============================================================================
 
 <<<
 size: 5586
@@ -41864,32 +42044,6 @@ returncode: 0
 stdout: 5290 bytes
 >>>
 ===============================================================================
-                            Wi-Fi scan list (wlan1)
-===============================================================================
-NAME:                                   [35mAP[1][0m
-SSID:                                   [35mwlan1-ap-4[0m
-SSID-HEX:                               [35m776C616E312D61702D34[0m
-BSSID:                                  [35m94:2B:E8:F6:D2:86[0m
-MODE:                                   [35mInfra[0m
-CHAN:                                   [35m1[0m
-FREQ:                                   [35m2412 MHz[0m
-RATE:                                   [35m54 Mbit/s[0m
-SIGNAL:                                 [35m48[0m
-BARS:                                   [35m**  [0m
-SECURITY:                               [35mWPA1 WPA2[0m
-WPA-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
-RSN-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
-DEVICE:                                 [35mwlan1[0m
-ACTIVE:                                 [35mno[0m
-IN-USE:                                 [35m [0m
-DBUS-PATH:                              [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
--------------------------------------------------------------------------------
-
-===============================================================================
-                            Wi-Fi scan list (wlan1)
-===============================================================================
-
-===============================================================================
                             Wi-Fi scan list (wlan0)
 ===============================================================================
 NAME:                                   [32mAP[1][0m
@@ -41946,6 +42100,32 @@ ACTIVE:                                 [35mno[0m
 IN-USE:                                 [35m [0m
 DBUS-PATH:                              [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m
 -------------------------------------------------------------------------------
+
+===============================================================================
+                            Wi-Fi scan list (wlan1)
+===============================================================================
+NAME:                                   [35mAP[1][0m
+SSID:                                   [35mwlan1-ap-4[0m
+SSID-HEX:                               [35m776C616E312D61702D34[0m
+BSSID:                                  [35m94:2B:E8:F6:D2:86[0m
+MODE:                                   [35mInfra[0m
+CHAN:                                   [35m1[0m
+FREQ:                                   [35m2412 MHz[0m
+RATE:                                   [35m54 Mbit/s[0m
+SIGNAL:                                 [35m48[0m
+BARS:                                   [35m**  [0m
+SECURITY:                               [35mWPA1 WPA2[0m
+WPA-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
+RSN-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
+DEVICE:                                 [35mwlan1[0m
+ACTIVE:                                 [35mno[0m
+IN-USE:                                 [35m [0m
+DBUS-PATH:                              [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
+-------------------------------------------------------------------------------
+
+===============================================================================
+                            Wi-Fi scan list (wlan1)
+===============================================================================
 
 <<<
 size: 5662
@@ -41956,32 +42136,6 @@ returncode: 0
 stdout: 5356 bytes
 >>>
 ===============================================================================
-                     Lista skanowania sieci Wi-Fi (wlan1)
-===============================================================================
-NAME:                                   [35mAP[1][0m
-SSID:                                   [35mwlan1-ap-4[0m
-SSID-HEX:                               [35m776C616E312D61702D34[0m
-BSSID:                                  [35m94:2B:E8:F6:D2:86[0m
-MODE:                                   [35mInfrastruktura[0m
-CHAN:                                   [35m1[0m
-FREQ:                                   [35m2412 MHz[0m
-RATE:                                   [35m54 Mb/s[0m
-SIGNAL:                                 [35m48[0m
-BARS:                                   [35m**  [0m
-SECURITY:                               [35mWPA1 WPA2[0m
-WPA-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
-RSN-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
-DEVICE:                                 [35mwlan1[0m
-ACTIVE:                                 [35mnie[0m
-IN-USE:                                 [35m [0m
-DBUS-PATH:                              [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
--------------------------------------------------------------------------------
-
-===============================================================================
-                     Lista skanowania sieci Wi-Fi (wlan1)
-===============================================================================
-
-===============================================================================
                      Lista skanowania sieci Wi-Fi (wlan0)
 ===============================================================================
 NAME:                                   [32mAP[1][0m
@@ -42039,13 +42193,39 @@ IN-USE:                                 [35m [0m
 DBUS-PATH:                              [35m/org/freedesktop/NetworkManager/AccessPoint/3[0m
 -------------------------------------------------------------------------------
 
+===============================================================================
+                     Lista skanowania sieci Wi-Fi (wlan1)
+===============================================================================
+NAME:                                   [35mAP[1][0m
+SSID:                                   [35mwlan1-ap-4[0m
+SSID-HEX:                               [35m776C616E312D61702D34[0m
+BSSID:                                  [35m94:2B:E8:F6:D2:86[0m
+MODE:                                   [35mInfrastruktura[0m
+CHAN:                                   [35m1[0m
+FREQ:                                   [35m2412 MHz[0m
+RATE:                                   [35m54 Mb/s[0m
+SIGNAL:                                 [35m48[0m
+BARS:                                   [35m**  [0m
+SECURITY:                               [35mWPA1 WPA2[0m
+WPA-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
+RSN-FLAGS:                              [35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
+DEVICE:                                 [35mwlan1[0m
+ACTIVE:                                 [35mnie[0m
+IN-USE:                                 [35m [0m
+DBUS-PATH:                              [35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
+-------------------------------------------------------------------------------
+
+===============================================================================
+                     Lista skanowania sieci Wi-Fi (wlan1)
+===============================================================================
+
 <<<
-size: 1582
+size: 1584
 location: clients/tests/test-client.py:1075:test_004()/747
 cmd: $NMCLI --mode multiline --pretty --color yes -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 1375 bytes
+stdout: 1377 bytes
 >>>
 ===============================================================================
                             Wi-Fi scan list (wlan0)
@@ -42069,13 +42249,15 @@ IN-USE:                                 [32m [0m
 DBUS-PATH:                              [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
 -------------------------------------------------------------------------------
 
+
+
 <<<
-size: 1610
+size: 1612
 location: clients/tests/test-client.py:1075:test_004()/748
 cmd: $NMCLI --mode multiline --pretty --color yes -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 1393 bytes
+stdout: 1395 bytes
 >>>
 ===============================================================================
                      Lista skanowania sieci Wi-Fi (wlan0)
@@ -42099,13 +42281,15 @@ IN-USE:                                 [32m [0m
 DBUS-PATH:                              [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
 -------------------------------------------------------------------------------
 
+
+
 <<<
-size: 942
+size: 944
 location: clients/tests/test-client.py:1077:test_004()/749
 cmd: $NMCLI --mode multiline --pretty --color yes -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 733 bytes
+stdout: 735 bytes
 >>>
 ===============================================================================
                             Wi-Fi scan list (wlan0)
@@ -42120,13 +42304,15 @@ BARS:                                   [32m****[0m
 SECURITY:                               [32mWPA1 WPA2[0m
 -------------------------------------------------------------------------------
 
+
+
 <<<
-size: 967
+size: 969
 location: clients/tests/test-client.py:1077:test_004()/750
 cmd: $NMCLI --mode multiline --pretty --color yes -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 748 bytes
+stdout: 750 bytes
 >>>
 ===============================================================================
                      Lista skanowania sieci Wi-Fi (wlan0)
@@ -42141,13 +42327,15 @@ BARS:                                   [32m****[0m
 SECURITY:                               [32mWPA1 WPA2[0m
 -------------------------------------------------------------------------------
 
+
+
 <<<
-size: 1695
+size: 1697
 location: clients/tests/test-client.py:1080:test_004()/751
 cmd: $NMCLI --mode multiline --pretty --color yes -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 1375 bytes
+stdout: 1377 bytes
 >>>
 ===============================================================================
                             Wi-Fi scan list (wlan0)
@@ -42171,13 +42359,15 @@ IN-USE:                                 [32m [0m
 DBUS-PATH:                              [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
 -------------------------------------------------------------------------------
 
+
+
 <<<
-size: 1723
+size: 1725
 location: clients/tests/test-client.py:1080:test_004()/752
 cmd: $NMCLI --mode multiline --pretty --color yes -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 1393 bytes
+stdout: 1395 bytes
 >>>
 ===============================================================================
                      Lista skanowania sieci Wi-Fi (wlan0)
@@ -42200,6 +42390,8 @@ ACTIVE:                                 [32mnie[0m
 IN-USE:                                 [32m [0m
 DBUS-PATH:                              [32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
 -------------------------------------------------------------------------------
+
+
 
 <<<
 size: 6206
@@ -43399,6 +43591,10 @@ lang: C
 returncode: 0
 stdout: 280 bytes
 >>>
+DEVICE:wlan0
+TYPE:wifi
+STATE:unavailable
+CONNECTION:con-vpn-1
 DEVICE:eth0
 TYPE:ethernet
 STATE:unavailable
@@ -43415,10 +43611,6 @@ DEVICE:wlan1
 TYPE:wifi
 STATE:unavailable
 CONNECTION:
-DEVICE:wlan0
-TYPE:wifi
-STATE:unavailable
-CONNECTION:con-vpn-1
 
 <<<
 size: 441
@@ -43428,6 +43620,10 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 280 bytes
 >>>
+DEVICE:wlan0
+TYPE:wifi
+STATE:unavailable
+CONNECTION:con-vpn-1
 DEVICE:eth0
 TYPE:ethernet
 STATE:unavailable
@@ -43444,10 +43640,6 @@ DEVICE:wlan1
 TYPE:wifi
 STATE:unavailable
 CONNECTION:
-DEVICE:wlan0
-TYPE:wifi
-STATE:unavailable
-CONNECTION:con-vpn-1
 
 <<<
 size: 1139
@@ -43457,6 +43649,15 @@ lang: C
 returncode: 0
 stdout: 976 bytes
 >>>
+DEVICE:wlan0
+TYPE:wifi
+STATE:unavailable
+IP4-CONNECTIVITY:unknown
+IP6-CONNECTIVITY:unknown
+DBUS-PATH:/org/freedesktop/NetworkManager/Devices/3
+CONNECTION:con-vpn-1
+CON-UUID:UUID-con-vpn-1-REPLACED-REPLACED-REP
+CON-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
 DEVICE:eth0
 TYPE:ethernet
 STATE:unavailable
@@ -43493,15 +43694,6 @@ DBUS-PATH:/org/freedesktop/NetworkManager/Devices/5
 CONNECTION:
 CON-UUID:
 CON-PATH:
-DEVICE:wlan0
-TYPE:wifi
-STATE:unavailable
-IP4-CONNECTIVITY:unknown
-IP6-CONNECTIVITY:unknown
-DBUS-PATH:/org/freedesktop/NetworkManager/Devices/3
-CONNECTION:con-vpn-1
-CON-UUID:UUID-con-vpn-1-REPLACED-REPLACED-REP
-CON-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
 
 <<<
 size: 1159
@@ -43511,6 +43703,15 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 986 bytes
 >>>
+DEVICE:wlan0
+TYPE:wifi
+STATE:unavailable
+IP4-CONNECTIVITY:nieznane
+IP6-CONNECTIVITY:nieznane
+DBUS-PATH:/org/freedesktop/NetworkManager/Devices/3
+CONNECTION:con-vpn-1
+CON-UUID:UUID-con-vpn-1-REPLACED-REPLACED-REP
+CON-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
 DEVICE:eth0
 TYPE:ethernet
 STATE:unavailable
@@ -43547,15 +43748,6 @@ DBUS-PATH:/org/freedesktop/NetworkManager/Devices/5
 CONNECTION:
 CON-UUID:
 CON-PATH:
-DEVICE:wlan0
-TYPE:wifi
-STATE:unavailable
-IP4-CONNECTIVITY:nieznane
-IP6-CONNECTIVITY:nieznane
-DBUS-PATH:/org/freedesktop/NetworkManager/Devices/3
-CONNECTION:con-vpn-1
-CON-UUID:UUID-con-vpn-1-REPLACED-REPLACED-REP
-CON-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
 
 <<<
 size: 4557
@@ -43565,6 +43757,31 @@ lang: C
 returncode: 0
 stdout: 4402 bytes
 >>>
+GENERAL.DEVICE:wlan0
+GENERAL.TYPE:wifi
+GENERAL.HWADDR:13:E0:74:85:7C:D9
+GENERAL.MTU:0
+GENERAL.STATE:20 (unavailable)
+GENERAL.CONNECTION:con-vpn-1
+GENERAL.CON-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
+IP4.ADDRESS[1]:192.168.228.18/32
+IP4.ADDRESS[2]:192.168.209.179/25
+IP4.GATEWAY:192.168.41.120
+IP4.DOMAIN[1]:sear4.foo2.bar
+IP4.DOMAIN[2]:sear4.fo.x.y
+IP4.DOMAIN[3]:sear4.foo1.bar
+IP4.DOMAIN[4]:sear4.foo4.bar
+IP4.DOMAIN[5]:sear4.fo.o.bar
+IP4.WINS[1]:192.168.120.79
+IP6.GATEWAY:
+IP6.ROUTE[1]:dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
+IP6.DOMAIN[1]:sear6.foo2.bar
+IP6.DOMAIN[2]:sear6.foo1.bar
+IP6.DOMAIN[3]:sear6.fo.x.y
+IP6.DOMAIN[4]:sear6.fo.o.bar
+IP6.DOMAIN[5]:sear6.foo3.bar
+IP6.DOMAIN[6]:sear6.foo4.bar
+
 GENERAL.DEVICE:eth0
 GENERAL.TYPE:ethernet
 GENERAL.HWADDR:AB:B7:BF:E2:48:E8
@@ -43677,31 +43894,6 @@ IP6.ROUTE[2]:dst = 2001:a::a976:2488:f49f:b48/106, nh = 2001:a::62ae:c734:fc7b:e
 IP6.ROUTE[3]:dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::
 IP6.DNS[1]:2001:a::2934:bd66:550d:ec19
 IP6.DOMAIN[1]:sear6.fo.x.y
-
-GENERAL.DEVICE:wlan0
-GENERAL.TYPE:wifi
-GENERAL.HWADDR:13:E0:74:85:7C:D9
-GENERAL.MTU:0
-GENERAL.STATE:20 (unavailable)
-GENERAL.CONNECTION:con-vpn-1
-GENERAL.CON-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
-IP4.ADDRESS[1]:192.168.228.18/32
-IP4.ADDRESS[2]:192.168.209.179/25
-IP4.GATEWAY:192.168.41.120
-IP4.DOMAIN[1]:sear4.foo2.bar
-IP4.DOMAIN[2]:sear4.fo.x.y
-IP4.DOMAIN[3]:sear4.foo1.bar
-IP4.DOMAIN[4]:sear4.foo4.bar
-IP4.DOMAIN[5]:sear4.fo.o.bar
-IP4.WINS[1]:192.168.120.79
-IP6.GATEWAY:
-IP6.ROUTE[1]:dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
-IP6.DOMAIN[1]:sear6.foo2.bar
-IP6.DOMAIN[2]:sear6.foo1.bar
-IP6.DOMAIN[3]:sear6.fo.x.y
-IP6.DOMAIN[4]:sear6.fo.o.bar
-IP6.DOMAIN[5]:sear6.foo3.bar
-IP6.DOMAIN[6]:sear6.foo4.bar
 
 <<<
 size: 4567
@@ -43711,119 +43903,6 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 4402 bytes
 >>>
-GENERAL.DEVICE:eth0
-GENERAL.TYPE:ethernet
-GENERAL.HWADDR:AB:B7:BF:E2:48:E8
-GENERAL.MTU:0
-GENERAL.STATE:20 (unavailable)
-GENERAL.CONNECTION:
-GENERAL.CON-PATH:
-WIRED-PROPERTIES.CARRIER:off
-IP4.ADDRESS[1]:192.168.49.34/22
-IP4.ADDRESS[2]:192.168.135.86/19
-IP4.GATEWAY:
-IP4.DNS[1]:192.168.45.230
-IP4.DNS[2]:192.168.180.201
-IP4.DNS[3]:192.168.253.2
-IP4.DOMAIN[1]:sear4.foo2.bar
-IP4.DOMAIN[2]:sear4.foo1.bar
-IP4.WINS[1]:192.168.163.23
-IP4.WINS[2]:192.168.151.246
-IP6.ADDRESS[1]:2001:a::ed81:3d7:c2e9:df82/99
-IP6.GATEWAY:
-IP6.DNS[1]:2001:a::2703:f06:9619:d89f
-IP6.DNS[2]:2001:a::3a75:3682:c683:8541
-IP6.DNS[3]:2001:a::584e:912:d5ee:c74f
-IP6.DOMAIN[1]:sear6.foo4.bar
-IP6.DOMAIN[2]:sear6.fo.o.bar
-
-GENERAL.DEVICE:eth1
-GENERAL.TYPE:ethernet
-GENERAL.HWADDR:E7:78:B1:93:2B:22
-GENERAL.MTU:0
-GENERAL.STATE:20 (unavailable)
-GENERAL.CONNECTION:
-GENERAL.CON-PATH:
-WIRED-PROPERTIES.CARRIER:off
-IP4.ADDRESS[1]:192.168.127.210/25
-IP4.GATEWAY:192.168.88.4
-IP4.ROUTE[1]:dst = 192.168.222.35/19, nh = 192.168.170.142, mt = 3609264321
-IP4.ROUTE[2]:dst = 192.168.135.81/32, nh = 192.168.32.11, mt = 1316413247
-IP4.ROUTE[3]:dst = 192.168.24.65/26, nh = 192.168.23.163, mt = 3855574583
-IP4.DNS[1]:192.168.16.144
-IP4.DNS[2]:192.168.79.53
-IP4.DNS[3]:192.168.237.155
-IP4.DOMAIN[1]:sear4.foo4.bar
-IP4.DOMAIN[2]:sear4.foo3.bar
-IP4.DOMAIN[3]:sear4.foo1.bar
-IP4.WINS[1]:192.168.211.91
-IP4.WINS[2]:192.168.58.182
-IP4.WINS[3]:192.168.114.97
-IP6.ADDRESS[1]:2001:a::1c1:c178:169f:2b80/93
-IP6.ADDRESS[2]:2001:a::1f79:e0fb:87b9:3cc6/123
-IP6.GATEWAY:
-IP6.ROUTE[1]:dst = 2001:a::3166:7ed1:e4ae:7612/123, nh = ::
-IP6.DNS[1]:2001:a::edda:955:dcf4:23d4
-IP6.DNS[2]:2001:a::109f:aa0f:fb4a:9d5a
-IP6.DNS[3]:2001:a::61cf:7c82:e9c0:c952
-IP6.DOMAIN[1]:sear6.foo1.bar
-
-GENERAL.DEVICE:wlan1
-GENERAL.TYPE:wifi
-GENERAL.HWADDR:21:E9:64:81:8C:A8
-GENERAL.MTU:0
-GENERAL.STATE:20 (unavailable)
-GENERAL.CONNECTION:
-GENERAL.CON-PATH:
-IP4.GATEWAY:192.168.57.160
-IP4.ROUTE[1]:dst = 192.168.36.106/21, nh = 192.168.199.128, mt = 979274165
-IP4.ROUTE[2]:dst = 192.168.238.130/19, nh = 0.0.0.0
-IP4.ROUTE[3]:dst = 192.168.224.39/32, nh = 192.168.148.69
-IP4.DNS[1]:192.168.61.83
-IP4.DOMAIN[1]:sear4.foo4.bar
-IP4.DOMAIN[2]:sear4.fo.x.y
-IP4.DOMAIN[3]:sear4.foo2.bar
-IP4.DOMAIN[4]:sear4.foo1.bar
-IP4.DOMAIN[5]:sear4.fo.o.bar
-IP4.DOMAIN[6]:sear4.foo3.bar
-IP6.ADDRESS[1]:2001:a::fa05:2ab4:9300:e8fe/116
-IP6.ADDRESS[2]:2001:a::e9cf:bd3:caba:99b3/86
-IP6.ADDRESS[3]:2001:a::2be6:44fa:2c95:5559/78
-IP6.GATEWAY:2001:a::4d70:d91a:770f:2319
-IP6.ROUTE[1]:dst = 2001:a::3cb2:719d:bb00:b22f/66, nh = 2001:a::81b1:58b9:7237:3511, mt = 2280277732
-IP6.ROUTE[2]:dst = 2001:a::986f:983c:5eb:1c7d/99, nh = ::, mt = 1204008676
-IP6.DNS[1]:2001:a::85e7:3d7d:53e8:50ac
-IP6.DNS[2]:2001:a::1c5:9cb5:e86d:25a5
-IP6.DOMAIN[1]:sear6.foo4.bar
-IP6.DOMAIN[2]:sear6.foo2.bar
-
-GENERAL.DEVICE:wlan1
-GENERAL.TYPE:wifi
-GENERAL.HWADDR:71:52:AD:63:5C:7C
-GENERAL.MTU:0
-GENERAL.STATE:20 (unavailable)
-GENERAL.CONNECTION:
-GENERAL.CON-PATH:
-IP4.ADDRESS[1]:192.168.97.124/29
-IP4.ADDRESS[2]:192.168.76.154/18
-IP4.GATEWAY:
-IP4.ROUTE[1]:dst = 192.168.33.233/22, nh = 192.168.222.210, mt = 2810496551
-IP4.DNS[1]:192.168.107.109
-IP4.DOMAIN[1]:sear4.fo.o.bar
-IP4.DOMAIN[2]:sear4.fo.x.y
-IP4.DOMAIN[3]:sear4.foo2.bar
-IP4.DOMAIN[4]:sear4.foo3.bar
-IP4.DOMAIN[5]:sear4.foo4.bar
-IP4.WINS[1]:192.168.60.60
-IP4.WINS[2]:192.168.63.92
-IP6.ADDRESS[1]:2001:a::88ca:3654:96b:ab44/89
-IP6.GATEWAY:
-IP6.ROUTE[1]:dst = 2001:a::cc8b:7c09:4673:bbb0/85, nh = ::, mt = 2821465568
-IP6.ROUTE[2]:dst = 2001:a::a976:2488:f49f:b48/106, nh = 2001:a::62ae:c734:fc7b:e931, mt = 2248613879
-IP6.ROUTE[3]:dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::
-IP6.DNS[1]:2001:a::2934:bd66:550d:ec19
-IP6.DOMAIN[1]:sear6.fo.x.y
-
 GENERAL.DEVICE:wlan0
 GENERAL.TYPE:wifi
 GENERAL.HWADDR:13:E0:74:85:7C:D9
@@ -43849,44 +43928,13 @@ IP6.DOMAIN[4]:sear6.fo.o.bar
 IP6.DOMAIN[5]:sear6.foo3.bar
 IP6.DOMAIN[6]:sear6.foo4.bar
 
-<<<
-size: 11954
-location: clients/tests/test-client.py:1050:test_004()/775
-cmd: $NMCLI --mode multiline --terse -f all dev show
-lang: C
-returncode: 0
-stdout: 11791 bytes
->>>
 GENERAL.DEVICE:eth0
 GENERAL.TYPE:ethernet
-GENERAL.NM-TYPE:NMDeviceEthernet
-GENERAL.VENDOR:
-GENERAL.PRODUCT:
-GENERAL.DRIVER:virtual
-GENERAL.DRIVER-VERSION:
-GENERAL.FIRMWARE-VERSION:
 GENERAL.HWADDR:AB:B7:BF:E2:48:E8
 GENERAL.MTU:0
 GENERAL.STATE:20 (unavailable)
-GENERAL.REASON:0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:0 (unknown)
-GENERAL.IP6-CONNECTIVITY:0 (unknown)
-GENERAL.UDI:/sys/devices/virtual/eth0
-GENERAL.IP-IFACE:
-GENERAL.IS-SOFTWARE:no
-GENERAL.NM-MANAGED:yes
-GENERAL.AUTOCONNECT:yes
-GENERAL.FIRMWARE-MISSING:no
-GENERAL.NM-PLUGIN-MISSING:no
-GENERAL.PHYS-PORT-ID:
 GENERAL.CONNECTION:
-GENERAL.CON-UUID:
 GENERAL.CON-PATH:
-GENERAL.METERED:unknown
-CAPABILITIES.CARRIER-DETECT:no
-CAPABILITIES.SPEED:100 Mb/s
-CAPABILITIES.IS-SOFTWARE:no
-CAPABILITIES.SRIOV:no
 WIRED-PROPERTIES.CARRIER:off
 IP4.ADDRESS[1]:192.168.49.34/22
 IP4.ADDRESS[2]:192.168.135.86/19
@@ -43898,8 +43946,6 @@ IP4.DOMAIN[1]:sear4.foo2.bar
 IP4.DOMAIN[2]:sear4.foo1.bar
 IP4.WINS[1]:192.168.163.23
 IP4.WINS[2]:192.168.151.246
-DHCP4.OPTION[1]:dhcp-4-opt-8 = val-8
-DHCP4.OPTION[2]:dhcp-4-opt-9 = val-9
 IP6.ADDRESS[1]:2001:a::ed81:3d7:c2e9:df82/99
 IP6.GATEWAY:
 IP6.DNS[1]:2001:a::2703:f06:9619:d89f
@@ -43907,49 +43953,14 @@ IP6.DNS[2]:2001:a::3a75:3682:c683:8541
 IP6.DNS[3]:2001:a::584e:912:d5ee:c74f
 IP6.DOMAIN[1]:sear6.foo4.bar
 IP6.DOMAIN[2]:sear6.fo.o.bar
-DHCP6.OPTION[1]:dhcp-6-opt-0 = val-0
-DHCP6.OPTION[2]:dhcp-6-opt-1 = val-1
-DHCP6.OPTION[3]:dhcp-6-opt-2 = val-2
-DHCP6.OPTION[4]:dhcp-6-opt-3 = val-3
-DHCP6.OPTION[5]:dhcp-6-opt-4 = val-4
-DHCP6.OPTION[6]:dhcp-6-opt-5 = val-5
-DHCP6.OPTION[7]:dhcp-6-opt-6 = val-6
-DHCP6.OPTION[8]:dhcp-6-opt-7 = val-7
-DHCP6.OPTION[9]:dhcp-6-opt-8 = val-8
-DHCP6.OPTION[10]:dhcp-6-opt-9 = val-9
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{1}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:5fcfd6d7-1e63-3332-8826-a7eda103792d | con-1
 
 GENERAL.DEVICE:eth1
 GENERAL.TYPE:ethernet
-GENERAL.NM-TYPE:NMDeviceEthernet
-GENERAL.VENDOR:
-GENERAL.PRODUCT:
-GENERAL.DRIVER:virtual
-GENERAL.DRIVER-VERSION:
-GENERAL.FIRMWARE-VERSION:
 GENERAL.HWADDR:E7:78:B1:93:2B:22
 GENERAL.MTU:0
 GENERAL.STATE:20 (unavailable)
-GENERAL.REASON:0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:0 (unknown)
-GENERAL.IP6-CONNECTIVITY:0 (unknown)
-GENERAL.UDI:/sys/devices/virtual/eth1
-GENERAL.IP-IFACE:
-GENERAL.IS-SOFTWARE:no
-GENERAL.NM-MANAGED:yes
-GENERAL.AUTOCONNECT:yes
-GENERAL.FIRMWARE-MISSING:no
-GENERAL.NM-PLUGIN-MISSING:no
-GENERAL.PHYS-PORT-ID:
 GENERAL.CONNECTION:
-GENERAL.CON-UUID:
 GENERAL.CON-PATH:
-GENERAL.METERED:unknown
-CAPABILITIES.CARRIER-DETECT:no
-CAPABILITIES.SPEED:100 Mb/s
-CAPABILITIES.IS-SOFTWARE:no
-CAPABILITIES.SRIOV:no
 WIRED-PROPERTIES.CARRIER:off
 IP4.ADDRESS[1]:192.168.127.210/25
 IP4.GATEWAY:192.168.88.4
@@ -43965,15 +43976,6 @@ IP4.DOMAIN[3]:sear4.foo1.bar
 IP4.WINS[1]:192.168.211.91
 IP4.WINS[2]:192.168.58.182
 IP4.WINS[3]:192.168.114.97
-DHCP4.OPTION[1]:dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:dhcp-4-opt-1 = val-1
-DHCP4.OPTION[3]:dhcp-4-opt-2 = val-2
-DHCP4.OPTION[4]:dhcp-4-opt-3 = val-3
-DHCP4.OPTION[5]:dhcp-4-opt-4 = val-4
-DHCP4.OPTION[6]:dhcp-4-opt-5 = val-5
-DHCP4.OPTION[7]:dhcp-4-opt-7 = val-7
-DHCP4.OPTION[8]:dhcp-4-opt-8 = val-8
-DHCP4.OPTION[9]:dhcp-4-opt-9 = val-9
 IP6.ADDRESS[1]:2001:a::1c1:c178:169f:2b80/93
 IP6.ADDRESS[2]:2001:a::1f79:e0fb:87b9:3cc6/123
 IP6.GATEWAY:
@@ -43982,61 +43984,14 @@ IP6.DNS[1]:2001:a::edda:955:dcf4:23d4
 IP6.DNS[2]:2001:a::109f:aa0f:fb4a:9d5a
 IP6.DNS[3]:2001:a::61cf:7c82:e9c0:c952
 IP6.DOMAIN[1]:sear6.foo1.bar
-DHCP6.OPTION[1]:dhcp-6-opt-2 = val-2
-DHCP6.OPTION[2]:dhcp-6-opt-5 = val-5
-DHCP6.OPTION[3]:dhcp-6-opt-6 = val-6
-DHCP6.OPTION[4]:dhcp-6-opt-8 = val-8
-DHCP6.OPTION[5]:dhcp-6-opt-9 = val-9
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{1}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:5fcfd6d7-1e63-3332-8826-a7eda103792d | con-1
 
 GENERAL.DEVICE:wlan1
 GENERAL.TYPE:wifi
-GENERAL.NM-TYPE:NMDeviceWifi
-GENERAL.VENDOR:
-GENERAL.PRODUCT:
-GENERAL.DRIVER:virtual
-GENERAL.DRIVER-VERSION:
-GENERAL.FIRMWARE-VERSION:
 GENERAL.HWADDR:21:E9:64:81:8C:A8
 GENERAL.MTU:0
 GENERAL.STATE:20 (unavailable)
-GENERAL.REASON:0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:0 (unknown)
-GENERAL.IP6-CONNECTIVITY:0 (unknown)
-GENERAL.UDI:/sys/devices/virtual/wlan1
-GENERAL.IP-IFACE:
-GENERAL.IS-SOFTWARE:no
-GENERAL.NM-MANAGED:yes
-GENERAL.AUTOCONNECT:yes
-GENERAL.FIRMWARE-MISSING:no
-GENERAL.NM-PLUGIN-MISSING:no
-GENERAL.PHYS-PORT-ID:
 GENERAL.CONNECTION:
-GENERAL.CON-UUID:
 GENERAL.CON-PATH:
-GENERAL.METERED:unknown
-CAPABILITIES.CARRIER-DETECT:no
-CAPABILITIES.SPEED:unknown
-CAPABILITIES.IS-SOFTWARE:no
-CAPABILITIES.SRIOV:no
-WIFI-PROPERTIES.WEP:yes
-WIFI-PROPERTIES.WPA:yes
-WIFI-PROPERTIES.WPA2:yes
-WIFI-PROPERTIES.TKIP:yes
-WIFI-PROPERTIES.CCMP:yes
-WIFI-PROPERTIES.AP:yes
-WIFI-PROPERTIES.ADHOC:yes
-WIFI-PROPERTIES.2GHZ:unknown
-WIFI-PROPERTIES.5GHZ:unknown
-AP[1].IN-USE: 
-AP[1].SSID:wlan1-ap-4
-AP[1].MODE:Infra
-AP[1].CHAN:1
-AP[1].RATE:54 Mbit/s
-AP[1].SIGNAL:48
-AP[1].BARS:**  
-AP[1].SECURITY:WPA1 WPA2
 IP4.GATEWAY:192.168.57.160
 IP4.ROUTE[1]:dst = 192.168.36.106/21, nh = 192.168.199.128, mt = 979274165
 IP4.ROUTE[2]:dst = 192.168.238.130/19, nh = 0.0.0.0
@@ -44048,14 +44003,6 @@ IP4.DOMAIN[3]:sear4.foo2.bar
 IP4.DOMAIN[4]:sear4.foo1.bar
 IP4.DOMAIN[5]:sear4.fo.o.bar
 IP4.DOMAIN[6]:sear4.foo3.bar
-DHCP4.OPTION[1]:dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:dhcp-4-opt-1 = val-1
-DHCP4.OPTION[3]:dhcp-4-opt-2 = val-2
-DHCP4.OPTION[4]:dhcp-4-opt-4 = val-4
-DHCP4.OPTION[5]:dhcp-4-opt-6 = val-6
-DHCP4.OPTION[6]:dhcp-4-opt-7 = val-7
-DHCP4.OPTION[7]:dhcp-4-opt-8 = val-8
-DHCP4.OPTION[8]:dhcp-4-opt-9 = val-9
 IP6.ADDRESS[1]:2001:a::fa05:2ab4:9300:e8fe/116
 IP6.ADDRESS[2]:2001:a::e9cf:bd3:caba:99b3/86
 IP6.ADDRESS[3]:2001:a::2be6:44fa:2c95:5559/78
@@ -44066,57 +44013,14 @@ IP6.DNS[1]:2001:a::85e7:3d7d:53e8:50ac
 IP6.DNS[2]:2001:a::1c5:9cb5:e86d:25a5
 IP6.DOMAIN[1]:sear6.foo4.bar
 IP6.DOMAIN[2]:sear6.foo2.bar
-DHCP6.OPTION[1]:dhcp-6-opt-0 = val-0
-DHCP6.OPTION[2]:dhcp-6-opt-1 = val-1
-DHCP6.OPTION[3]:dhcp-6-opt-2 = val-2
-DHCP6.OPTION[4]:dhcp-6-opt-3 = val-3
-DHCP6.OPTION[5]:dhcp-6-opt-4 = val-4
-DHCP6.OPTION[6]:dhcp-6-opt-5 = val-5
-DHCP6.OPTION[7]:dhcp-6-opt-6 = val-6
-DHCP6.OPTION[8]:dhcp-6-opt-7 = val-7
-DHCP6.OPTION[9]:dhcp-6-opt-9 = val-9
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{2}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
 GENERAL.DEVICE:wlan1
 GENERAL.TYPE:wifi
-GENERAL.NM-TYPE:NMDeviceWifi
-GENERAL.VENDOR:
-GENERAL.PRODUCT:
-GENERAL.DRIVER:virtual
-GENERAL.DRIVER-VERSION:
-GENERAL.FIRMWARE-VERSION:
 GENERAL.HWADDR:71:52:AD:63:5C:7C
 GENERAL.MTU:0
 GENERAL.STATE:20 (unavailable)
-GENERAL.REASON:0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:0 (unknown)
-GENERAL.IP6-CONNECTIVITY:0 (unknown)
-GENERAL.UDI:/sys/devices/virtual/wlan1
-GENERAL.IP-IFACE:
-GENERAL.IS-SOFTWARE:no
-GENERAL.NM-MANAGED:yes
-GENERAL.AUTOCONNECT:yes
-GENERAL.FIRMWARE-MISSING:no
-GENERAL.NM-PLUGIN-MISSING:no
-GENERAL.PHYS-PORT-ID:
 GENERAL.CONNECTION:
-GENERAL.CON-UUID:
 GENERAL.CON-PATH:
-GENERAL.METERED:unknown
-CAPABILITIES.CARRIER-DETECT:no
-CAPABILITIES.SPEED:unknown
-CAPABILITIES.IS-SOFTWARE:no
-CAPABILITIES.SRIOV:no
-WIFI-PROPERTIES.WEP:yes
-WIFI-PROPERTIES.WPA:yes
-WIFI-PROPERTIES.WPA2:yes
-WIFI-PROPERTIES.TKIP:yes
-WIFI-PROPERTIES.CCMP:yes
-WIFI-PROPERTIES.AP:yes
-WIFI-PROPERTIES.ADHOC:yes
-WIFI-PROPERTIES.2GHZ:unknown
-WIFI-PROPERTIES.5GHZ:unknown
 IP4.ADDRESS[1]:192.168.97.124/29
 IP4.ADDRESS[2]:192.168.76.154/18
 IP4.GATEWAY:
@@ -44129,8 +44033,6 @@ IP4.DOMAIN[4]:sear4.foo3.bar
 IP4.DOMAIN[5]:sear4.foo4.bar
 IP4.WINS[1]:192.168.60.60
 IP4.WINS[2]:192.168.63.92
-DHCP4.OPTION[1]:dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:dhcp-4-opt-5 = val-5
 IP6.ADDRESS[1]:2001:a::88ca:3654:96b:ab44/89
 IP6.GATEWAY:
 IP6.ROUTE[1]:dst = 2001:a::cc8b:7c09:4673:bbb0/85, nh = ::, mt = 2821465568
@@ -44138,14 +44040,15 @@ IP6.ROUTE[2]:dst = 2001:a::a976:2488:f49f:b48/106, nh = 2001:a::62ae:c734:fc7b:e
 IP6.ROUTE[3]:dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::
 IP6.DNS[1]:2001:a::2934:bd66:550d:ec19
 IP6.DOMAIN[1]:sear6.fo.x.y
-DHCP6.OPTION[1]:dhcp-6-opt-2 = val-2
-DHCP6.OPTION[2]:dhcp-6-opt-6 = val-6
-DHCP6.OPTION[3]:dhcp-6-opt-7 = val-7
-DHCP6.OPTION[4]:dhcp-6-opt-8 = val-8
-DHCP6.OPTION[5]:dhcp-6-opt-9 = val-9
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{2}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
+<<<
+size: 11954
+location: clients/tests/test-client.py:1050:test_004()/775
+cmd: $NMCLI --mode multiline --terse -f all dev show
+lang: C
+returncode: 0
+stdout: 11791 bytes
+>>>
 GENERAL.DEVICE:wlan0
 GENERAL.TYPE:wifi
 GENERAL.NM-TYPE:NMDeviceWifi
@@ -44238,6 +44141,295 @@ DHCP6.OPTION[5]:dhcp-6-opt-5 = val-5
 CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{2}
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
+GENERAL.DEVICE:eth0
+GENERAL.TYPE:ethernet
+GENERAL.NM-TYPE:NMDeviceEthernet
+GENERAL.VENDOR:
+GENERAL.PRODUCT:
+GENERAL.DRIVER:virtual
+GENERAL.DRIVER-VERSION:
+GENERAL.FIRMWARE-VERSION:
+GENERAL.HWADDR:AB:B7:BF:E2:48:E8
+GENERAL.MTU:0
+GENERAL.STATE:20 (unavailable)
+GENERAL.REASON:0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:0 (unknown)
+GENERAL.IP6-CONNECTIVITY:0 (unknown)
+GENERAL.UDI:/sys/devices/virtual/eth0
+GENERAL.IP-IFACE:
+GENERAL.IS-SOFTWARE:no
+GENERAL.NM-MANAGED:yes
+GENERAL.AUTOCONNECT:yes
+GENERAL.FIRMWARE-MISSING:no
+GENERAL.NM-PLUGIN-MISSING:no
+GENERAL.PHYS-PORT-ID:
+GENERAL.CONNECTION:
+GENERAL.CON-UUID:
+GENERAL.CON-PATH:
+GENERAL.METERED:unknown
+CAPABILITIES.CARRIER-DETECT:no
+CAPABILITIES.SPEED:100 Mb/s
+CAPABILITIES.IS-SOFTWARE:no
+CAPABILITIES.SRIOV:no
+WIRED-PROPERTIES.CARRIER:off
+IP4.ADDRESS[1]:192.168.49.34/22
+IP4.ADDRESS[2]:192.168.135.86/19
+IP4.GATEWAY:
+IP4.DNS[1]:192.168.45.230
+IP4.DNS[2]:192.168.180.201
+IP4.DNS[3]:192.168.253.2
+IP4.DOMAIN[1]:sear4.foo2.bar
+IP4.DOMAIN[2]:sear4.foo1.bar
+IP4.WINS[1]:192.168.163.23
+IP4.WINS[2]:192.168.151.246
+DHCP4.OPTION[1]:dhcp-4-opt-8 = val-8
+DHCP4.OPTION[2]:dhcp-4-opt-9 = val-9
+IP6.ADDRESS[1]:2001:a::ed81:3d7:c2e9:df82/99
+IP6.GATEWAY:
+IP6.DNS[1]:2001:a::2703:f06:9619:d89f
+IP6.DNS[2]:2001:a::3a75:3682:c683:8541
+IP6.DNS[3]:2001:a::584e:912:d5ee:c74f
+IP6.DOMAIN[1]:sear6.foo4.bar
+IP6.DOMAIN[2]:sear6.fo.o.bar
+DHCP6.OPTION[1]:dhcp-6-opt-0 = val-0
+DHCP6.OPTION[2]:dhcp-6-opt-1 = val-1
+DHCP6.OPTION[3]:dhcp-6-opt-2 = val-2
+DHCP6.OPTION[4]:dhcp-6-opt-3 = val-3
+DHCP6.OPTION[5]:dhcp-6-opt-4 = val-4
+DHCP6.OPTION[6]:dhcp-6-opt-5 = val-5
+DHCP6.OPTION[7]:dhcp-6-opt-6 = val-6
+DHCP6.OPTION[8]:dhcp-6-opt-7 = val-7
+DHCP6.OPTION[9]:dhcp-6-opt-8 = val-8
+DHCP6.OPTION[10]:dhcp-6-opt-9 = val-9
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{1}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:5fcfd6d7-1e63-3332-8826-a7eda103792d | con-1
+
+GENERAL.DEVICE:eth1
+GENERAL.TYPE:ethernet
+GENERAL.NM-TYPE:NMDeviceEthernet
+GENERAL.VENDOR:
+GENERAL.PRODUCT:
+GENERAL.DRIVER:virtual
+GENERAL.DRIVER-VERSION:
+GENERAL.FIRMWARE-VERSION:
+GENERAL.HWADDR:E7:78:B1:93:2B:22
+GENERAL.MTU:0
+GENERAL.STATE:20 (unavailable)
+GENERAL.REASON:0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:0 (unknown)
+GENERAL.IP6-CONNECTIVITY:0 (unknown)
+GENERAL.UDI:/sys/devices/virtual/eth1
+GENERAL.IP-IFACE:
+GENERAL.IS-SOFTWARE:no
+GENERAL.NM-MANAGED:yes
+GENERAL.AUTOCONNECT:yes
+GENERAL.FIRMWARE-MISSING:no
+GENERAL.NM-PLUGIN-MISSING:no
+GENERAL.PHYS-PORT-ID:
+GENERAL.CONNECTION:
+GENERAL.CON-UUID:
+GENERAL.CON-PATH:
+GENERAL.METERED:unknown
+CAPABILITIES.CARRIER-DETECT:no
+CAPABILITIES.SPEED:100 Mb/s
+CAPABILITIES.IS-SOFTWARE:no
+CAPABILITIES.SRIOV:no
+WIRED-PROPERTIES.CARRIER:off
+IP4.ADDRESS[1]:192.168.127.210/25
+IP4.GATEWAY:192.168.88.4
+IP4.ROUTE[1]:dst = 192.168.222.35/19, nh = 192.168.170.142, mt = 3609264321
+IP4.ROUTE[2]:dst = 192.168.135.81/32, nh = 192.168.32.11, mt = 1316413247
+IP4.ROUTE[3]:dst = 192.168.24.65/26, nh = 192.168.23.163, mt = 3855574583
+IP4.DNS[1]:192.168.16.144
+IP4.DNS[2]:192.168.79.53
+IP4.DNS[3]:192.168.237.155
+IP4.DOMAIN[1]:sear4.foo4.bar
+IP4.DOMAIN[2]:sear4.foo3.bar
+IP4.DOMAIN[3]:sear4.foo1.bar
+IP4.WINS[1]:192.168.211.91
+IP4.WINS[2]:192.168.58.182
+IP4.WINS[3]:192.168.114.97
+DHCP4.OPTION[1]:dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:dhcp-4-opt-1 = val-1
+DHCP4.OPTION[3]:dhcp-4-opt-2 = val-2
+DHCP4.OPTION[4]:dhcp-4-opt-3 = val-3
+DHCP4.OPTION[5]:dhcp-4-opt-4 = val-4
+DHCP4.OPTION[6]:dhcp-4-opt-5 = val-5
+DHCP4.OPTION[7]:dhcp-4-opt-7 = val-7
+DHCP4.OPTION[8]:dhcp-4-opt-8 = val-8
+DHCP4.OPTION[9]:dhcp-4-opt-9 = val-9
+IP6.ADDRESS[1]:2001:a::1c1:c178:169f:2b80/93
+IP6.ADDRESS[2]:2001:a::1f79:e0fb:87b9:3cc6/123
+IP6.GATEWAY:
+IP6.ROUTE[1]:dst = 2001:a::3166:7ed1:e4ae:7612/123, nh = ::
+IP6.DNS[1]:2001:a::edda:955:dcf4:23d4
+IP6.DNS[2]:2001:a::109f:aa0f:fb4a:9d5a
+IP6.DNS[3]:2001:a::61cf:7c82:e9c0:c952
+IP6.DOMAIN[1]:sear6.foo1.bar
+DHCP6.OPTION[1]:dhcp-6-opt-2 = val-2
+DHCP6.OPTION[2]:dhcp-6-opt-5 = val-5
+DHCP6.OPTION[3]:dhcp-6-opt-6 = val-6
+DHCP6.OPTION[4]:dhcp-6-opt-8 = val-8
+DHCP6.OPTION[5]:dhcp-6-opt-9 = val-9
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{1}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:5fcfd6d7-1e63-3332-8826-a7eda103792d | con-1
+
+GENERAL.DEVICE:wlan1
+GENERAL.TYPE:wifi
+GENERAL.NM-TYPE:NMDeviceWifi
+GENERAL.VENDOR:
+GENERAL.PRODUCT:
+GENERAL.DRIVER:virtual
+GENERAL.DRIVER-VERSION:
+GENERAL.FIRMWARE-VERSION:
+GENERAL.HWADDR:21:E9:64:81:8C:A8
+GENERAL.MTU:0
+GENERAL.STATE:20 (unavailable)
+GENERAL.REASON:0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:0 (unknown)
+GENERAL.IP6-CONNECTIVITY:0 (unknown)
+GENERAL.UDI:/sys/devices/virtual/wlan1
+GENERAL.IP-IFACE:
+GENERAL.IS-SOFTWARE:no
+GENERAL.NM-MANAGED:yes
+GENERAL.AUTOCONNECT:yes
+GENERAL.FIRMWARE-MISSING:no
+GENERAL.NM-PLUGIN-MISSING:no
+GENERAL.PHYS-PORT-ID:
+GENERAL.CONNECTION:
+GENERAL.CON-UUID:
+GENERAL.CON-PATH:
+GENERAL.METERED:unknown
+CAPABILITIES.CARRIER-DETECT:no
+CAPABILITIES.SPEED:unknown
+CAPABILITIES.IS-SOFTWARE:no
+CAPABILITIES.SRIOV:no
+WIFI-PROPERTIES.WEP:yes
+WIFI-PROPERTIES.WPA:yes
+WIFI-PROPERTIES.WPA2:yes
+WIFI-PROPERTIES.TKIP:yes
+WIFI-PROPERTIES.CCMP:yes
+WIFI-PROPERTIES.AP:yes
+WIFI-PROPERTIES.ADHOC:yes
+WIFI-PROPERTIES.2GHZ:unknown
+WIFI-PROPERTIES.5GHZ:unknown
+AP[1].IN-USE: 
+AP[1].SSID:wlan1-ap-4
+AP[1].MODE:Infra
+AP[1].CHAN:1
+AP[1].RATE:54 Mbit/s
+AP[1].SIGNAL:48
+AP[1].BARS:**  
+AP[1].SECURITY:WPA1 WPA2
+IP4.GATEWAY:192.168.57.160
+IP4.ROUTE[1]:dst = 192.168.36.106/21, nh = 192.168.199.128, mt = 979274165
+IP4.ROUTE[2]:dst = 192.168.238.130/19, nh = 0.0.0.0
+IP4.ROUTE[3]:dst = 192.168.224.39/32, nh = 192.168.148.69
+IP4.DNS[1]:192.168.61.83
+IP4.DOMAIN[1]:sear4.foo4.bar
+IP4.DOMAIN[2]:sear4.fo.x.y
+IP4.DOMAIN[3]:sear4.foo2.bar
+IP4.DOMAIN[4]:sear4.foo1.bar
+IP4.DOMAIN[5]:sear4.fo.o.bar
+IP4.DOMAIN[6]:sear4.foo3.bar
+DHCP4.OPTION[1]:dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:dhcp-4-opt-1 = val-1
+DHCP4.OPTION[3]:dhcp-4-opt-2 = val-2
+DHCP4.OPTION[4]:dhcp-4-opt-4 = val-4
+DHCP4.OPTION[5]:dhcp-4-opt-6 = val-6
+DHCP4.OPTION[6]:dhcp-4-opt-7 = val-7
+DHCP4.OPTION[7]:dhcp-4-opt-8 = val-8
+DHCP4.OPTION[8]:dhcp-4-opt-9 = val-9
+IP6.ADDRESS[1]:2001:a::fa05:2ab4:9300:e8fe/116
+IP6.ADDRESS[2]:2001:a::e9cf:bd3:caba:99b3/86
+IP6.ADDRESS[3]:2001:a::2be6:44fa:2c95:5559/78
+IP6.GATEWAY:2001:a::4d70:d91a:770f:2319
+IP6.ROUTE[1]:dst = 2001:a::3cb2:719d:bb00:b22f/66, nh = 2001:a::81b1:58b9:7237:3511, mt = 2280277732
+IP6.ROUTE[2]:dst = 2001:a::986f:983c:5eb:1c7d/99, nh = ::, mt = 1204008676
+IP6.DNS[1]:2001:a::85e7:3d7d:53e8:50ac
+IP6.DNS[2]:2001:a::1c5:9cb5:e86d:25a5
+IP6.DOMAIN[1]:sear6.foo4.bar
+IP6.DOMAIN[2]:sear6.foo2.bar
+DHCP6.OPTION[1]:dhcp-6-opt-0 = val-0
+DHCP6.OPTION[2]:dhcp-6-opt-1 = val-1
+DHCP6.OPTION[3]:dhcp-6-opt-2 = val-2
+DHCP6.OPTION[4]:dhcp-6-opt-3 = val-3
+DHCP6.OPTION[5]:dhcp-6-opt-4 = val-4
+DHCP6.OPTION[6]:dhcp-6-opt-5 = val-5
+DHCP6.OPTION[7]:dhcp-6-opt-6 = val-6
+DHCP6.OPTION[8]:dhcp-6-opt-7 = val-7
+DHCP6.OPTION[9]:dhcp-6-opt-9 = val-9
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{2}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
+
+GENERAL.DEVICE:wlan1
+GENERAL.TYPE:wifi
+GENERAL.NM-TYPE:NMDeviceWifi
+GENERAL.VENDOR:
+GENERAL.PRODUCT:
+GENERAL.DRIVER:virtual
+GENERAL.DRIVER-VERSION:
+GENERAL.FIRMWARE-VERSION:
+GENERAL.HWADDR:71:52:AD:63:5C:7C
+GENERAL.MTU:0
+GENERAL.STATE:20 (unavailable)
+GENERAL.REASON:0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:0 (unknown)
+GENERAL.IP6-CONNECTIVITY:0 (unknown)
+GENERAL.UDI:/sys/devices/virtual/wlan1
+GENERAL.IP-IFACE:
+GENERAL.IS-SOFTWARE:no
+GENERAL.NM-MANAGED:yes
+GENERAL.AUTOCONNECT:yes
+GENERAL.FIRMWARE-MISSING:no
+GENERAL.NM-PLUGIN-MISSING:no
+GENERAL.PHYS-PORT-ID:
+GENERAL.CONNECTION:
+GENERAL.CON-UUID:
+GENERAL.CON-PATH:
+GENERAL.METERED:unknown
+CAPABILITIES.CARRIER-DETECT:no
+CAPABILITIES.SPEED:unknown
+CAPABILITIES.IS-SOFTWARE:no
+CAPABILITIES.SRIOV:no
+WIFI-PROPERTIES.WEP:yes
+WIFI-PROPERTIES.WPA:yes
+WIFI-PROPERTIES.WPA2:yes
+WIFI-PROPERTIES.TKIP:yes
+WIFI-PROPERTIES.CCMP:yes
+WIFI-PROPERTIES.AP:yes
+WIFI-PROPERTIES.ADHOC:yes
+WIFI-PROPERTIES.2GHZ:unknown
+WIFI-PROPERTIES.5GHZ:unknown
+IP4.ADDRESS[1]:192.168.97.124/29
+IP4.ADDRESS[2]:192.168.76.154/18
+IP4.GATEWAY:
+IP4.ROUTE[1]:dst = 192.168.33.233/22, nh = 192.168.222.210, mt = 2810496551
+IP4.DNS[1]:192.168.107.109
+IP4.DOMAIN[1]:sear4.fo.o.bar
+IP4.DOMAIN[2]:sear4.fo.x.y
+IP4.DOMAIN[3]:sear4.foo2.bar
+IP4.DOMAIN[4]:sear4.foo3.bar
+IP4.DOMAIN[5]:sear4.foo4.bar
+IP4.WINS[1]:192.168.60.60
+IP4.WINS[2]:192.168.63.92
+DHCP4.OPTION[1]:dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:dhcp-4-opt-5 = val-5
+IP6.ADDRESS[1]:2001:a::88ca:3654:96b:ab44/89
+IP6.GATEWAY:
+IP6.ROUTE[1]:dst = 2001:a::cc8b:7c09:4673:bbb0/85, nh = ::, mt = 2821465568
+IP6.ROUTE[2]:dst = 2001:a::a976:2488:f49f:b48/106, nh = 2001:a::62ae:c734:fc7b:e931, mt = 2248613879
+IP6.ROUTE[3]:dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::
+IP6.DNS[1]:2001:a::2934:bd66:550d:ec19
+IP6.DOMAIN[1]:sear6.fo.x.y
+DHCP6.OPTION[1]:dhcp-6-opt-2 = val-2
+DHCP6.OPTION[2]:dhcp-6-opt-6 = val-6
+DHCP6.OPTION[3]:dhcp-6-opt-7 = val-7
+DHCP6.OPTION[4]:dhcp-6-opt-8 = val-8
+DHCP6.OPTION[5]:dhcp-6-opt-9 = val-9
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{2}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
+
 <<<
 size: 12010
 location: clients/tests/test-client.py:1050:test_004()/776
@@ -44246,6 +44438,98 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 11837 bytes
 >>>
+GENERAL.DEVICE:wlan0
+GENERAL.TYPE:wifi
+GENERAL.NM-TYPE:NMDeviceWifi
+GENERAL.VENDOR:
+GENERAL.PRODUCT:
+GENERAL.DRIVER:virtual
+GENERAL.DRIVER-VERSION:
+GENERAL.FIRMWARE-VERSION:
+GENERAL.HWADDR:13:E0:74:85:7C:D9
+GENERAL.MTU:0
+GENERAL.STATE:20 (unavailable)
+GENERAL.REASON:0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:0 (nieznane)
+GENERAL.IP6-CONNECTIVITY:0 (nieznane)
+GENERAL.UDI:/sys/devices/virtual/wlan0
+GENERAL.IP-IFACE:
+GENERAL.IS-SOFTWARE:no
+GENERAL.NM-MANAGED:yes
+GENERAL.AUTOCONNECT:yes
+GENERAL.FIRMWARE-MISSING:no
+GENERAL.NM-PLUGIN-MISSING:no
+GENERAL.PHYS-PORT-ID:
+GENERAL.CONNECTION:con-vpn-1
+GENERAL.CON-UUID:UUID-con-vpn-1-REPLACED-REPLACED-REP
+GENERAL.CON-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
+GENERAL.METERED:unknown
+CAPABILITIES.CARRIER-DETECT:no
+CAPABILITIES.SPEED:unknown
+CAPABILITIES.IS-SOFTWARE:no
+CAPABILITIES.SRIOV:no
+WIFI-PROPERTIES.WEP:yes
+WIFI-PROPERTIES.WPA:yes
+WIFI-PROPERTIES.WPA2:yes
+WIFI-PROPERTIES.TKIP:yes
+WIFI-PROPERTIES.CCMP:yes
+WIFI-PROPERTIES.AP:yes
+WIFI-PROPERTIES.ADHOC:yes
+WIFI-PROPERTIES.2GHZ:unknown
+WIFI-PROPERTIES.5GHZ:unknown
+AP[1].IN-USE: 
+AP[1].SSID:wlan0-ap-2
+AP[1].MODE:Infrastruktura
+AP[1].CHAN:1
+AP[1].RATE:54 Mb/s
+AP[1].SIGNAL:92
+AP[1].BARS:****
+AP[1].SECURITY:WPA1 WPA2
+AP[2].IN-USE: 
+AP[2].SSID:wlan0-ap-1
+AP[2].MODE:Infrastruktura
+AP[2].CHAN:1
+AP[2].RATE:54 Mb/s
+AP[2].SIGNAL:81
+AP[2].BARS:****
+AP[2].SECURITY:WPA1 WPA2
+AP[3].IN-USE: 
+AP[3].SSID:wlan0-ap-3
+AP[3].MODE:Infrastruktura
+AP[3].CHAN:1
+AP[3].RATE:54 Mb/s
+AP[3].SIGNAL:55
+AP[3].BARS:**  
+AP[3].SECURITY:WPA1 WPA2
+IP4.ADDRESS[1]:192.168.228.18/32
+IP4.ADDRESS[2]:192.168.209.179/25
+IP4.GATEWAY:192.168.41.120
+IP4.DOMAIN[1]:sear4.foo2.bar
+IP4.DOMAIN[2]:sear4.fo.x.y
+IP4.DOMAIN[3]:sear4.foo1.bar
+IP4.DOMAIN[4]:sear4.foo4.bar
+IP4.DOMAIN[5]:sear4.fo.o.bar
+IP4.WINS[1]:192.168.120.79
+DHCP4.OPTION[1]:dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:dhcp-4-opt-2 = val-2
+DHCP4.OPTION[3]:dhcp-4-opt-4 = val-4
+DHCP4.OPTION[4]:dhcp-4-opt-7 = val-7
+IP6.GATEWAY:
+IP6.ROUTE[1]:dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
+IP6.DOMAIN[1]:sear6.foo2.bar
+IP6.DOMAIN[2]:sear6.foo1.bar
+IP6.DOMAIN[3]:sear6.fo.x.y
+IP6.DOMAIN[4]:sear6.fo.o.bar
+IP6.DOMAIN[5]:sear6.foo3.bar
+IP6.DOMAIN[6]:sear6.foo4.bar
+DHCP6.OPTION[1]:dhcp-6-opt-1 = val-1
+DHCP6.OPTION[2]:dhcp-6-opt-2 = val-2
+DHCP6.OPTION[3]:dhcp-6-opt-3 = val-3
+DHCP6.OPTION[4]:dhcp-6-opt-4 = val-4
+DHCP6.OPTION[5]:dhcp-6-opt-5 = val-5
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{2}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
+
 GENERAL.DEVICE:eth0
 GENERAL.TYPE:ethernet
 GENERAL.NM-TYPE:NMDeviceEthernet
@@ -44532,98 +44816,6 @@ DHCP6.OPTION[2]:dhcp-6-opt-6 = val-6
 DHCP6.OPTION[3]:dhcp-6-opt-7 = val-7
 DHCP6.OPTION[4]:dhcp-6-opt-8 = val-8
 DHCP6.OPTION[5]:dhcp-6-opt-9 = val-9
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{2}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
-
-GENERAL.DEVICE:wlan0
-GENERAL.TYPE:wifi
-GENERAL.NM-TYPE:NMDeviceWifi
-GENERAL.VENDOR:
-GENERAL.PRODUCT:
-GENERAL.DRIVER:virtual
-GENERAL.DRIVER-VERSION:
-GENERAL.FIRMWARE-VERSION:
-GENERAL.HWADDR:13:E0:74:85:7C:D9
-GENERAL.MTU:0
-GENERAL.STATE:20 (unavailable)
-GENERAL.REASON:0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:0 (nieznane)
-GENERAL.IP6-CONNECTIVITY:0 (nieznane)
-GENERAL.UDI:/sys/devices/virtual/wlan0
-GENERAL.IP-IFACE:
-GENERAL.IS-SOFTWARE:no
-GENERAL.NM-MANAGED:yes
-GENERAL.AUTOCONNECT:yes
-GENERAL.FIRMWARE-MISSING:no
-GENERAL.NM-PLUGIN-MISSING:no
-GENERAL.PHYS-PORT-ID:
-GENERAL.CONNECTION:con-vpn-1
-GENERAL.CON-UUID:UUID-con-vpn-1-REPLACED-REPLACED-REP
-GENERAL.CON-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
-GENERAL.METERED:unknown
-CAPABILITIES.CARRIER-DETECT:no
-CAPABILITIES.SPEED:unknown
-CAPABILITIES.IS-SOFTWARE:no
-CAPABILITIES.SRIOV:no
-WIFI-PROPERTIES.WEP:yes
-WIFI-PROPERTIES.WPA:yes
-WIFI-PROPERTIES.WPA2:yes
-WIFI-PROPERTIES.TKIP:yes
-WIFI-PROPERTIES.CCMP:yes
-WIFI-PROPERTIES.AP:yes
-WIFI-PROPERTIES.ADHOC:yes
-WIFI-PROPERTIES.2GHZ:unknown
-WIFI-PROPERTIES.5GHZ:unknown
-AP[1].IN-USE: 
-AP[1].SSID:wlan0-ap-2
-AP[1].MODE:Infrastruktura
-AP[1].CHAN:1
-AP[1].RATE:54 Mb/s
-AP[1].SIGNAL:92
-AP[1].BARS:****
-AP[1].SECURITY:WPA1 WPA2
-AP[2].IN-USE: 
-AP[2].SSID:wlan0-ap-1
-AP[2].MODE:Infrastruktura
-AP[2].CHAN:1
-AP[2].RATE:54 Mb/s
-AP[2].SIGNAL:81
-AP[2].BARS:****
-AP[2].SECURITY:WPA1 WPA2
-AP[3].IN-USE: 
-AP[3].SSID:wlan0-ap-3
-AP[3].MODE:Infrastruktura
-AP[3].CHAN:1
-AP[3].RATE:54 Mb/s
-AP[3].SIGNAL:55
-AP[3].BARS:**  
-AP[3].SECURITY:WPA1 WPA2
-IP4.ADDRESS[1]:192.168.228.18/32
-IP4.ADDRESS[2]:192.168.209.179/25
-IP4.GATEWAY:192.168.41.120
-IP4.DOMAIN[1]:sear4.foo2.bar
-IP4.DOMAIN[2]:sear4.fo.x.y
-IP4.DOMAIN[3]:sear4.foo1.bar
-IP4.DOMAIN[4]:sear4.foo4.bar
-IP4.DOMAIN[5]:sear4.fo.o.bar
-IP4.WINS[1]:192.168.120.79
-DHCP4.OPTION[1]:dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:dhcp-4-opt-2 = val-2
-DHCP4.OPTION[3]:dhcp-4-opt-4 = val-4
-DHCP4.OPTION[4]:dhcp-4-opt-7 = val-7
-IP6.GATEWAY:
-IP6.ROUTE[1]:dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
-IP6.DOMAIN[1]:sear6.foo2.bar
-IP6.DOMAIN[2]:sear6.foo1.bar
-IP6.DOMAIN[3]:sear6.fo.x.y
-IP6.DOMAIN[4]:sear6.fo.o.bar
-IP6.DOMAIN[5]:sear6.foo3.bar
-IP6.DOMAIN[6]:sear6.foo4.bar
-DHCP6.OPTION[1]:dhcp-6-opt-1 = val-1
-DHCP6.OPTION[2]:dhcp-6-opt-2 = val-2
-DHCP6.OPTION[3]:dhcp-6-opt-3 = val-3
-DHCP6.OPTION[4]:dhcp-6-opt-4 = val-4
-DHCP6.OPTION[5]:dhcp-6-opt-5 = val-5
 CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{2}
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
@@ -45081,6 +45273,9 @@ lang: C
 returncode: 0
 stdout: 381 bytes
 >>>
+DEVICE:wlan0
+TYPE:wifi
+DBUS-PATH:/org/freedesktop/NetworkManager/Devices/3
 DEVICE:eth0
 TYPE:ethernet
 DBUS-PATH:/org/freedesktop/NetworkManager/Devices/1
@@ -45093,9 +45288,6 @@ DBUS-PATH:/org/freedesktop/NetworkManager/Devices/4
 DEVICE:wlan1
 TYPE:wifi
 DBUS-PATH:/org/freedesktop/NetworkManager/Devices/5
-DEVICE:wlan0
-TYPE:wifi
-DBUS-PATH:/org/freedesktop/NetworkManager/Devices/3
 
 <<<
 size: 565
@@ -45105,6 +45297,9 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 381 bytes
 >>>
+DEVICE:wlan0
+TYPE:wifi
+DBUS-PATH:/org/freedesktop/NetworkManager/Devices/3
 DEVICE:eth0
 TYPE:ethernet
 DBUS-PATH:/org/freedesktop/NetworkManager/Devices/1
@@ -45117,9 +45312,6 @@ DBUS-PATH:/org/freedesktop/NetworkManager/Devices/4
 DEVICE:wlan1
 TYPE:wifi
 DBUS-PATH:/org/freedesktop/NetworkManager/Devices/5
-DEVICE:wlan0
-TYPE:wifi
-DBUS-PATH:/org/freedesktop/NetworkManager/Devices/3
 
 <<<
 size: 1640
@@ -45130,25 +45322,6 @@ returncode: 0
 stdout: 1470 bytes
 >>>
 NAME:AP[1]
-SSID:wlan1-ap-4
-SSID-HEX:776C616E312D61702D34
-BSSID:94:2B:E8:F6:D2:86
-MODE:Infra
-CHAN:1
-FREQ:2412 MHz
-RATE:54 Mbit/s
-SIGNAL:48
-BARS:**  
-SECURITY:WPA1 WPA2
-WPA-FLAGS:pair_tkip pair_ccmp group_tkip group_ccmp psk
-RSN-FLAGS:pair_tkip pair_ccmp group_tkip group_ccmp psk
-DEVICE:wlan1
-ACTIVE:no
-IN-USE: 
-DBUS-PATH:/org/freedesktop/NetworkManager/AccessPoint/4
-
-
-NAME:AP[1]
 SSID:wlan0-ap-2
 SSID-HEX:776C616E302D61702D32
 BSSID:C0:E2:BE:E8:EF:B6
@@ -45199,6 +45372,25 @@ DEVICE:wlan0
 ACTIVE:no
 IN-USE: 
 DBUS-PATH:/org/freedesktop/NetworkManager/AccessPoint/3
+
+NAME:AP[1]
+SSID:wlan1-ap-4
+SSID-HEX:776C616E312D61702D34
+BSSID:94:2B:E8:F6:D2:86
+MODE:Infra
+CHAN:1
+FREQ:2412 MHz
+RATE:54 Mbit/s
+SIGNAL:48
+BARS:**  
+SECURITY:WPA1 WPA2
+WPA-FLAGS:pair_tkip pair_ccmp group_tkip group_ccmp psk
+RSN-FLAGS:pair_tkip pair_ccmp group_tkip group_ccmp psk
+DEVICE:wlan1
+ACTIVE:no
+IN-USE: 
+DBUS-PATH:/org/freedesktop/NetworkManager/AccessPoint/4
+
 
 <<<
 size: 1698
@@ -45209,25 +45401,6 @@ returncode: 0
 stdout: 1518 bytes
 >>>
 NAME:AP[1]
-SSID:wlan1-ap-4
-SSID-HEX:776C616E312D61702D34
-BSSID:94:2B:E8:F6:D2:86
-MODE:Infrastruktura
-CHAN:1
-FREQ:2412 MHz
-RATE:54 Mb/s
-SIGNAL:48
-BARS:**  
-SECURITY:WPA1 WPA2
-WPA-FLAGS:pair_tkip pair_ccmp group_tkip group_ccmp psk
-RSN-FLAGS:pair_tkip pair_ccmp group_tkip group_ccmp psk
-DEVICE:wlan1
-ACTIVE:nie
-IN-USE: 
-DBUS-PATH:/org/freedesktop/NetworkManager/AccessPoint/4
-
-
-NAME:AP[1]
 SSID:wlan0-ap-2
 SSID-HEX:776C616E302D61702D32
 BSSID:C0:E2:BE:E8:EF:B6
@@ -45278,6 +45451,25 @@ DEVICE:wlan0
 ACTIVE:nie
 IN-USE: 
 DBUS-PATH:/org/freedesktop/NetworkManager/AccessPoint/3
+
+NAME:AP[1]
+SSID:wlan1-ap-4
+SSID-HEX:776C616E312D61702D34
+BSSID:94:2B:E8:F6:D2:86
+MODE:Infrastruktura
+CHAN:1
+FREQ:2412 MHz
+RATE:54 Mb/s
+SIGNAL:48
+BARS:**  
+SECURITY:WPA1 WPA2
+WPA-FLAGS:pair_tkip pair_ccmp group_tkip group_ccmp psk
+RSN-FLAGS:pair_tkip pair_ccmp group_tkip group_ccmp psk
+DEVICE:wlan1
+ACTIVE:nie
+IN-USE: 
+DBUS-PATH:/org/freedesktop/NetworkManager/AccessPoint/4
+
 
 <<<
 size: 562
@@ -45288,16 +45480,6 @@ returncode: 0
 stdout: 390 bytes
 >>>
 IN-USE: 
-SSID:wlan1-ap-4
-MODE:Infra
-CHAN:1
-RATE:54 Mbit/s
-SIGNAL:48
-BARS:**  
-SECURITY:WPA1 WPA2
-
-
-IN-USE: 
 SSID:wlan0-ap-2
 MODE:Infra
 CHAN:1
@@ -45321,6 +45503,16 @@ RATE:54 Mbit/s
 SIGNAL:55
 BARS:**  
 SECURITY:WPA1 WPA2
+
+IN-USE: 
+SSID:wlan1-ap-4
+MODE:Infra
+CHAN:1
+RATE:54 Mbit/s
+SIGNAL:48
+BARS:**  
+SECURITY:WPA1 WPA2
+
 
 <<<
 size: 608
@@ -45331,16 +45523,6 @@ returncode: 0
 stdout: 426 bytes
 >>>
 IN-USE: 
-SSID:wlan1-ap-4
-MODE:Infrastruktura
-CHAN:1
-RATE:54 Mb/s
-SIGNAL:48
-BARS:**  
-SECURITY:WPA1 WPA2
-
-
-IN-USE: 
 SSID:wlan0-ap-2
 MODE:Infrastruktura
 CHAN:1
@@ -45364,6 +45546,16 @@ RATE:54 Mb/s
 SIGNAL:55
 BARS:**  
 SECURITY:WPA1 WPA2
+
+IN-USE: 
+SSID:wlan1-ap-4
+MODE:Infrastruktura
+CHAN:1
+RATE:54 Mb/s
+SIGNAL:48
+BARS:**  
+SECURITY:WPA1 WPA2
+
 
 <<<
 size: 1753
@@ -45374,25 +45566,6 @@ returncode: 0
 stdout: 1470 bytes
 >>>
 NAME:AP[1]
-SSID:wlan1-ap-4
-SSID-HEX:776C616E312D61702D34
-BSSID:94:2B:E8:F6:D2:86
-MODE:Infra
-CHAN:1
-FREQ:2412 MHz
-RATE:54 Mbit/s
-SIGNAL:48
-BARS:**  
-SECURITY:WPA1 WPA2
-WPA-FLAGS:pair_tkip pair_ccmp group_tkip group_ccmp psk
-RSN-FLAGS:pair_tkip pair_ccmp group_tkip group_ccmp psk
-DEVICE:wlan1
-ACTIVE:no
-IN-USE: 
-DBUS-PATH:/org/freedesktop/NetworkManager/AccessPoint/4
-
-
-NAME:AP[1]
 SSID:wlan0-ap-2
 SSID-HEX:776C616E302D61702D32
 BSSID:C0:E2:BE:E8:EF:B6
@@ -45443,6 +45616,25 @@ DEVICE:wlan0
 ACTIVE:no
 IN-USE: 
 DBUS-PATH:/org/freedesktop/NetworkManager/AccessPoint/3
+
+NAME:AP[1]
+SSID:wlan1-ap-4
+SSID-HEX:776C616E312D61702D34
+BSSID:94:2B:E8:F6:D2:86
+MODE:Infra
+CHAN:1
+FREQ:2412 MHz
+RATE:54 Mbit/s
+SIGNAL:48
+BARS:**  
+SECURITY:WPA1 WPA2
+WPA-FLAGS:pair_tkip pair_ccmp group_tkip group_ccmp psk
+RSN-FLAGS:pair_tkip pair_ccmp group_tkip group_ccmp psk
+DEVICE:wlan1
+ACTIVE:no
+IN-USE: 
+DBUS-PATH:/org/freedesktop/NetworkManager/AccessPoint/4
+
 
 <<<
 size: 1811
@@ -45453,25 +45645,6 @@ returncode: 0
 stdout: 1518 bytes
 >>>
 NAME:AP[1]
-SSID:wlan1-ap-4
-SSID-HEX:776C616E312D61702D34
-BSSID:94:2B:E8:F6:D2:86
-MODE:Infrastruktura
-CHAN:1
-FREQ:2412 MHz
-RATE:54 Mb/s
-SIGNAL:48
-BARS:**  
-SECURITY:WPA1 WPA2
-WPA-FLAGS:pair_tkip pair_ccmp group_tkip group_ccmp psk
-RSN-FLAGS:pair_tkip pair_ccmp group_tkip group_ccmp psk
-DEVICE:wlan1
-ACTIVE:nie
-IN-USE: 
-DBUS-PATH:/org/freedesktop/NetworkManager/AccessPoint/4
-
-
-NAME:AP[1]
 SSID:wlan0-ap-2
 SSID-HEX:776C616E302D61702D32
 BSSID:C0:E2:BE:E8:EF:B6
@@ -45523,13 +45696,32 @@ ACTIVE:nie
 IN-USE: 
 DBUS-PATH:/org/freedesktop/NetworkManager/AccessPoint/3
 
+NAME:AP[1]
+SSID:wlan1-ap-4
+SSID-HEX:776C616E312D61702D34
+BSSID:94:2B:E8:F6:D2:86
+MODE:Infrastruktura
+CHAN:1
+FREQ:2412 MHz
+RATE:54 Mb/s
+SIGNAL:48
+BARS:**  
+SECURITY:WPA1 WPA2
+WPA-FLAGS:pair_tkip pair_ccmp group_tkip group_ccmp psk
+RSN-FLAGS:pair_tkip pair_ccmp group_tkip group_ccmp psk
+DEVICE:wlan1
+ACTIVE:nie
+IN-USE: 
+DBUS-PATH:/org/freedesktop/NetworkManager/AccessPoint/4
+
+
 <<<
-size: 560
+size: 562
 location: clients/tests/test-client.py:1075:test_004()/793
 cmd: $NMCLI --mode multiline --terse -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 367 bytes
+stdout: 369 bytes
 >>>
 NAME:AP[1]
 SSID:wlan0-ap-2
@@ -45549,13 +45741,15 @@ ACTIVE:no
 IN-USE: 
 DBUS-PATH:/org/freedesktop/NetworkManager/AccessPoint/2
 
+
+
 <<<
-size: 582
+size: 584
 location: clients/tests/test-client.py:1075:test_004()/794
 cmd: $NMCLI --mode multiline --terse -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 379 bytes
+stdout: 381 bytes
 >>>
 NAME:AP[1]
 SSID:wlan0-ap-2
@@ -45575,13 +45769,15 @@ ACTIVE:nie
 IN-USE: 
 DBUS-PATH:/org/freedesktop/NetworkManager/AccessPoint/2
 
+
+
 <<<
-size: 292
+size: 294
 location: clients/tests/test-client.py:1077:test_004()/795
 cmd: $NMCLI --mode multiline --terse -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 97 bytes
+stdout: 99 bytes
 >>>
 IN-USE: 
 SSID:wlan0-ap-2
@@ -45592,13 +45788,15 @@ SIGNAL:92
 BARS:****
 SECURITY:WPA1 WPA2
 
+
+
 <<<
-size: 312
+size: 314
 location: clients/tests/test-client.py:1077:test_004()/796
 cmd: $NMCLI --mode multiline --terse -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 106 bytes
+stdout: 108 bytes
 >>>
 IN-USE: 
 SSID:wlan0-ap-2
@@ -45609,13 +45807,15 @@ SIGNAL:92
 BARS:****
 SECURITY:WPA1 WPA2
 
+
+
 <<<
-size: 673
+size: 675
 location: clients/tests/test-client.py:1080:test_004()/797
 cmd: $NMCLI --mode multiline --terse -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 367 bytes
+stdout: 369 bytes
 >>>
 NAME:AP[1]
 SSID:wlan0-ap-2
@@ -45635,13 +45835,15 @@ ACTIVE:no
 IN-USE: 
 DBUS-PATH:/org/freedesktop/NetworkManager/AccessPoint/2
 
+
+
 <<<
-size: 695
+size: 697
 location: clients/tests/test-client.py:1080:test_004()/798
 cmd: $NMCLI --mode multiline --terse -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 379 bytes
+stdout: 381 bytes
 >>>
 NAME:AP[1]
 SSID:wlan0-ap-2
@@ -45660,6 +45862,8 @@ DEVICE:wlan0
 ACTIVE:nie
 IN-USE: 
 DBUS-PATH:/org/freedesktop/NetworkManager/AccessPoint/2
+
+
 
 <<<
 size: 2723
@@ -46779,6 +46983,10 @@ lang: C
 returncode: 0
 stdout: 440 bytes
 >>>
+DEVICE:[2mwlan0[0m
+TYPE:[2mwifi[0m
+STATE:[2munavailable[0m
+CONNECTION:[2mcon-vpn-1[0m
 DEVICE:[2meth0[0m
 TYPE:[2methernet[0m
 STATE:[2munavailable[0m
@@ -46795,10 +47003,6 @@ DEVICE:[2mwlan1[0m
 TYPE:[2mwifi[0m
 STATE:[2munavailable[0m
 CONNECTION:[2m[0m
-DEVICE:[2mwlan0[0m
-TYPE:[2mwifi[0m
-STATE:[2munavailable[0m
-CONNECTION:[2mcon-vpn-1[0m
 
 <<<
 size: 613
@@ -46808,6 +47012,10 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 440 bytes
 >>>
+DEVICE:[2mwlan0[0m
+TYPE:[2mwifi[0m
+STATE:[2munavailable[0m
+CONNECTION:[2mcon-vpn-1[0m
 DEVICE:[2meth0[0m
 TYPE:[2methernet[0m
 STATE:[2munavailable[0m
@@ -46824,10 +47032,6 @@ DEVICE:[2mwlan1[0m
 TYPE:[2mwifi[0m
 STATE:[2munavailable[0m
 CONNECTION:[2m[0m
-DEVICE:[2mwlan0[0m
-TYPE:[2mwifi[0m
-STATE:[2munavailable[0m
-CONNECTION:[2mcon-vpn-1[0m
 
 <<<
 size: 1512
@@ -46837,6 +47041,15 @@ lang: C
 returncode: 0
 stdout: 1336 bytes
 >>>
+DEVICE:[2mwlan0[0m
+TYPE:[2mwifi[0m
+STATE:[2munavailable[0m
+IP4-CONNECTIVITY:[2munknown[0m
+IP6-CONNECTIVITY:[2munknown[0m
+DBUS-PATH:[2m/org/freedesktop/NetworkManager/Devices/3[0m
+CONNECTION:[2mcon-vpn-1[0m
+CON-UUID:[2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m
+CON-PATH:[2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
 DEVICE:[2meth0[0m
 TYPE:[2methernet[0m
 STATE:[2munavailable[0m
@@ -46873,15 +47086,6 @@ DBUS-PATH:[2m/org/freedesktop/NetworkManager/Devices/5[0m
 CONNECTION:[2m[0m
 CON-UUID:[2m[0m
 CON-PATH:[2m[0m
-DEVICE:[2mwlan0[0m
-TYPE:[2mwifi[0m
-STATE:[2munavailable[0m
-IP4-CONNECTIVITY:[2munknown[0m
-IP6-CONNECTIVITY:[2munknown[0m
-DBUS-PATH:[2m/org/freedesktop/NetworkManager/Devices/3[0m
-CONNECTION:[2mcon-vpn-1[0m
-CON-UUID:[2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m
-CON-PATH:[2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
 
 <<<
 size: 1532
@@ -46891,6 +47095,15 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 1346 bytes
 >>>
+DEVICE:[2mwlan0[0m
+TYPE:[2mwifi[0m
+STATE:[2munavailable[0m
+IP4-CONNECTIVITY:[2mnieznane[0m
+IP6-CONNECTIVITY:[2mnieznane[0m
+DBUS-PATH:[2m/org/freedesktop/NetworkManager/Devices/3[0m
+CONNECTION:[2mcon-vpn-1[0m
+CON-UUID:[2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m
+CON-PATH:[2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
 DEVICE:[2meth0[0m
 TYPE:[2methernet[0m
 STATE:[2munavailable[0m
@@ -46927,15 +47140,6 @@ DBUS-PATH:[2m/org/freedesktop/NetworkManager/Devices/5[0m
 CONNECTION:[2m[0m
 CON-UUID:[2m[0m
 CON-PATH:[2m[0m
-DEVICE:[2mwlan0[0m
-TYPE:[2mwifi[0m
-STATE:[2munavailable[0m
-IP4-CONNECTIVITY:[2mnieznane[0m
-IP6-CONNECTIVITY:[2mnieznane[0m
-DBUS-PATH:[2m/org/freedesktop/NetworkManager/Devices/3[0m
-CONNECTION:[2mcon-vpn-1[0m
-CON-UUID:[2mUUID-con-vpn-1-REPLACED-REPLACED-REP[0m
-CON-PATH:[2m/org/freedesktop/NetworkManager/ActiveConnection/2[0m
 
 <<<
 size: 4569
@@ -46945,6 +47149,31 @@ lang: C
 returncode: 0
 stdout: 4402 bytes
 >>>
+GENERAL.DEVICE:wlan0
+GENERAL.TYPE:wifi
+GENERAL.HWADDR:13:E0:74:85:7C:D9
+GENERAL.MTU:0
+GENERAL.STATE:20 (unavailable)
+GENERAL.CONNECTION:con-vpn-1
+GENERAL.CON-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
+IP4.ADDRESS[1]:192.168.228.18/32
+IP4.ADDRESS[2]:192.168.209.179/25
+IP4.GATEWAY:192.168.41.120
+IP4.DOMAIN[1]:sear4.foo2.bar
+IP4.DOMAIN[2]:sear4.fo.x.y
+IP4.DOMAIN[3]:sear4.foo1.bar
+IP4.DOMAIN[4]:sear4.foo4.bar
+IP4.DOMAIN[5]:sear4.fo.o.bar
+IP4.WINS[1]:192.168.120.79
+IP6.GATEWAY:
+IP6.ROUTE[1]:dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
+IP6.DOMAIN[1]:sear6.foo2.bar
+IP6.DOMAIN[2]:sear6.foo1.bar
+IP6.DOMAIN[3]:sear6.fo.x.y
+IP6.DOMAIN[4]:sear6.fo.o.bar
+IP6.DOMAIN[5]:sear6.foo3.bar
+IP6.DOMAIN[6]:sear6.foo4.bar
+
 GENERAL.DEVICE:eth0
 GENERAL.TYPE:ethernet
 GENERAL.HWADDR:AB:B7:BF:E2:48:E8
@@ -47057,31 +47286,6 @@ IP6.ROUTE[2]:dst = 2001:a::a976:2488:f49f:b48/106, nh = 2001:a::62ae:c734:fc7b:e
 IP6.ROUTE[3]:dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::
 IP6.DNS[1]:2001:a::2934:bd66:550d:ec19
 IP6.DOMAIN[1]:sear6.fo.x.y
-
-GENERAL.DEVICE:wlan0
-GENERAL.TYPE:wifi
-GENERAL.HWADDR:13:E0:74:85:7C:D9
-GENERAL.MTU:0
-GENERAL.STATE:20 (unavailable)
-GENERAL.CONNECTION:con-vpn-1
-GENERAL.CON-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
-IP4.ADDRESS[1]:192.168.228.18/32
-IP4.ADDRESS[2]:192.168.209.179/25
-IP4.GATEWAY:192.168.41.120
-IP4.DOMAIN[1]:sear4.foo2.bar
-IP4.DOMAIN[2]:sear4.fo.x.y
-IP4.DOMAIN[3]:sear4.foo1.bar
-IP4.DOMAIN[4]:sear4.foo4.bar
-IP4.DOMAIN[5]:sear4.fo.o.bar
-IP4.WINS[1]:192.168.120.79
-IP6.GATEWAY:
-IP6.ROUTE[1]:dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
-IP6.DOMAIN[1]:sear6.foo2.bar
-IP6.DOMAIN[2]:sear6.foo1.bar
-IP6.DOMAIN[3]:sear6.fo.x.y
-IP6.DOMAIN[4]:sear6.fo.o.bar
-IP6.DOMAIN[5]:sear6.foo3.bar
-IP6.DOMAIN[6]:sear6.foo4.bar
 
 <<<
 size: 4579
@@ -47091,6 +47295,31 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 4402 bytes
 >>>
+GENERAL.DEVICE:wlan0
+GENERAL.TYPE:wifi
+GENERAL.HWADDR:13:E0:74:85:7C:D9
+GENERAL.MTU:0
+GENERAL.STATE:20 (unavailable)
+GENERAL.CONNECTION:con-vpn-1
+GENERAL.CON-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
+IP4.ADDRESS[1]:192.168.228.18/32
+IP4.ADDRESS[2]:192.168.209.179/25
+IP4.GATEWAY:192.168.41.120
+IP4.DOMAIN[1]:sear4.foo2.bar
+IP4.DOMAIN[2]:sear4.fo.x.y
+IP4.DOMAIN[3]:sear4.foo1.bar
+IP4.DOMAIN[4]:sear4.foo4.bar
+IP4.DOMAIN[5]:sear4.fo.o.bar
+IP4.WINS[1]:192.168.120.79
+IP6.GATEWAY:
+IP6.ROUTE[1]:dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
+IP6.DOMAIN[1]:sear6.foo2.bar
+IP6.DOMAIN[2]:sear6.foo1.bar
+IP6.DOMAIN[3]:sear6.fo.x.y
+IP6.DOMAIN[4]:sear6.fo.o.bar
+IP6.DOMAIN[5]:sear6.foo3.bar
+IP6.DOMAIN[6]:sear6.foo4.bar
+
 GENERAL.DEVICE:eth0
 GENERAL.TYPE:ethernet
 GENERAL.HWADDR:AB:B7:BF:E2:48:E8
@@ -47204,13 +47433,77 @@ IP6.ROUTE[3]:dst = 2001:a::afb7:4449:3787:8bb4/123, nh = ::
 IP6.DNS[1]:2001:a::2934:bd66:550d:ec19
 IP6.DOMAIN[1]:sear6.fo.x.y
 
+<<<
+size: 12254
+location: clients/tests/test-client.py:1050:test_004()/821
+cmd: $NMCLI --mode multiline --terse --color yes -f all dev show
+lang: C
+returncode: 0
+stdout: 12079 bytes
+>>>
 GENERAL.DEVICE:wlan0
 GENERAL.TYPE:wifi
+GENERAL.NM-TYPE:NMDeviceWifi
+GENERAL.VENDOR:
+GENERAL.PRODUCT:
+GENERAL.DRIVER:virtual
+GENERAL.DRIVER-VERSION:
+GENERAL.FIRMWARE-VERSION:
 GENERAL.HWADDR:13:E0:74:85:7C:D9
 GENERAL.MTU:0
 GENERAL.STATE:20 (unavailable)
+GENERAL.REASON:0 (No reason given)
+GENERAL.IP4-CONNECTIVITY:0 (unknown)
+GENERAL.IP6-CONNECTIVITY:0 (unknown)
+GENERAL.UDI:/sys/devices/virtual/wlan0
+GENERAL.IP-IFACE:
+GENERAL.IS-SOFTWARE:no
+GENERAL.NM-MANAGED:yes
+GENERAL.AUTOCONNECT:yes
+GENERAL.FIRMWARE-MISSING:no
+GENERAL.NM-PLUGIN-MISSING:no
+GENERAL.PHYS-PORT-ID:
 GENERAL.CONNECTION:con-vpn-1
+GENERAL.CON-UUID:UUID-con-vpn-1-REPLACED-REPLACED-REP
 GENERAL.CON-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
+GENERAL.METERED:unknown
+CAPABILITIES.CARRIER-DETECT:no
+CAPABILITIES.SPEED:unknown
+CAPABILITIES.IS-SOFTWARE:no
+CAPABILITIES.SRIOV:no
+WIFI-PROPERTIES.WEP:yes
+WIFI-PROPERTIES.WPA:yes
+WIFI-PROPERTIES.WPA2:yes
+WIFI-PROPERTIES.TKIP:yes
+WIFI-PROPERTIES.CCMP:yes
+WIFI-PROPERTIES.AP:yes
+WIFI-PROPERTIES.ADHOC:yes
+WIFI-PROPERTIES.2GHZ:unknown
+WIFI-PROPERTIES.5GHZ:unknown
+AP[1].IN-USE:[32m [0m
+AP[1].SSID:[32mwlan0-ap-2[0m
+AP[1].MODE:[32mInfra[0m
+AP[1].CHAN:[32m1[0m
+AP[1].RATE:[32m54 Mbit/s[0m
+AP[1].SIGNAL:[32m92[0m
+AP[1].BARS:[32m****[0m
+AP[1].SECURITY:[32mWPA1 WPA2[0m
+AP[2].IN-USE:[32m [0m
+AP[2].SSID:[32mwlan0-ap-1[0m
+AP[2].MODE:[32mInfra[0m
+AP[2].CHAN:[32m1[0m
+AP[2].RATE:[32m54 Mbit/s[0m
+AP[2].SIGNAL:[32m81[0m
+AP[2].BARS:[32m****[0m
+AP[2].SECURITY:[32mWPA1 WPA2[0m
+AP[3].IN-USE:[35m [0m
+AP[3].SSID:[35mwlan0-ap-3[0m
+AP[3].MODE:[35mInfra[0m
+AP[3].CHAN:[35m1[0m
+AP[3].RATE:[35m54 Mbit/s[0m
+AP[3].SIGNAL:[35m55[0m
+AP[3].BARS:[35m**  [0m
+AP[3].SECURITY:[35mWPA1 WPA2[0m
 IP4.ADDRESS[1]:192.168.228.18/32
 IP4.ADDRESS[2]:192.168.209.179/25
 IP4.GATEWAY:192.168.41.120
@@ -47220,6 +47513,10 @@ IP4.DOMAIN[3]:sear4.foo1.bar
 IP4.DOMAIN[4]:sear4.foo4.bar
 IP4.DOMAIN[5]:sear4.fo.o.bar
 IP4.WINS[1]:192.168.120.79
+DHCP4.OPTION[1]:dhcp-4-opt-0 = val-0
+DHCP4.OPTION[2]:dhcp-4-opt-2 = val-2
+DHCP4.OPTION[3]:dhcp-4-opt-4 = val-4
+DHCP4.OPTION[4]:dhcp-4-opt-7 = val-7
 IP6.GATEWAY:
 IP6.ROUTE[1]:dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
 IP6.DOMAIN[1]:sear6.foo2.bar
@@ -47228,15 +47525,14 @@ IP6.DOMAIN[3]:sear6.fo.x.y
 IP6.DOMAIN[4]:sear6.fo.o.bar
 IP6.DOMAIN[5]:sear6.foo3.bar
 IP6.DOMAIN[6]:sear6.foo4.bar
+DHCP6.OPTION[1]:dhcp-6-opt-1 = val-1
+DHCP6.OPTION[2]:dhcp-6-opt-2 = val-2
+DHCP6.OPTION[3]:dhcp-6-opt-3 = val-3
+DHCP6.OPTION[4]:dhcp-6-opt-4 = val-4
+DHCP6.OPTION[5]:dhcp-6-opt-5 = val-5
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{2}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
-<<<
-size: 12254
-location: clients/tests/test-client.py:1050:test_004()/821
-cmd: $NMCLI --mode multiline --terse --color yes -f all dev show
-lang: C
-returncode: 0
-stdout: 12079 bytes
->>>
 GENERAL.DEVICE:eth0
 GENERAL.TYPE:ethernet
 GENERAL.NM-TYPE:NMDeviceEthernet
@@ -47526,6 +47822,14 @@ DHCP6.OPTION[5]:dhcp-6-opt-9 = val-9
 CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{2}
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
+<<<
+size: 12310
+location: clients/tests/test-client.py:1050:test_004()/822
+cmd: $NMCLI --mode multiline --terse --color yes -f all dev show
+lang: pl_PL.UTF-8
+returncode: 0
+stdout: 12125 bytes
+>>>
 GENERAL.DEVICE:wlan0
 GENERAL.TYPE:wifi
 GENERAL.NM-TYPE:NMDeviceWifi
@@ -47538,8 +47842,8 @@ GENERAL.HWADDR:13:E0:74:85:7C:D9
 GENERAL.MTU:0
 GENERAL.STATE:20 (unavailable)
 GENERAL.REASON:0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:0 (unknown)
-GENERAL.IP6-CONNECTIVITY:0 (unknown)
+GENERAL.IP4-CONNECTIVITY:0 (nieznane)
+GENERAL.IP6-CONNECTIVITY:0 (nieznane)
 GENERAL.UDI:/sys/devices/virtual/wlan0
 GENERAL.IP-IFACE:
 GENERAL.IS-SOFTWARE:no
@@ -47567,25 +47871,25 @@ WIFI-PROPERTIES.2GHZ:unknown
 WIFI-PROPERTIES.5GHZ:unknown
 AP[1].IN-USE:[32m [0m
 AP[1].SSID:[32mwlan0-ap-2[0m
-AP[1].MODE:[32mInfra[0m
+AP[1].MODE:[32mInfrastruktura[0m
 AP[1].CHAN:[32m1[0m
-AP[1].RATE:[32m54 Mbit/s[0m
+AP[1].RATE:[32m54 Mb/s[0m
 AP[1].SIGNAL:[32m92[0m
 AP[1].BARS:[32m****[0m
 AP[1].SECURITY:[32mWPA1 WPA2[0m
 AP[2].IN-USE:[32m [0m
 AP[2].SSID:[32mwlan0-ap-1[0m
-AP[2].MODE:[32mInfra[0m
+AP[2].MODE:[32mInfrastruktura[0m
 AP[2].CHAN:[32m1[0m
-AP[2].RATE:[32m54 Mbit/s[0m
+AP[2].RATE:[32m54 Mb/s[0m
 AP[2].SIGNAL:[32m81[0m
 AP[2].BARS:[32m****[0m
 AP[2].SECURITY:[32mWPA1 WPA2[0m
 AP[3].IN-USE:[35m [0m
 AP[3].SSID:[35mwlan0-ap-3[0m
-AP[3].MODE:[35mInfra[0m
+AP[3].MODE:[35mInfrastruktura[0m
 AP[3].CHAN:[35m1[0m
-AP[3].RATE:[35m54 Mbit/s[0m
+AP[3].RATE:[35m54 Mb/s[0m
 AP[3].SIGNAL:[35m55[0m
 AP[3].BARS:[35m**  [0m
 AP[3].SECURITY:[35mWPA1 WPA2[0m
@@ -47618,14 +47922,6 @@ DHCP6.OPTION[5]:dhcp-6-opt-5 = val-5
 CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{2}
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
-<<<
-size: 12310
-location: clients/tests/test-client.py:1050:test_004()/822
-cmd: $NMCLI --mode multiline --terse --color yes -f all dev show
-lang: pl_PL.UTF-8
-returncode: 0
-stdout: 12125 bytes
->>>
 GENERAL.DEVICE:eth0
 GENERAL.TYPE:ethernet
 GENERAL.NM-TYPE:NMDeviceEthernet
@@ -47912,98 +48208,6 @@ DHCP6.OPTION[2]:dhcp-6-opt-6 = val-6
 DHCP6.OPTION[3]:dhcp-6-opt-7 = val-7
 DHCP6.OPTION[4]:dhcp-6-opt-8 = val-8
 DHCP6.OPTION[5]:dhcp-6-opt-9 = val-9
-CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{2}
-CONNECTIONS.AVAILABLE-CONNECTIONS[1]:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
-
-GENERAL.DEVICE:wlan0
-GENERAL.TYPE:wifi
-GENERAL.NM-TYPE:NMDeviceWifi
-GENERAL.VENDOR:
-GENERAL.PRODUCT:
-GENERAL.DRIVER:virtual
-GENERAL.DRIVER-VERSION:
-GENERAL.FIRMWARE-VERSION:
-GENERAL.HWADDR:13:E0:74:85:7C:D9
-GENERAL.MTU:0
-GENERAL.STATE:20 (unavailable)
-GENERAL.REASON:0 (No reason given)
-GENERAL.IP4-CONNECTIVITY:0 (nieznane)
-GENERAL.IP6-CONNECTIVITY:0 (nieznane)
-GENERAL.UDI:/sys/devices/virtual/wlan0
-GENERAL.IP-IFACE:
-GENERAL.IS-SOFTWARE:no
-GENERAL.NM-MANAGED:yes
-GENERAL.AUTOCONNECT:yes
-GENERAL.FIRMWARE-MISSING:no
-GENERAL.NM-PLUGIN-MISSING:no
-GENERAL.PHYS-PORT-ID:
-GENERAL.CONNECTION:con-vpn-1
-GENERAL.CON-UUID:UUID-con-vpn-1-REPLACED-REPLACED-REP
-GENERAL.CON-PATH:/org/freedesktop/NetworkManager/ActiveConnection/2
-GENERAL.METERED:unknown
-CAPABILITIES.CARRIER-DETECT:no
-CAPABILITIES.SPEED:unknown
-CAPABILITIES.IS-SOFTWARE:no
-CAPABILITIES.SRIOV:no
-WIFI-PROPERTIES.WEP:yes
-WIFI-PROPERTIES.WPA:yes
-WIFI-PROPERTIES.WPA2:yes
-WIFI-PROPERTIES.TKIP:yes
-WIFI-PROPERTIES.CCMP:yes
-WIFI-PROPERTIES.AP:yes
-WIFI-PROPERTIES.ADHOC:yes
-WIFI-PROPERTIES.2GHZ:unknown
-WIFI-PROPERTIES.5GHZ:unknown
-AP[1].IN-USE:[32m [0m
-AP[1].SSID:[32mwlan0-ap-2[0m
-AP[1].MODE:[32mInfrastruktura[0m
-AP[1].CHAN:[32m1[0m
-AP[1].RATE:[32m54 Mb/s[0m
-AP[1].SIGNAL:[32m92[0m
-AP[1].BARS:[32m****[0m
-AP[1].SECURITY:[32mWPA1 WPA2[0m
-AP[2].IN-USE:[32m [0m
-AP[2].SSID:[32mwlan0-ap-1[0m
-AP[2].MODE:[32mInfrastruktura[0m
-AP[2].CHAN:[32m1[0m
-AP[2].RATE:[32m54 Mb/s[0m
-AP[2].SIGNAL:[32m81[0m
-AP[2].BARS:[32m****[0m
-AP[2].SECURITY:[32mWPA1 WPA2[0m
-AP[3].IN-USE:[35m [0m
-AP[3].SSID:[35mwlan0-ap-3[0m
-AP[3].MODE:[35mInfrastruktura[0m
-AP[3].CHAN:[35m1[0m
-AP[3].RATE:[35m54 Mb/s[0m
-AP[3].SIGNAL:[35m55[0m
-AP[3].BARS:[35m**  [0m
-AP[3].SECURITY:[35mWPA1 WPA2[0m
-IP4.ADDRESS[1]:192.168.228.18/32
-IP4.ADDRESS[2]:192.168.209.179/25
-IP4.GATEWAY:192.168.41.120
-IP4.DOMAIN[1]:sear4.foo2.bar
-IP4.DOMAIN[2]:sear4.fo.x.y
-IP4.DOMAIN[3]:sear4.foo1.bar
-IP4.DOMAIN[4]:sear4.foo4.bar
-IP4.DOMAIN[5]:sear4.fo.o.bar
-IP4.WINS[1]:192.168.120.79
-DHCP4.OPTION[1]:dhcp-4-opt-0 = val-0
-DHCP4.OPTION[2]:dhcp-4-opt-2 = val-2
-DHCP4.OPTION[3]:dhcp-4-opt-4 = val-4
-DHCP4.OPTION[4]:dhcp-4-opt-7 = val-7
-IP6.GATEWAY:
-IP6.ROUTE[1]:dst = 2001:a::dd5b:aa7b:b4a2:e42/102, nh = ::, mt = 2504159086
-IP6.DOMAIN[1]:sear6.foo2.bar
-IP6.DOMAIN[2]:sear6.foo1.bar
-IP6.DOMAIN[3]:sear6.fo.x.y
-IP6.DOMAIN[4]:sear6.fo.o.bar
-IP6.DOMAIN[5]:sear6.foo3.bar
-IP6.DOMAIN[6]:sear6.foo4.bar
-DHCP6.OPTION[1]:dhcp-6-opt-1 = val-1
-DHCP6.OPTION[2]:dhcp-6-opt-2 = val-2
-DHCP6.OPTION[3]:dhcp-6-opt-3 = val-3
-DHCP6.OPTION[4]:dhcp-6-opt-4 = val-4
-DHCP6.OPTION[5]:dhcp-6-opt-5 = val-5
 CONNECTIONS.AVAILABLE-CONNECTION-PATHS:/org/freedesktop/NetworkManager/Settings/Connection/{2}
 CONNECTIONS.AVAILABLE-CONNECTIONS[1]:UUID-con-xx1-REPLACED-REPLACED-REPLA | con-xx1
 
@@ -48461,6 +48665,9 @@ lang: C
 returncode: 0
 stdout: 501 bytes
 >>>
+DEVICE:[2mwlan0[0m
+TYPE:[2mwifi[0m
+DBUS-PATH:[2m/org/freedesktop/NetworkManager/Devices/3[0m
 DEVICE:[2meth0[0m
 TYPE:[2methernet[0m
 DBUS-PATH:[2m/org/freedesktop/NetworkManager/Devices/1[0m
@@ -48473,9 +48680,6 @@ DBUS-PATH:[2m/org/freedesktop/NetworkManager/Devices/4[0m
 DEVICE:[2mwlan1[0m
 TYPE:[2mwifi[0m
 DBUS-PATH:[2m/org/freedesktop/NetworkManager/Devices/5[0m
-DEVICE:[2mwlan0[0m
-TYPE:[2mwifi[0m
-DBUS-PATH:[2m/org/freedesktop/NetworkManager/Devices/3[0m
 
 <<<
 size: 697
@@ -48485,6 +48689,9 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 501 bytes
 >>>
+DEVICE:[2mwlan0[0m
+TYPE:[2mwifi[0m
+DBUS-PATH:[2m/org/freedesktop/NetworkManager/Devices/3[0m
 DEVICE:[2meth0[0m
 TYPE:[2methernet[0m
 DBUS-PATH:[2m/org/freedesktop/NetworkManager/Devices/1[0m
@@ -48497,9 +48704,6 @@ DBUS-PATH:[2m/org/freedesktop/NetworkManager/Devices/4[0m
 DEVICE:[2mwlan1[0m
 TYPE:[2mwifi[0m
 DBUS-PATH:[2m/org/freedesktop/NetworkManager/Devices/5[0m
-DEVICE:[2mwlan0[0m
-TYPE:[2mwifi[0m
-DBUS-PATH:[2m/org/freedesktop/NetworkManager/Devices/3[0m
 
 <<<
 size: 2264
@@ -48509,25 +48713,6 @@ lang: C
 returncode: 0
 stdout: 2082 bytes
 >>>
-NAME:[35mAP[1][0m
-SSID:[35mwlan1-ap-4[0m
-SSID-HEX:[35m776C616E312D61702D34[0m
-BSSID:[35m94:2B:E8:F6:D2:86[0m
-MODE:[35mInfra[0m
-CHAN:[35m1[0m
-FREQ:[35m2412 MHz[0m
-RATE:[35m54 Mbit/s[0m
-SIGNAL:[35m48[0m
-BARS:[35m**  [0m
-SECURITY:[35mWPA1 WPA2[0m
-WPA-FLAGS:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
-RSN-FLAGS:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
-DEVICE:[35mwlan1[0m
-ACTIVE:[35mno[0m
-IN-USE:[35m [0m
-DBUS-PATH:[35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
-
-
 NAME:[32mAP[1][0m
 SSID:[32mwlan0-ap-2[0m
 SSID-HEX:[32m776C616E302D61702D32[0m
@@ -48579,6 +48764,25 @@ DEVICE:[35mwlan0[0m
 ACTIVE:[35mno[0m
 IN-USE:[35m [0m
 DBUS-PATH:[35m/org/freedesktop/NetworkManager/AccessPoint/3[0m
+
+NAME:[35mAP[1][0m
+SSID:[35mwlan1-ap-4[0m
+SSID-HEX:[35m776C616E312D61702D34[0m
+BSSID:[35m94:2B:E8:F6:D2:86[0m
+MODE:[35mInfra[0m
+CHAN:[35m1[0m
+FREQ:[35m2412 MHz[0m
+RATE:[35m54 Mbit/s[0m
+SIGNAL:[35m48[0m
+BARS:[35m**  [0m
+SECURITY:[35mWPA1 WPA2[0m
+WPA-FLAGS:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
+RSN-FLAGS:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
+DEVICE:[35mwlan1[0m
+ACTIVE:[35mno[0m
+IN-USE:[35m [0m
+DBUS-PATH:[35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
+
 
 <<<
 size: 2322
@@ -48588,25 +48792,6 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 2130 bytes
 >>>
-NAME:[35mAP[1][0m
-SSID:[35mwlan1-ap-4[0m
-SSID-HEX:[35m776C616E312D61702D34[0m
-BSSID:[35m94:2B:E8:F6:D2:86[0m
-MODE:[35mInfrastruktura[0m
-CHAN:[35m1[0m
-FREQ:[35m2412 MHz[0m
-RATE:[35m54 Mb/s[0m
-SIGNAL:[35m48[0m
-BARS:[35m**  [0m
-SECURITY:[35mWPA1 WPA2[0m
-WPA-FLAGS:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
-RSN-FLAGS:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
-DEVICE:[35mwlan1[0m
-ACTIVE:[35mnie[0m
-IN-USE:[35m [0m
-DBUS-PATH:[35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
-
-
 NAME:[32mAP[1][0m
 SSID:[32mwlan0-ap-2[0m
 SSID-HEX:[32m776C616E302D61702D32[0m
@@ -48658,6 +48843,25 @@ DEVICE:[35mwlan0[0m
 ACTIVE:[35mnie[0m
 IN-USE:[35m [0m
 DBUS-PATH:[35m/org/freedesktop/NetworkManager/AccessPoint/3[0m
+
+NAME:[35mAP[1][0m
+SSID:[35mwlan1-ap-4[0m
+SSID-HEX:[35m776C616E312D61702D34[0m
+BSSID:[35m94:2B:E8:F6:D2:86[0m
+MODE:[35mInfrastruktura[0m
+CHAN:[35m1[0m
+FREQ:[35m2412 MHz[0m
+RATE:[35m54 Mb/s[0m
+SIGNAL:[35m48[0m
+BARS:[35m**  [0m
+SECURITY:[35mWPA1 WPA2[0m
+WPA-FLAGS:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
+RSN-FLAGS:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
+DEVICE:[35mwlan1[0m
+ACTIVE:[35mnie[0m
+IN-USE:[35m [0m
+DBUS-PATH:[35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
+
 
 <<<
 size: 862
@@ -48667,16 +48871,6 @@ lang: C
 returncode: 0
 stdout: 678 bytes
 >>>
-IN-USE:[35m [0m
-SSID:[35mwlan1-ap-4[0m
-MODE:[35mInfra[0m
-CHAN:[35m1[0m
-RATE:[35m54 Mbit/s[0m
-SIGNAL:[35m48[0m
-BARS:[35m**  [0m
-SECURITY:[35mWPA1 WPA2[0m
-
-
 IN-USE:[32m [0m
 SSID:[32mwlan0-ap-2[0m
 MODE:[32mInfra[0m
@@ -48701,6 +48895,16 @@ RATE:[35m54 Mbit/s[0m
 SIGNAL:[35m55[0m
 BARS:[35m**  [0m
 SECURITY:[35mWPA1 WPA2[0m
+
+IN-USE:[35m [0m
+SSID:[35mwlan1-ap-4[0m
+MODE:[35mInfra[0m
+CHAN:[35m1[0m
+RATE:[35m54 Mbit/s[0m
+SIGNAL:[35m48[0m
+BARS:[35m**  [0m
+SECURITY:[35mWPA1 WPA2[0m
+
 
 <<<
 size: 908
@@ -48710,16 +48914,6 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 714 bytes
 >>>
-IN-USE:[35m [0m
-SSID:[35mwlan1-ap-4[0m
-MODE:[35mInfrastruktura[0m
-CHAN:[35m1[0m
-RATE:[35m54 Mb/s[0m
-SIGNAL:[35m48[0m
-BARS:[35m**  [0m
-SECURITY:[35mWPA1 WPA2[0m
-
-
 IN-USE:[32m [0m
 SSID:[32mwlan0-ap-2[0m
 MODE:[32mInfrastruktura[0m
@@ -48744,6 +48938,16 @@ RATE:[35m54 Mb/s[0m
 SIGNAL:[35m55[0m
 BARS:[35m**  [0m
 SECURITY:[35mWPA1 WPA2[0m
+
+IN-USE:[35m [0m
+SSID:[35mwlan1-ap-4[0m
+MODE:[35mInfrastruktura[0m
+CHAN:[35m1[0m
+RATE:[35m54 Mb/s[0m
+SIGNAL:[35m48[0m
+BARS:[35m**  [0m
+SECURITY:[35mWPA1 WPA2[0m
+
 
 <<<
 size: 2377
@@ -48753,25 +48957,6 @@ lang: C
 returncode: 0
 stdout: 2082 bytes
 >>>
-NAME:[35mAP[1][0m
-SSID:[35mwlan1-ap-4[0m
-SSID-HEX:[35m776C616E312D61702D34[0m
-BSSID:[35m94:2B:E8:F6:D2:86[0m
-MODE:[35mInfra[0m
-CHAN:[35m1[0m
-FREQ:[35m2412 MHz[0m
-RATE:[35m54 Mbit/s[0m
-SIGNAL:[35m48[0m
-BARS:[35m**  [0m
-SECURITY:[35mWPA1 WPA2[0m
-WPA-FLAGS:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
-RSN-FLAGS:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
-DEVICE:[35mwlan1[0m
-ACTIVE:[35mno[0m
-IN-USE:[35m [0m
-DBUS-PATH:[35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
-
-
 NAME:[32mAP[1][0m
 SSID:[32mwlan0-ap-2[0m
 SSID-HEX:[32m776C616E302D61702D32[0m
@@ -48823,6 +49008,25 @@ DEVICE:[35mwlan0[0m
 ACTIVE:[35mno[0m
 IN-USE:[35m [0m
 DBUS-PATH:[35m/org/freedesktop/NetworkManager/AccessPoint/3[0m
+
+NAME:[35mAP[1][0m
+SSID:[35mwlan1-ap-4[0m
+SSID-HEX:[35m776C616E312D61702D34[0m
+BSSID:[35m94:2B:E8:F6:D2:86[0m
+MODE:[35mInfra[0m
+CHAN:[35m1[0m
+FREQ:[35m2412 MHz[0m
+RATE:[35m54 Mbit/s[0m
+SIGNAL:[35m48[0m
+BARS:[35m**  [0m
+SECURITY:[35mWPA1 WPA2[0m
+WPA-FLAGS:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
+RSN-FLAGS:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
+DEVICE:[35mwlan1[0m
+ACTIVE:[35mno[0m
+IN-USE:[35m [0m
+DBUS-PATH:[35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
+
 
 <<<
 size: 2435
@@ -48832,25 +49036,6 @@ lang: pl_PL.UTF-8
 returncode: 0
 stdout: 2130 bytes
 >>>
-NAME:[35mAP[1][0m
-SSID:[35mwlan1-ap-4[0m
-SSID-HEX:[35m776C616E312D61702D34[0m
-BSSID:[35m94:2B:E8:F6:D2:86[0m
-MODE:[35mInfrastruktura[0m
-CHAN:[35m1[0m
-FREQ:[35m2412 MHz[0m
-RATE:[35m54 Mb/s[0m
-SIGNAL:[35m48[0m
-BARS:[35m**  [0m
-SECURITY:[35mWPA1 WPA2[0m
-WPA-FLAGS:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
-RSN-FLAGS:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
-DEVICE:[35mwlan1[0m
-ACTIVE:[35mnie[0m
-IN-USE:[35m [0m
-DBUS-PATH:[35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
-
-
 NAME:[32mAP[1][0m
 SSID:[32mwlan0-ap-2[0m
 SSID-HEX:[32m776C616E302D61702D32[0m
@@ -48903,13 +49088,32 @@ ACTIVE:[35mnie[0m
 IN-USE:[35m [0m
 DBUS-PATH:[35m/org/freedesktop/NetworkManager/AccessPoint/3[0m
 
+NAME:[35mAP[1][0m
+SSID:[35mwlan1-ap-4[0m
+SSID-HEX:[35m776C616E312D61702D34[0m
+BSSID:[35m94:2B:E8:F6:D2:86[0m
+MODE:[35mInfrastruktura[0m
+CHAN:[35m1[0m
+FREQ:[35m2412 MHz[0m
+RATE:[35m54 Mb/s[0m
+SIGNAL:[35m48[0m
+BARS:[35m**  [0m
+SECURITY:[35mWPA1 WPA2[0m
+WPA-FLAGS:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
+RSN-FLAGS:[35mpair_tkip pair_ccmp group_tkip group_ccmp psk[0m
+DEVICE:[35mwlan1[0m
+ACTIVE:[35mnie[0m
+IN-USE:[35m [0m
+DBUS-PATH:[35m/org/freedesktop/NetworkManager/AccessPoint/4[0m
+
+
 <<<
-size: 725
+size: 727
 location: clients/tests/test-client.py:1075:test_004()/839
 cmd: $NMCLI --mode multiline --terse --color yes -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 520 bytes
+stdout: 522 bytes
 >>>
 NAME:[32mAP[1][0m
 SSID:[32mwlan0-ap-2[0m
@@ -48929,13 +49133,15 @@ ACTIVE:[32mno[0m
 IN-USE:[32m [0m
 DBUS-PATH:[32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
 
+
+
 <<<
-size: 747
+size: 749
 location: clients/tests/test-client.py:1075:test_004()/840
 cmd: $NMCLI --mode multiline --terse --color yes -f ALL device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 532 bytes
+stdout: 534 bytes
 >>>
 NAME:[32mAP[1][0m
 SSID:[32mwlan0-ap-2[0m
@@ -48955,13 +49161,15 @@ ACTIVE:[32mnie[0m
 IN-USE:[32m [0m
 DBUS-PATH:[32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
 
+
+
 <<<
-size: 377
+size: 379
 location: clients/tests/test-client.py:1077:test_004()/841
 cmd: $NMCLI --mode multiline --terse --color yes -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 169 bytes
+stdout: 171 bytes
 >>>
 IN-USE:[32m [0m
 SSID:[32mwlan0-ap-2[0m
@@ -48972,13 +49180,15 @@ SIGNAL:[32m92[0m
 BARS:[32m****[0m
 SECURITY:[32mWPA1 WPA2[0m
 
+
+
 <<<
-size: 396
+size: 398
 location: clients/tests/test-client.py:1077:test_004()/842
 cmd: $NMCLI --mode multiline --terse --color yes -f COMMON device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 178 bytes
+stdout: 180 bytes
 >>>
 IN-USE:[32m [0m
 SSID:[32mwlan0-ap-2[0m
@@ -48989,13 +49199,15 @@ SIGNAL:[32m92[0m
 BARS:[32m****[0m
 SECURITY:[32mWPA1 WPA2[0m
 
+
+
 <<<
-size: 838
+size: 840
 location: clients/tests/test-client.py:1080:test_004()/843
 cmd: $NMCLI --mode multiline --terse --color yes -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: C
 returncode: 0
-stdout: 520 bytes
+stdout: 522 bytes
 >>>
 NAME:[32mAP[1][0m
 SSID:[32mwlan0-ap-2[0m
@@ -49015,13 +49227,15 @@ ACTIVE:[32mno[0m
 IN-USE:[32m [0m
 DBUS-PATH:[32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
 
+
+
 <<<
-size: 860
+size: 862
 location: clients/tests/test-client.py:1080:test_004()/844
 cmd: $NMCLI --mode multiline --terse --color yes -f NAME,SSID,SSID-HEX,BSSID,MODE,CHAN,FREQ,RATE,SIGNAL,BARS,SECURITY,WPA-FLAGS,RSN-FLAGS,DEVICE,ACTIVE,IN-USE,DBUS-PATH device wifi list bssid C0:E2:BE:E8:EF:B6
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 532 bytes
+stdout: 534 bytes
 >>>
 NAME:[32mAP[1][0m
 SSID:[32mwlan0-ap-2[0m
@@ -49040,6 +49254,8 @@ DEVICE:[32mwlan0[0m
 ACTIVE:[32mnie[0m
 IN-USE:[32m [0m
 DBUS-PATH:[32m/org/freedesktop/NetworkManager/AccessPoint/2[0m
+
+
 
 <<<
 size: 2951

--- a/libnm/nm-remote-connection.c
+++ b/libnm/nm-remote-connection.c
@@ -918,7 +918,7 @@ get_property (GObject *object, guint prop_id,
 		g_value_set_boolean (value, NM_REMOTE_CONNECTION_GET_PRIVATE (object)->unsaved);
 		break;
 	case PROP_FLAGS:
-		g_value_set_boolean (value, NM_REMOTE_CONNECTION_GET_PRIVATE (object)->flags);
+		g_value_set_uint (value, NM_REMOTE_CONNECTION_GET_PRIVATE (object)->flags);
 		break;
 	case PROP_FILENAME:
 		g_value_set_string (value, NM_REMOTE_CONNECTION_GET_PRIVATE (object)->filename);


### PR DESCRIPTION
This aims to improve two things:

1.) Sort Hotspots higher (in "nmcli c", "nmcli d" and "nmcli")
2.) Get rid of duplicates in sorting policy