### PR TITLE
lr/dispatcher-split: split the dispatcher into an optional package

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3891,14 +3891,15 @@ dispatcher/org.freedesktop.nm_dispatcher.service: $(srcdir)/dispatcher/org.freed
 dbusactivation_DATA += dispatcher/org.freedesktop.nm_dispatcher.service
 CLEANFILES += dispatcher/org.freedesktop.nm_dispatcher.service
 
-
-dispatcherdir=$(sysconfdir)/NetworkManager/dispatcher.d
-
 install-data-hook-dispatcher:
-	$(mkinstalldirs) -m 0755 $(DESTDIR)$(dispatcherdir)
-	$(mkinstalldirs) -m 0755 $(DESTDIR)$(dispatcherdir)/pre-down.d
-	$(mkinstalldirs) -m 0755 $(DESTDIR)$(dispatcherdir)/pre-up.d
-	$(mkinstalldirs) -m 0755 $(DESTDIR)$(dispatcherdir)/no-wait.d
+	$(mkinstalldirs) -m 0755 $(DESTDIR)$(nmconfdir)/dispatcher.d
+	$(mkinstalldirs) -m 0755 $(DESTDIR)$(nmconfdir)/dispatcher.d/pre-down.d
+	$(mkinstalldirs) -m 0755 $(DESTDIR)$(nmconfdir)/dispatcher.d/pre-up.d
+	$(mkinstalldirs) -m 0755 $(DESTDIR)$(nmconfdir)/dispatcher.d/no-wait.d
+	$(mkinstalldirs) -m 0755 $(DESTDIR)$(nmlibdir)/dispatcher.d
+	$(mkinstalldirs) -m 0755 $(DESTDIR)$(nmlibdir)/dispatcher.d/pre-down.d
+	$(mkinstalldirs) -m 0755 $(DESTDIR)$(nmlibdir)/dispatcher.d/pre-up.d
+	$(mkinstalldirs) -m 0755 $(DESTDIR)$(nmlibdir)/dispatcher.d/no-wait.d
 
 install_data_hook += install-data-hook-dispatcher
 

--- a/contrib/fedora/rpm/NetworkManager.spec
+++ b/contrib/fedora/rpm/NetworkManager.spec
@@ -242,6 +242,8 @@ BuildRequires: libubsan
 %endif
 %endif
 
+Provides: %{name}-dispatcher%{?_isa} = %{epoch}:%{version}-%{release}
+
 # NetworkManager uses various parts of systemd-networkd internally, including
 # DHCP client, IPv4 Link-Local address negotiation or LLDP support.
 # This provide is essentially here so that NetworkManager shows on Security

--- a/contrib/fedora/rpm/NetworkManager.spec
+++ b/contrib/fedora/rpm/NetworkManager.spec
@@ -824,13 +824,15 @@ fi
 %{_sbindir}/%{name}
 %{_bindir}/nmcli
 %{_datadir}/bash-completion/completions/nmcli
-%dir %{_sysconfdir}/%{name}/
+%dir %{_sysconfdir}/%{name}
+%dir %{_sysconfdir}/%{name}/conf.d
 %dir %{_sysconfdir}/%{name}/dispatcher.d
 %dir %{_sysconfdir}/%{name}/dispatcher.d/pre-down.d
 %dir %{_sysconfdir}/%{name}/dispatcher.d/pre-up.d
 %dir %{_sysconfdir}/%{name}/dispatcher.d/no-wait.d
 %dir %{_sysconfdir}/%{name}/dnsmasq.d
 %dir %{_sysconfdir}/%{name}/dnsmasq-shared.d
+%dir %{_sysconfdir}/%{name}/system-connections
 %config(noreplace) %{_sysconfdir}/%{name}/NetworkManager.conf
 %{_bindir}/nm-online
 %{_libexecdir}/nm-ifup
@@ -847,8 +849,6 @@ fi
 %if %{with nmtui}
 %exclude %{_mandir}/man1/nmtui*
 %endif
-%dir %{_sysconfdir}/%{name}
-%dir %{_sysconfdir}/%{name}/conf.d
 %dir %{nmlibdir}
 %dir %{nmlibdir}/conf.d
 %dir %{nmlibdir}/VPN
@@ -857,7 +857,6 @@ fi
 %{_mandir}/man7/nmcli-examples.7*
 %{_mandir}/man8/*
 %dir %{_localstatedir}/lib/NetworkManager
-%dir %{_sysconfdir}/NetworkManager/system-connections
 %dir %{_sysconfdir}/sysconfig/network-scripts
 %{_datadir}/dbus-1/system-services/org.freedesktop.nm_dispatcher.service
 %{_datadir}/polkit-1/actions/*.policy

--- a/shared/nm-libnm-core-aux/nm-dispatcher-api.h
+++ b/shared/nm-libnm-core-aux/nm-dispatcher-api.h
@@ -21,11 +21,6 @@
 #ifndef __NM_DISPACHER_API_H__
 #define __NM_DISPACHER_API_H__
 
-#define NMD_SCRIPT_DIR_DEFAULT  NMCONFDIR "/dispatcher.d"
-#define NMD_SCRIPT_DIR_PRE_UP   NMD_SCRIPT_DIR_DEFAULT "/pre-up.d"
-#define NMD_SCRIPT_DIR_PRE_DOWN NMD_SCRIPT_DIR_DEFAULT "/pre-down.d"
-#define NMD_SCRIPT_DIR_NO_WAIT  NMD_SCRIPT_DIR_DEFAULT "/no-wait.d"
-
 #define NM_DISPATCHER_DBUS_SERVICE   "org.freedesktop.nm_dispatcher"
 #define NM_DISPATCHER_DBUS_INTERFACE "org.freedesktop.nm_dispatcher"
 #define NM_DISPATCHER_DBUS_PATH      "/org/freedesktop/nm_dispatcher"

--- a/tools/meson-post-install.sh
+++ b/tools/meson-post-install.sh
@@ -27,6 +27,9 @@ for dir in "${pkgconfdir}/conf.d" \
            "${pkgconfdir}/dnsmasq.d" \
            "${pkgconfdir}/dnsmasq-shared.d" \
            "${pkglibdir}/conf.d" \
+           "${pkglibdir}/dispatcher.d/no-wait.d" \
+           "${pkglibdir}/dispatcher.d/pre-down.d" \
+           "${pkglibdir}/dispatcher.d/pre-up.d" \
            "${pkglibdir}/VPN"; do
     mkdir -p "${DESTDIR}${dir}"
     chmod 0755 "${DESTDIR}${dir}"


### PR DESCRIPTION
This aims to improve things for packages that install dispatcher scripts; adds support for scripts in /usr and makes the whole dispatcher optional.

Packages that actually use the dispatcher (I'm in the process of compiling the list for Fedora) shall depend on NetworkManager-dispatcher or /usr/libexec/nm-dispatcher (if they want to support older NM as well).
