### PR TITLE
[th/dhcp-infiniband-client]

### DIFF
--- a/src/dhcp/nm-dhcp-systemd.c
+++ b/src/dhcp/nm-dhcp-systemd.c
@@ -559,19 +559,6 @@ dhcp_event_cb (sd_dhcp_client *client, int event, gpointer user_data)
 	}
 }
 
-static guint16
-get_arp_type (gsize hwaddr_len)
-{
-	switch (hwaddr_len) {
-	case ETH_ALEN:
-		return ARPHRD_ETHER;
-	case INFINIBAND_ALEN:
-		return ARPHRD_INFINIBAND;
-	default:
-		return ARPHRD_NONE;
-	}
-}
-
 static gboolean
 ip4_start (NMDhcpClient *client,
            const char *dhcp_anycast_addr,
@@ -585,7 +572,7 @@ ip4_start (NMDhcpClient *client,
 	GBytes *hwaddr;
 	const uint8_t *hwaddr_arr;
 	gsize hwaddr_len;
-	guint16 arptype;
+	int arp_type;
 	GBytes *client_id;
 	gs_unref_bytes GBytes *client_id_new = NULL;
 	const uint8_t *client_id_arr;
@@ -614,14 +601,14 @@ ip4_start (NMDhcpClient *client,
 	hwaddr = nm_dhcp_client_get_hw_addr (client);
 	if (   !hwaddr
 	    || !(hwaddr_arr = g_bytes_get_data (hwaddr, &hwaddr_len))
-	    || (arptype = get_arp_type (hwaddr_len)) == ARPHRD_NONE) {
+	    || (arp_type = nm_utils_detect_arp_type_from_addrlen (hwaddr_len)) < 0) {
 		nm_utils_error_set_literal (error, NM_UTILS_ERROR_UNKNOWN, "invalid MAC address");
 		return FALSE;
 	}
 	r = sd_dhcp_client_set_mac (sd_client,
 	                            hwaddr_arr,
 	                            hwaddr_len,
-	                            arptype);
+	                            (guint16) arp_type);
 	if (r < 0) {
 		nm_utils_error_set_errno (error, r, "failed to set MAC address: %s");
 		return FALSE;
@@ -901,7 +888,7 @@ ip6_start (NMDhcpClient *client,
 	GBytes *duid;
 	const uint8_t *hwaddr_arr;
 	gsize hwaddr_len;
-	guint16 arptype;
+	int arp_type;
 
 	g_return_val_if_fail (!priv->client4, FALSE);
 	g_return_val_if_fail (!priv->client6, FALSE);
@@ -958,14 +945,14 @@ ip6_start (NMDhcpClient *client,
 	hwaddr = nm_dhcp_client_get_hw_addr (client);
 	if (   !hwaddr
 	    || !(hwaddr_arr = g_bytes_get_data (hwaddr, &hwaddr_len))
-	    || (arptype = get_arp_type (hwaddr_len)) == ARPHRD_NONE) {
+	    || (arp_type = nm_utils_detect_arp_type_from_addrlen (hwaddr_len)) < 0) {
 		nm_utils_error_set_literal (error, NM_UTILS_ERROR_UNKNOWN, "invalid MAC address");
 		return FALSE;
 	}
 	r = sd_dhcp6_client_set_mac (sd_client,
 	                             hwaddr_arr,
 	                             hwaddr_len,
-	                             arptype);
+	                             (guint16) arp_type);
 	if (r < 0) {
 		nm_utils_error_set_errno (error, r, "failed to set MAC address: %s");
 		return FALSE;

--- a/src/nm-core-utils.c
+++ b/src/nm-core-utils.c
@@ -36,6 +36,7 @@
 #include <sys/stat.h>
 #include <linux/if.h>
 #include <linux/if_infiniband.h>
+#include <net/if_arp.h>
 #include <net/ethernet.h>
 
 #include "nm-utils/nm-random-utils.h"
@@ -2838,6 +2839,33 @@ nm_utils_boot_id_bin (void)
 }
 
 /*****************************************************************************/
+
+/**
+ * nm_utils_detect_arp_type_from_addrlen:
+ * @hwaddr_len: the length of the hardware address in bytes.
+ *
+ * Detects the arp-type based on the length of the MAC address.
+ * On success, this returns a (positive) value in uint16_t range,
+ * like ARPHRD_ETHER or ARPHRD_INFINIBAND.
+ *
+ * On failure, returns a negative error code.
+ *
+ * Returns: the arp-type or negative value on error. */
+int
+nm_utils_detect_arp_type_from_addrlen (gsize hwaddr_len)
+{
+	switch (hwaddr_len) {
+	case ETH_ALEN:
+		return ARPHRD_ETHER;
+	case INFINIBAND_ALEN:
+		return ARPHRD_INFINIBAND;
+	default:
+		/* Note: if you ever support anything but ethernet and infiniband,
+		 * make sure to look at all callers. They assert that it's one of
+		 * these two. */
+		return -EINVAL;
+	}
+}
 
 /* Returns the "u" (universal/local) bit value for a Modified EUI-64 */
 static gboolean

--- a/src/nm-core-utils.h
+++ b/src/nm-core-utils.h
@@ -279,6 +279,8 @@ gboolean nm_utils_host_id_get (const guint8 **out_host_id,
                                gsize *out_host_id_len);
 gint64 nm_utils_host_id_get_timestamp_ns (void);
 
+int nm_utils_detect_arp_type_from_addrlen (gsize hwaddr_len);
+
 /* IPv6 Interface Identifier helpers */
 
 /**


### PR DESCRIPTION
Support infiniband types for 

 - `ipv4.dhcp-client-id=mac`
 - `ipv4.dhcp-client-id=perm-mac`
 - `ipv6.dhcp-duid=ll`
 - `ipv6.dhcp-duid=llt`
 - `ipv6.dhcp-duid=stable-ll`
 - `ipv6.dhcp-duid=stable-llt`
