### PR TITLE
settings,gsm: deprecate and stop using 'number' property

### DIFF
--- a/clients/common/nm-meta-setting-desc.c
+++ b/clients/common/nm-meta-setting-desc.c
@@ -7944,9 +7944,9 @@ static void
 _setting_init_fcn_gsm (ARGS_SETTING_INIT_FCN)
 {
 	if (init_type == NM_META_ACCESSOR_SETTING_INIT_TYPE_CLI) {
-		/* Initialize 'number' so that 'gsm' is valid */
+		/* Initialize 'apn' so that 'gsm' is valid */
 		g_object_set (NM_SETTING_GSM (setting),
-		              NM_SETTING_GSM_NUMBER, "*99#",
+		              NM_SETTING_GSM_APN, "internet",
 		              NULL);
 	}
 }

--- a/clients/common/settings-docs.h.in
+++ b/clients/common/settings-docs.h.in
@@ -169,7 +169,7 @@
 #define DESCRIBE_DOC_NM_SETTING_GSM_HOME_ONLY N_("When TRUE, only connections to the home network will be allowed. Connections to roaming networks will not be made.")
 #define DESCRIBE_DOC_NM_SETTING_GSM_MTU N_("If non-zero, only transmit packets of the specified size or smaller, breaking larger packets up into multiple frames.")
 #define DESCRIBE_DOC_NM_SETTING_GSM_NETWORK_ID N_("The Network ID (GSM LAI format, ie MCC-MNC) to force specific network registration.  If the Network ID is specified, NetworkManager will attempt to force the device to register only on the specified network. This can be used to ensure that the device does not roam when direct roaming control of the device is not otherwise possible.")
-#define DESCRIBE_DOC_NM_SETTING_GSM_NUMBER N_("Number to dial when establishing a PPP data session with the GSM-based mobile broadband network.  Many modems do not require PPP for connections to the mobile network and thus this property should be left blank, which allows NetworkManager to select the appropriate settings automatically.")
+#define DESCRIBE_DOC_NM_SETTING_GSM_NUMBER N_("Legacy setting that used to help establishing PPP data sessions for GSM-based modems. Deprecated: 1")
 #define DESCRIBE_DOC_NM_SETTING_GSM_PASSWORD N_("The password used to authenticate with the network, if required.  Many providers do not require a password, or accept any password.  But if a password is required, it is specified here.")
 #define DESCRIBE_DOC_NM_SETTING_GSM_PASSWORD_FLAGS N_("Flags indicating how to handle the \"password\" property.")
 #define DESCRIBE_DOC_NM_SETTING_GSM_PIN N_("If the SIM is locked with a PIN it must be unlocked before any other operations are requested.  Specify the PIN here to allow operation of the device.")

--- a/clients/tests/test-client.check-on-disk/test_003.expected
+++ b/clients/tests/test-client.check-on-disk/test_003.expected
@@ -150,12 +150,12 @@ id
 path
 uuid
 <<<
-size: 3989
+size: 3987
 location: clients/tests/test-client.py:898:test_003()/12
 cmd: $NMCLI con s con-gsm1
 lang: C
 returncode: 0
-stdout: 3855 bytes
+stdout: 3853 bytes
 >>>
 connection.id:                          con-gsm1
 connection.uuid:                        UUID-con-gsm1-REPLACED-REPLACED-REPL
@@ -225,7 +225,7 @@ serial.bits:                            8
 serial.parity:                          even
 serial.stopbits:                        1
 serial.send-delay:                      100
-gsm.number:                             *99#
+gsm.number:                             --
 gsm.username:                           --
 gsm.password:                           <hidden>
 gsm.password-flags:                     0 (none)
@@ -244,12 +244,12 @@ proxy.pac-url:                          --
 proxy.pac-script:                       --
 
 <<<
-size: 4018
+size: 4016
 location: clients/tests/test-client.py:898:test_003()/13
 cmd: $NMCLI con s con-gsm1
 lang: pl_PL.UTF-8
 returncode: 0
-stdout: 3874 bytes
+stdout: 3872 bytes
 >>>
 connection.id:                          con-gsm1
 connection.uuid:                        UUID-con-gsm1-REPLACED-REPLACED-REPL
@@ -319,7 +319,7 @@ serial.bits:                            8
 serial.parity:                          even
 serial.stopbits:                        1
 serial.send-delay:                      100
-gsm.number:                             *99#
+gsm.number:                             --
 gsm.username:                           --
 gsm.password:                           <hidden>
 gsm.password-flags:                     0 (brak)

--- a/libnm-core/nm-setting-gsm.c
+++ b/libnm-core/nm-setting-gsm.c
@@ -100,6 +100,8 @@ nm_setting_gsm_new (void)
  * @setting: the #NMSettingGsm
  *
  * Returns: the #NMSettingGsm:number property of the setting
+ *
+ * Deprecated: 1.16:  user-provided values for this setting are no longer used.
  **/
 const char *
 nm_setting_gsm_get_number (NMSettingGsm *setting)
@@ -621,10 +623,10 @@ nm_setting_gsm_class_init (NMSettingGsmClass *klass)
 	/**
 	 * NMSettingGsm:number:
 	 *
-	 * Number to dial when establishing a PPP data session with the GSM-based
-	 * mobile broadband network.  Many modems do not require PPP for connections
-	 * to the mobile network and thus this property should be left blank, which
-	 * allows NetworkManager to select the appropriate settings automatically.
+	 * Legacy setting that used to help establishing PPP data sessions for
+	 * GSM-based modems.
+	 *
+	 * Deprecated: 1.16: user-provided values for this setting are no longer used.
 	 **/
 	g_object_class_install_property
 		(object_class, PROP_NUMBER,

--- a/libnm-core/nm-setting-gsm.h
+++ b/libnm-core/nm-setting-gsm.h
@@ -40,7 +40,6 @@ G_BEGIN_DECLS
 
 #define NM_SETTING_GSM_SETTING_NAME "gsm"
 
-#define NM_SETTING_GSM_NUMBER          "number"
 #define NM_SETTING_GSM_USERNAME        "username"
 #define NM_SETTING_GSM_PASSWORD        "password"
 #define NM_SETTING_GSM_PASSWORD_FLAGS  "password-flags"
@@ -53,6 +52,9 @@ G_BEGIN_DECLS
 #define NM_SETTING_GSM_SIM_ID          "sim-id"
 #define NM_SETTING_GSM_SIM_OPERATOR_ID "sim-operator-id"
 #define NM_SETTING_GSM_MTU             "mtu"
+
+/* Deprecated */
+#define NM_SETTING_GSM_NUMBER          "number"
 
 /**
  * NMSettingGsm:
@@ -73,7 +75,6 @@ typedef struct {
 GType nm_setting_gsm_get_type (void);
 
 NMSetting *nm_setting_gsm_new                  (void);
-const char *nm_setting_gsm_get_number          (NMSettingGsm *setting);
 const char *nm_setting_gsm_get_username        (NMSettingGsm *setting);
 const char *nm_setting_gsm_get_password        (NMSettingGsm *setting);
 const char *nm_setting_gsm_get_apn             (NMSettingGsm *setting);
@@ -89,6 +90,9 @@ NM_AVAILABLE_IN_1_2
 const char *nm_setting_gsm_get_sim_operator_id (NMSettingGsm *setting);
 NM_AVAILABLE_IN_1_8
 guint32 nm_setting_gsm_get_mtu                 (NMSettingGsm *setting);
+
+NM_DEPRECATED_IN_1_16
+const char *nm_setting_gsm_get_number          (NMSettingGsm *setting);
 
 NMSettingSecretFlags nm_setting_gsm_get_pin_flags      (NMSettingGsm *setting);
 NMSettingSecretFlags nm_setting_gsm_get_password_flags (NMSettingGsm *setting);

--- a/libnm-core/tests/test-general.c
+++ b/libnm-core/tests/test-general.c
@@ -1351,8 +1351,6 @@ test_setting_gsm_apn_bad_chars (void)
 	s_gsm = (NMSettingGsm *) nm_setting_gsm_new ();
 	g_assert (s_gsm);
 
-	g_object_set (s_gsm, NM_SETTING_GSM_NUMBER, "*99#", NULL);
-
 	/* Make sure a valid APN works */
 	g_object_set (s_gsm, NM_SETTING_GSM_APN, "foobar123.-baz", NULL);
 	g_assert (nm_setting_verify (NM_SETTING (s_gsm), NULL, NULL));
@@ -1381,8 +1379,6 @@ test_setting_gsm_apn_underscore (void)
 
 	s_gsm = (NMSettingGsm *) nm_setting_gsm_new ();
 	g_assert (s_gsm);
-
-	g_object_set (s_gsm, NM_SETTING_GSM_NUMBER, "*99#", NULL);
 
 	/* 65-character long */
 	g_object_set (s_gsm, NM_SETTING_GSM_APN, "foobar_baz", NULL);
@@ -2946,7 +2942,6 @@ test_connection_good_base_types (void)
 
 	setting = nm_setting_gsm_new ();
 	g_object_set (setting,
-	              NM_SETTING_GSM_NUMBER, "*99#",
 	              NM_SETTING_GSM_APN, "metered.billing.sucks",
 	              NULL);
 	nm_connection_add_setting (connection, setting);
@@ -7564,4 +7559,3 @@ int main (int argc, char **argv)
 
 	return g_test_run ();
 }
-

--- a/src/devices/bluetooth/nm-device-bt.c
+++ b/src/devices/bluetooth/nm-device-bt.c
@@ -320,8 +320,6 @@ complete_connection (NMDevice *device,
 
 		if (s_gsm) {
 			fallback_prefix = _("GSM connection");
-			if (!nm_setting_gsm_get_number (s_gsm))
-				g_object_set (G_OBJECT (s_gsm), NM_SETTING_GSM_NUMBER, "*99#", NULL);
 		} else {
 			fallback_prefix = _("CDMA connection");
 			if (!nm_setting_cdma_get_number (s_cdma))

--- a/src/devices/wwan/nm-modem-broadband.c
+++ b/src/devices/wwan/nm-modem-broadband.c
@@ -279,11 +279,6 @@ create_gsm_connect_properties (NMConnection *connection)
 	setting = nm_connection_get_setting_gsm (connection);
 	properties = mm_simple_connect_properties_new ();
 
-	/* TODO: not needed */
-	str = nm_setting_gsm_get_number (setting);
-	if (str)
-		mm_simple_connect_properties_set_number (properties, str);
-
 	/* Blank APN ("") means the default subscription APN */
 	str = nm_setting_gsm_get_apn (setting);
 	mm_simple_connect_properties_set_apn (properties, str ?: "");
@@ -692,10 +687,6 @@ complete_connection (NMModem *_self,
 			g_prefix_error (error, "%s: ", NM_SETTING_GSM_SETTING_NAME);
 			return FALSE;
 		}
-
-		/* TODO: This is not needed */
-		if (!nm_setting_gsm_get_number (s_gsm))
-			g_object_set (G_OBJECT (s_gsm), NM_SETTING_GSM_NUMBER, "*99#", NULL);
 
 		nm_utils_complete_generic (NM_PLATFORM_GET,
 		                           connection,

--- a/src/settings/plugins/ifcfg-rh/tests/test-ifcfg-rh.c
+++ b/src/settings/plugins/ifcfg-rh/tests/test-ifcfg-rh.c
@@ -7402,8 +7402,6 @@ test_write_mobile_broadband (gconstpointer data)
 		/* GSM setting */
 		s_gsm = (NMSettingGsm *) nm_setting_gsm_new ();
 		nm_connection_add_setting (connection, NM_SETTING (s_gsm));
-
-		g_object_set (s_gsm, NM_SETTING_GSM_NUMBER, "*99#", NULL);
 	} else {
 		/* CDMA setting */
 		s_cdma = (NMSettingCdma *) nm_setting_cdma_new ();

--- a/src/settings/plugins/keyfile/tests/test-keyfile.c
+++ b/src/settings/plugins/keyfile/tests/test-keyfile.c
@@ -1177,7 +1177,6 @@ test_write_bt_dun_connection (void)
 	              NM_SETTING_GSM_APN, "internet2.voicestream.com",
 	              NM_SETTING_GSM_USERNAME, "george.clinton",
 	              NM_SETTING_GSM_PASSWORD, "parliament",
-	              NM_SETTING_GSM_NUMBER,  "*99#",
 	              NULL);
 
 	write_test_connection_and_reread (connection, TRUE);
@@ -1259,7 +1258,6 @@ test_write_gsm_connection (void)
 	              NM_SETTING_GSM_APN, "internet2.voicestream.com",
 	              NM_SETTING_GSM_USERNAME, "george.clinton.again",
 	              NM_SETTING_GSM_PASSWORD, "parliament2",
-	              NM_SETTING_GSM_NUMBER,  "*99#",
 	              NM_SETTING_GSM_PIN, "123456",
 	              NM_SETTING_GSM_NETWORK_ID, "254098",
 	              NM_SETTING_GSM_HOME_ONLY, TRUE,
@@ -2333,7 +2331,6 @@ test_write_flags_property (void)
 	s_gsm = nm_setting_gsm_new ();
 	nm_connection_add_setting (connection, s_gsm);
 	g_object_set (s_gsm,
-	              NM_SETTING_GSM_NUMBER, "#99*",
 	              NM_SETTING_GSM_APN, "myapn",
 	              NM_SETTING_GSM_USERNAME, "adfasdfasdf",
 	              NM_SETTING_GSM_PASSWORD_FLAGS, NM_SETTING_SECRET_FLAG_NOT_SAVED | NM_SETTING_SECRET_FLAG_NOT_REQUIRED,
@@ -2700,4 +2697,3 @@ int main (int argc, char **argv)
 
 	return g_test_run ();
 }
-


### PR DESCRIPTION
The 'number' property in GSM settings is a legacy thing that comes
from when ModemManager used user-provided numbers, if any, to connect
3GPP modems.

Since ModemManager 1.0, this property is completely unused for 3GPP
modems, and so it doesn't make sense to use it in the NetworkManager
settings. Ofono does not use it either.

For AT+PPP-based 3GPP modems, the 'number' to call to establish the
data connection is decided by ModemManager itself, e.g. for standard
GSM/UMTS/LTE modems it will connect a given predefined PDP context,
and for other modems like Iridium it will have the number to call
hardcoded in the plugin itself.