### PR TITLE
[th/libnm-settings-properties]

### DIFF
--- a/libnm-core/nm-connection.c
+++ b/libnm-core/nm-connection.c
@@ -3006,8 +3006,6 @@ nm_connection_get_private (NMConnection *connection)
 static void
 nm_connection_default_init (NMConnectionInterface *iface)
 {
-	/* Signals */
-
 	/**
 	 * NMConnection::secrets-updated:
 	 * @connection: the object on which the signal is emitted
@@ -3018,14 +3016,14 @@ nm_connection_default_init (NMConnectionInterface *iface)
 	 * have been changed.
 	 */
 	signals[SECRETS_UPDATED] =
-		g_signal_new (NM_CONNECTION_SECRETS_UPDATED,
-		              NM_TYPE_CONNECTION,
-		              G_SIGNAL_RUN_FIRST,
-		              G_STRUCT_OFFSET (NMConnectionInterface, secrets_updated),
-		              NULL, NULL,
-		              g_cclosure_marshal_VOID__STRING,
-		              G_TYPE_NONE, 1,
-		              G_TYPE_STRING);
+	    g_signal_new (NM_CONNECTION_SECRETS_UPDATED,
+	                 NM_TYPE_CONNECTION,
+	                 G_SIGNAL_RUN_FIRST,
+	                 G_STRUCT_OFFSET (NMConnectionInterface, secrets_updated),
+	                 NULL, NULL,
+	                 g_cclosure_marshal_VOID__STRING,
+	                 G_TYPE_NONE, 1,
+	                 G_TYPE_STRING);
 
 	/**
 	 * NMConnection::secrets-cleared:
@@ -3035,13 +3033,13 @@ nm_connection_default_init (NMConnectionInterface *iface)
 	 * are cleared.
 	 */
 	signals[SECRETS_CLEARED] =
-		g_signal_new (NM_CONNECTION_SECRETS_CLEARED,
-		              NM_TYPE_CONNECTION,
-		              G_SIGNAL_RUN_FIRST,
-		              G_STRUCT_OFFSET (NMConnectionInterface, secrets_cleared),
-		              NULL, NULL,
-		              g_cclosure_marshal_VOID__VOID,
-		              G_TYPE_NONE, 0);
+	    g_signal_new (NM_CONNECTION_SECRETS_CLEARED,
+	                 NM_TYPE_CONNECTION,
+	                 G_SIGNAL_RUN_FIRST,
+	                 G_STRUCT_OFFSET (NMConnectionInterface, secrets_cleared),
+	                 NULL, NULL,
+	                 g_cclosure_marshal_VOID__VOID,
+	                 G_TYPE_NONE, 0);
 
 	/**
 	 * NMConnection::changed:
@@ -3052,11 +3050,11 @@ nm_connection_default_init (NMConnectionInterface *iface)
 	 * or when settings are added or removed.
 	 */
 	signals[CHANGED] =
-		g_signal_new (NM_CONNECTION_CHANGED,
-		              NM_TYPE_CONNECTION,
-		              G_SIGNAL_RUN_FIRST,
-		              G_STRUCT_OFFSET (NMConnectionInterface, changed),
-		              NULL, NULL,
-		              g_cclosure_marshal_VOID__VOID,
-		              G_TYPE_NONE, 0);
+	    g_signal_new (NM_CONNECTION_CHANGED,
+	                 NM_TYPE_CONNECTION,
+	                 G_SIGNAL_RUN_FIRST,
+	                 G_STRUCT_OFFSET (NMConnectionInterface, changed),
+	                 NULL, NULL,
+	                 g_cclosure_marshal_VOID__VOID,
+	                 G_TYPE_NONE, 0);
 }

--- a/libnm-core/nm-connection.c
+++ b/libnm-core/nm-connection.c
@@ -22,10 +22,11 @@
 
 #include "nm-default.h"
 
+#include "nm-connection.h"
+
 #include <string.h>
 #include <arpa/inet.h>
 
-#include "nm-connection.h"
 #include "nm-connection-private.h"
 #include "nm-utils.h"
 #include "nm-setting-private.h"
@@ -50,19 +51,7 @@
  *
  */
 
-typedef struct {
-	NMConnection *self;
-
-	GHashTable *settings;
-
-	/* D-Bus path of the connection, if any */
-	char *path;
-} NMConnectionPrivate;
-
-static NMConnectionPrivate *nm_connection_get_private (NMConnection *connection);
-#define NM_CONNECTION_GET_PRIVATE(o) (nm_connection_get_private ((NMConnection *)o))
-
-G_DEFINE_INTERFACE (NMConnection, nm_connection, G_TYPE_OBJECT)
+/*****************************************************************************/
 
 enum {
 	SECRETS_UPDATED,
@@ -72,6 +61,20 @@ enum {
 };
 
 static guint signals[LAST_SIGNAL] = { 0 };
+
+typedef struct {
+	NMConnection *self;
+
+	GHashTable *settings;
+
+	/* D-Bus path of the connection, if any */
+	char *path;
+} NMConnectionPrivate;
+
+G_DEFINE_INTERFACE (NMConnection, nm_connection, G_TYPE_OBJECT)
+
+static NMConnectionPrivate *nm_connection_get_private (NMConnection *connection);
+#define NM_CONNECTION_GET_PRIVATE(o) (nm_connection_get_private ((NMConnection *)o))
 
 /*****************************************************************************/
 

--- a/libnm-core/nm-setting-6lowpan.c
+++ b/libnm-core/nm-setting-6lowpan.c
@@ -19,8 +19,19 @@
 
 #include "nm-default.h"
 
-#include "nm-setting-private.h"
 #include "nm-setting-6lowpan.h"
+
+#include "nm-setting-private.h"
+
+/**
+ * SECTION:nm-setting-6lowpan
+ * @short_description: Describes connection properties for 6LoWPAN interfaces
+ *
+ * The #NMSetting6Lowpan object is a #NMSetting subclass that describes properties
+ * necessary for connection to 6LoWPAN interfaces.
+ **/
+
+/*****************************************************************************/
 
 NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_PARENT,
@@ -43,33 +54,11 @@ struct _NMSetting6LowpanClass {
 	NMSettingClass parent;
 };
 
-/**
- * SECTION:nm-setting-6lowpan
- * @short_description: Describes connection properties for 6LoWPAN interfaces
- *
- * The #NMSetting6Lowpan object is a #NMSetting subclass that describes properties
- * necessary for connection to 6LoWPAN interfaces.
- **/
-
 G_DEFINE_TYPE (NMSetting6Lowpan, nm_setting_6lowpan, NM_TYPE_SETTING)
 
 #define NM_SETTING_6LOWPAN_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_6LOWPAN, NMSetting6LowpanPrivate))
 
-
-/**
- * nm_setting_6lowpan_new:
- *
- * Creates a new #NMSetting6Lowpan object with default values.
- *
- * Returns: (transfer full): the new empty #NMSetting6Lowpan object
- *
- * Since: 1.14
- **/
-NMSetting *
-nm_setting_6lowpan_new (void)
-{
-	return (NMSetting *) g_object_new (NM_TYPE_SETTING_6LOWPAN, NULL);
-}
+/*****************************************************************************/
 
 /**
  * nm_setting_6lowpan_get_parent:
@@ -143,9 +132,23 @@ verify (NMSetting *setting, NMConnection *connection, GError **error)
 	return TRUE;
 }
 
+/*****************************************************************************/
+
 static void
-nm_setting_6lowpan_init (NMSetting6Lowpan *setting)
+get_property (GObject *object, guint prop_id,
+              GValue *value, GParamSpec *pspec)
 {
+	NMSetting6Lowpan *setting = NM_SETTING_6LOWPAN (object);
+	NMSetting6LowpanPrivate *priv = NM_SETTING_6LOWPAN_GET_PRIVATE (setting);
+
+	switch (prop_id) {
+	case PROP_PARENT:
+		g_value_set_string (value, priv->parent);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
 }
 
 static void
@@ -166,21 +169,26 @@ set_property (GObject *object, guint prop_id,
 	}
 }
 
-static void
-get_property (GObject *object, guint prop_id,
-              GValue *value, GParamSpec *pspec)
-{
-	NMSetting6Lowpan *setting = NM_SETTING_6LOWPAN (object);
-	NMSetting6LowpanPrivate *priv = NM_SETTING_6LOWPAN_GET_PRIVATE (setting);
+/*****************************************************************************/
 
-	switch (prop_id) {
-	case PROP_PARENT:
-		g_value_set_string (value, priv->parent);
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
+static void
+nm_setting_6lowpan_init (NMSetting6Lowpan *setting)
+{
+}
+
+/**
+ * nm_setting_6lowpan_new:
+ *
+ * Creates a new #NMSetting6Lowpan object with default values.
+ *
+ * Returns: (transfer full): the new empty #NMSetting6Lowpan object
+ *
+ * Since: 1.14
+ **/
+NMSetting *
+nm_setting_6lowpan_new (void)
+{
+	return (NMSetting *) g_object_new (NM_TYPE_SETTING_6LOWPAN, NULL);
 }
 
 static void
@@ -202,8 +210,8 @@ nm_setting_6lowpan_class_init (NMSetting6LowpanClass *klass)
 
 	g_type_class_add_private (klass, sizeof (NMSetting6LowpanPrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->verify = verify;

--- a/libnm-core/nm-setting-8021x.c
+++ b/libnm-core/nm-setting-8021x.c
@@ -3369,8 +3369,6 @@ finalize (GObject *object)
 	NMSetting8021x *self = NM_SETTING_802_1X (object);
 	NMSetting8021xPrivate *priv = NM_SETTING_802_1X_GET_PRIVATE (self);
 
-	/* Strings first. g_free() already checks for NULLs so we don't have to */
-
 	g_free (priv->identity);
 	g_free (priv->anonymous_identity);
 	g_free (priv->ca_path);
@@ -3416,8 +3414,8 @@ nm_setting_802_1x_class_init (NMSetting8021xClass *klass)
 
 	g_type_class_add_private (klass, sizeof (NMSetting8021xPrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->verify       = verify;

--- a/libnm-core/nm-setting-adsl.c
+++ b/libnm-core/nm-setting-adsl.c
@@ -51,8 +51,7 @@ typedef struct {
 	guint32 vci;
 } NMSettingAdslPrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_USERNAME,
 	PROP_PASSWORD,
 	PROP_PASSWORD_FLAGS,
@@ -60,9 +59,7 @@ enum {
 	PROP_ENCAPSULATION,
 	PROP_VPI,
 	PROP_VCI,
-
-	LAST_PROP
-};
+);
 
 /**
  * nm_setting_adsl_new:
@@ -364,86 +361,81 @@ nm_setting_adsl_class_init (NMSettingAdslClass *klass)
 	 *
 	 * Username used to authenticate with the ADSL service.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_USERNAME,
-		 g_param_spec_string (NM_SETTING_ADSL_USERNAME, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_USERNAME] =
+	    g_param_spec_string (NM_SETTING_ADSL_USERNAME, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingAdsl:password:
 	 *
 	 * Password used to authenticate with the ADSL service.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_PASSWORD,
-		 g_param_spec_string (NM_SETTING_ADSL_PASSWORD, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_SECRET |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PASSWORD] =
+	    g_param_spec_string (NM_SETTING_ADSL_PASSWORD, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_SECRET |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingAdsl:password-flags:
 	 *
 	 * Flags indicating how to handle the #NMSettingAdsl:password property.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_PASSWORD_FLAGS,
-		 g_param_spec_flags (NM_SETTING_ADSL_PASSWORD_FLAGS, "", "",
-		                     NM_TYPE_SETTING_SECRET_FLAGS,
-		                     NM_SETTING_SECRET_FLAG_NONE,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PASSWORD_FLAGS] =
+	    g_param_spec_flags (NM_SETTING_ADSL_PASSWORD_FLAGS, "", "",
+	                        NM_TYPE_SETTING_SECRET_FLAGS,
+	                        NM_SETTING_SECRET_FLAG_NONE,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingAdsl:protocol:
 	 *
 	 * ADSL connection protocol.  Can be "pppoa", "pppoe" or "ipoatm".
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_PROTOCOL,
-		 g_param_spec_string (NM_SETTING_ADSL_PROTOCOL, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PROTOCOL] =
+	    g_param_spec_string (NM_SETTING_ADSL_PROTOCOL, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingAdsl:encapsulation:
 	 *
 	 * Encapsulation of ADSL connection.  Can be "vcmux" or "llc".
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_ENCAPSULATION,
-		 g_param_spec_string (NM_SETTING_ADSL_ENCAPSULATION, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_ENCAPSULATION] =
+	    g_param_spec_string (NM_SETTING_ADSL_ENCAPSULATION, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingAdsl:vpi:
 	 *
 	 * VPI of ADSL connection
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_VPI,
-		 g_param_spec_uint (NM_SETTING_ADSL_VPI, "", "",
-		                    0, 65536, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_VPI] =
+	    g_param_spec_uint (NM_SETTING_ADSL_VPI, "", "",
+	                       0, 65536, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingAdsl:vci:
 	 *
 	 * VCI of ADSL connection
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_VCI,
-		 g_param_spec_uint (NM_SETTING_ADSL_VCI, "", "",
-		                    0, 65536, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_VCI] =
+	    g_param_spec_uint (NM_SETTING_ADSL_VCI, "", "",
+	                       0, 65536, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_STATIC_STRINGS);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit (setting_class, NM_META_SETTING_TYPE_ADSL);
 }

--- a/libnm-core/nm-setting-adsl.c
+++ b/libnm-core/nm-setting-adsl.c
@@ -21,9 +21,10 @@
 
 #include "nm-default.h"
 
+#include "nm-setting-adsl.h"
+
 #include <string.h>
 
-#include "nm-setting-adsl.h"
 #include "nm-setting-ppp.h"
 #include "nm-setting-private.h"
 #include "nm-utils.h"
@@ -37,19 +38,7 @@
  * properties of ADSL connections.
  */
 
-G_DEFINE_TYPE (NMSettingAdsl, nm_setting_adsl, NM_TYPE_SETTING)
-
-#define NM_SETTING_ADSL_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_ADSL, NMSettingAdslPrivate))
-
-typedef struct {
-	char *  username;
-	char *  password;
-	NMSettingSecretFlags password_flags;
-	char *  protocol;
-	char *  encapsulation;
-	guint32 vpi;
-	guint32 vci;
-} NMSettingAdslPrivate;
+/*****************************************************************************/
 
 NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_USERNAME,
@@ -61,18 +50,21 @@ NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_VCI,
 );
 
-/**
- * nm_setting_adsl_new:
- *
- * Creates a new #NMSettingAdsl object with default values.
- *
- * Returns: the new empty #NMSettingAdsl object
- **/
-NMSetting *
-nm_setting_adsl_new (void)
-{
-	return (NMSetting *) g_object_new (NM_TYPE_SETTING_ADSL, NULL);
-}
+typedef struct {
+	char *  username;
+	char *  password;
+	NMSettingSecretFlags password_flags;
+	char *  protocol;
+	char *  encapsulation;
+	guint32 vpi;
+	guint32 vci;
+} NMSettingAdslPrivate;
+
+G_DEFINE_TYPE (NMSettingAdsl, nm_setting_adsl, NM_TYPE_SETTING)
+
+#define NM_SETTING_ADSL_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_ADSL, NMSettingAdslPrivate))
+
+/*****************************************************************************/
 
 /**
  * nm_setting_adsl_get_username:
@@ -247,22 +239,40 @@ need_secrets (NMSetting *setting)
 	return secrets;
 }
 
-static void
-nm_setting_adsl_init (NMSettingAdsl *setting)
-{
-}
+/*****************************************************************************/
 
 static void
-finalize (GObject *object)
+get_property (GObject *object, guint prop_id,
+              GValue *value, GParamSpec *pspec)
 {
-	NMSettingAdslPrivate *priv = NM_SETTING_ADSL_GET_PRIVATE (object);
+	NMSettingAdsl *setting = NM_SETTING_ADSL (object);
 
-	g_free (priv->username);
-	g_free (priv->password);
-	g_free (priv->protocol);
-	g_free (priv->encapsulation);
-
-	G_OBJECT_CLASS (nm_setting_adsl_parent_class)->finalize (object);
+	switch (prop_id) {
+	case PROP_USERNAME:
+		g_value_set_string (value, nm_setting_adsl_get_username (setting));
+		break;
+	case PROP_PASSWORD:
+		g_value_set_string (value, nm_setting_adsl_get_password (setting));
+		break;
+	case PROP_PASSWORD_FLAGS:
+		g_value_set_flags (value, nm_setting_adsl_get_password_flags (setting));
+		break;
+	case PROP_PROTOCOL:
+		g_value_set_string (value, nm_setting_adsl_get_protocol (setting));
+		break;
+	case PROP_ENCAPSULATION:
+		g_value_set_string (value, nm_setting_adsl_get_encapsulation (setting));
+		break;
+	case PROP_VPI:
+		g_value_set_uint (value, nm_setting_adsl_get_vpi (setting));
+		break;
+	case PROP_VCI:
+		g_value_set_uint (value, nm_setting_adsl_get_vci (setting));
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
 }
 
 static void
@@ -306,38 +316,37 @@ set_property (GObject *object, guint prop_id,
 	}
 }
 
-static void
-get_property (GObject *object, guint prop_id,
-              GValue *value, GParamSpec *pspec)
-{
-	NMSettingAdsl *setting = NM_SETTING_ADSL (object);
+/*****************************************************************************/
 
-	switch (prop_id) {
-	case PROP_USERNAME:
-		g_value_set_string (value, nm_setting_adsl_get_username (setting));
-		break;
-	case PROP_PASSWORD:
-		g_value_set_string (value, nm_setting_adsl_get_password (setting));
-		break;
-	case PROP_PASSWORD_FLAGS:
-		g_value_set_flags (value, nm_setting_adsl_get_password_flags (setting));
-		break;
-	case PROP_PROTOCOL:
-		g_value_set_string (value, nm_setting_adsl_get_protocol (setting));
-		break;
-	case PROP_ENCAPSULATION:
-		g_value_set_string (value, nm_setting_adsl_get_encapsulation (setting));
-		break;
-	case PROP_VPI:
-		g_value_set_uint (value, nm_setting_adsl_get_vpi (setting));
-		break;
-	case PROP_VCI:
-		g_value_set_uint (value, nm_setting_adsl_get_vci (setting));
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
+static void
+nm_setting_adsl_init (NMSettingAdsl *setting)
+{
+}
+
+/**
+ * nm_setting_adsl_new:
+ *
+ * Creates a new #NMSettingAdsl object with default values.
+ *
+ * Returns: the new empty #NMSettingAdsl object
+ **/
+NMSetting *
+nm_setting_adsl_new (void)
+{
+	return (NMSetting *) g_object_new (NM_TYPE_SETTING_ADSL, NULL);
+}
+
+static void
+finalize (GObject *object)
+{
+	NMSettingAdslPrivate *priv = NM_SETTING_ADSL_GET_PRIVATE (object);
+
+	g_free (priv->username);
+	g_free (priv->password);
+	g_free (priv->protocol);
+	g_free (priv->encapsulation);
+
+	G_OBJECT_CLASS (nm_setting_adsl_parent_class)->finalize (object);
 }
 
 static void
@@ -348,8 +357,8 @@ nm_setting_adsl_class_init (NMSettingAdslClass *klass)
 
 	g_type_class_add_private (klass, sizeof (NMSettingAdslPrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->verify         = verify;

--- a/libnm-core/nm-setting-bluetooth.c
+++ b/libnm-core/nm-setting-bluetooth.c
@@ -22,11 +22,12 @@
 
 #include "nm-default.h"
 
+#include "nm-setting-bluetooth.h"
+
 #include <string.h>
 #include <net/ethernet.h>
 
 #include "nm-connection-private.h"
-#include "nm-setting-bluetooth.h"
 #include "nm-setting-cdma.h"
 #include "nm-setting-gsm.h"
 #include "nm-setting-private.h"
@@ -43,31 +44,23 @@
  * Point (NAP) profiles.
  **/
 
-G_DEFINE_TYPE (NMSettingBluetooth, nm_setting_bluetooth, NM_TYPE_SETTING)
-
-#define NM_SETTING_BLUETOOTH_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_BLUETOOTH, NMSettingBluetoothPrivate))
-
-typedef struct {
-	char *bdaddr;
-	char *type;
-} NMSettingBluetoothPrivate;
+/*****************************************************************************/
 
 NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_BDADDR,
 	PROP_TYPE,
 );
 
-/**
- * nm_setting_bluetooth_new:
- *
- * Creates a new #NMSettingBluetooth object with default values.
- *
- * Returns: (transfer full): the new empty #NMSettingBluetooth object
- **/
-NMSetting *nm_setting_bluetooth_new (void)
-{
-	return (NMSetting *) g_object_new (NM_TYPE_SETTING_BLUETOOTH, NULL);
-}
+typedef struct {
+	char *bdaddr;
+	char *type;
+} NMSettingBluetoothPrivate;
+
+G_DEFINE_TYPE (NMSettingBluetooth, nm_setting_bluetooth, NM_TYPE_SETTING)
+
+#define NM_SETTING_BLUETOOTH_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_BLUETOOTH, NMSettingBluetoothPrivate))
+
+/*****************************************************************************/
 
 /**
  * nm_setting_bluetooth_get_connection_type:
@@ -221,20 +214,25 @@ verify (NMSetting *setting, NMConnection *connection, GError **error)
 	return TRUE;
 }
 
-static void
-nm_setting_bluetooth_init (NMSettingBluetooth *setting)
-{
-}
+/*****************************************************************************/
 
 static void
-finalize (GObject *object)
+get_property (GObject *object, guint prop_id,
+              GValue *value, GParamSpec *pspec)
 {
-	NMSettingBluetoothPrivate *priv = NM_SETTING_BLUETOOTH_GET_PRIVATE (object);
+	NMSettingBluetooth *setting = NM_SETTING_BLUETOOTH (object);
 
-	g_free (priv->bdaddr);
-	g_free (priv->type);
-
-	G_OBJECT_CLASS (nm_setting_bluetooth_parent_class)->finalize (object);
+	switch (prop_id) {
+	case PROP_BDADDR:
+		g_value_set_string (value, nm_setting_bluetooth_get_bdaddr (setting));
+		break;
+	case PROP_TYPE:
+		g_value_set_string (value, nm_setting_bluetooth_get_connection_type (setting));
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
 }
 
 static void
@@ -258,23 +256,34 @@ set_property (GObject *object, guint prop_id,
 	}
 }
 
-static void
-get_property (GObject *object, guint prop_id,
-              GValue *value, GParamSpec *pspec)
-{
-	NMSettingBluetooth *setting = NM_SETTING_BLUETOOTH (object);
+/*****************************************************************************/
 
-	switch (prop_id) {
-	case PROP_BDADDR:
-		g_value_set_string (value, nm_setting_bluetooth_get_bdaddr (setting));
-		break;
-	case PROP_TYPE:
-		g_value_set_string (value, nm_setting_bluetooth_get_connection_type (setting));
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
+static void
+nm_setting_bluetooth_init (NMSettingBluetooth *setting)
+{
+}
+
+/**
+ * nm_setting_bluetooth_new:
+ *
+ * Creates a new #NMSettingBluetooth object with default values.
+ *
+ * Returns: (transfer full): the new empty #NMSettingBluetooth object
+ **/
+NMSetting *nm_setting_bluetooth_new (void)
+{
+	return (NMSetting *) g_object_new (NM_TYPE_SETTING_BLUETOOTH, NULL);
+}
+
+static void
+finalize (GObject *object)
+{
+	NMSettingBluetoothPrivate *priv = NM_SETTING_BLUETOOTH_GET_PRIVATE (object);
+
+	g_free (priv->bdaddr);
+	g_free (priv->type);
+
+	G_OBJECT_CLASS (nm_setting_bluetooth_parent_class)->finalize (object);
 }
 
 static void
@@ -286,8 +295,8 @@ nm_setting_bluetooth_class_init (NMSettingBluetoothClass *klass)
 
 	g_type_class_add_private (klass, sizeof (NMSettingBluetoothPrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->verify       = verify;

--- a/libnm-core/nm-setting-bluetooth.c
+++ b/libnm-core/nm-setting-bluetooth.c
@@ -52,13 +52,10 @@ typedef struct {
 	char *type;
 } NMSettingBluetoothPrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_BDADDR,
 	PROP_TYPE,
-
-	LAST_PROP
-};
+);
 
 /**
  * nm_setting_bluetooth_new:
@@ -300,17 +297,15 @@ nm_setting_bluetooth_class_init (NMSettingBluetoothClass *klass)
 	 *
 	 * The Bluetooth address of the device.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_BDADDR,
-		 g_param_spec_string (NM_SETTING_BLUETOOTH_BDADDR, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_BDADDR] =
+	    g_param_spec_string (NM_SETTING_BLUETOOTH_BDADDR, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_transform (properties_override,
-	                                    g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                  NM_SETTING_BLUETOOTH_BDADDR),
+	                                    obj_properties[PROP_BDADDR],
 	                                    G_VARIANT_TYPE_BYTESTRING,
 	                                    _nm_utils_hwaddr_to_dbus,
 	                                    _nm_utils_hwaddr_from_dbus);
@@ -321,13 +316,14 @@ nm_setting_bluetooth_class_init (NMSettingBluetoothClass *klass)
 	 * Either "dun" for Dial-Up Networking connections or "panu" for Personal
 	 * Area Networking connections to devices supporting the NAP profile.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_TYPE,
-		 g_param_spec_string (NM_SETTING_BLUETOOTH_TYPE, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_TYPE] =
+	    g_param_spec_string (NM_SETTING_BLUETOOTH_TYPE, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit_full (setting_class, NM_META_SETTING_TYPE_BLUETOOTH,
 	                               NULL, properties_override);

--- a/libnm-core/nm-setting-bond.c
+++ b/libnm-core/nm-setting-bond.c
@@ -46,11 +46,9 @@
 
 /*****************************************************************************/
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE (NMSettingBond,
 	PROP_OPTIONS,
-	LAST_PROP
-};
+);
 
 typedef struct {
 	GHashTable *options;
@@ -365,7 +363,7 @@ nm_setting_bond_add_option (NMSettingBond *setting,
 		g_hash_table_remove (priv->options, NM_SETTING_BOND_OPTION_UPDELAY);
 	}
 
-	g_object_notify (G_OBJECT (setting), NM_SETTING_BOND_OPTIONS);
+	_notify (setting, PROP_OPTIONS);
 
 	return TRUE;
 }
@@ -398,7 +396,7 @@ nm_setting_bond_remove_option (NMSettingBond *setting,
 	nm_clear_g_free (&priv->options_idx_cache);
 	found = g_hash_table_remove (priv->options, name);
 	if (found)
-		g_object_notify (G_OBJECT (setting), NM_SETTING_BOND_OPTIONS);
+		_notify (setting, PROP_OPTIONS);
 	return found;
 }
 
@@ -983,17 +981,15 @@ nm_setting_bond_class_init (NMSettingBondClass *klass)
 	 * example: BONDING_OPTS="miimon=100 mode=broadcast"
 	 * ---end---
 	 */
-	 g_object_class_install_property
-		 (object_class, PROP_OPTIONS,
-		 g_param_spec_boxed (NM_SETTING_BOND_OPTIONS, "", "",
-		                     G_TYPE_HASH_TABLE,
-		                     G_PARAM_READWRITE |
-		                     NM_SETTING_PARAM_INFERRABLE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_OPTIONS] =
+	    g_param_spec_boxed (NM_SETTING_BOND_OPTIONS, "", "",
+	                        G_TYPE_HASH_TABLE,
+	                        G_PARAM_READWRITE |
+	                        NM_SETTING_PARAM_INFERRABLE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_transform (properties_override,
-	                                    g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                  NM_SETTING_BOND_OPTIONS),
+	                                    obj_properties[PROP_OPTIONS],
 	                                    G_VARIANT_TYPE ("a{ss}"),
 	                                    _nm_utils_strdict_to_dbus,
 	                                    _nm_utils_strdict_from_dbus);
@@ -1011,6 +1007,8 @@ nm_setting_bond_class_init (NMSettingBondClass *klass)
 	                                    G_VARIANT_TYPE_STRING,
 	                                    _nm_setting_get_deprecated_virtual_interface_name,
 	                                    NULL);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit_full (setting_class, NM_META_SETTING_TYPE_BOND,
 	                               NULL, properties_override);

--- a/libnm-core/nm-setting-bond.c
+++ b/libnm-core/nm-setting-bond.c
@@ -21,13 +21,14 @@
 
 #include "nm-default.h"
 
+#include "nm-setting-bond.h"
+
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-#include "nm-setting-bond.h"
 #include "nm-utils.h"
 #include "nm-utils-private.h"
 #include "nm-connection-private.h"
@@ -960,8 +961,8 @@ nm_setting_bond_class_init (NMSettingBondClass *klass)
 
 	g_type_class_add_private (klass, sizeof (NMSettingBondPrivate));
 
-	object_class->set_property     = set_property;
 	object_class->get_property     = get_property;
+	object_class->set_property     = set_property;
 	object_class->finalize         = finalize;
 
 	setting_class->verify           = verify;

--- a/libnm-core/nm-setting-bridge-port.c
+++ b/libnm-core/nm-setting-bridge-port.c
@@ -21,11 +21,12 @@
 
 #include "nm-default.h"
 
+#include "nm-setting-bridge-port.h"
+
 #include <string.h>
 #include <ctype.h>
 #include <stdlib.h>
 
-#include "nm-setting-bridge-port.h"
 #include "nm-utils.h"
 #include "nm-utils-private.h"
 #include "nm-connection-private.h"
@@ -40,9 +41,13 @@
  * optional properties that apply to bridge ports.
  **/
 
-G_DEFINE_TYPE (NMSettingBridgePort, nm_setting_bridge_port, NM_TYPE_SETTING)
+/*****************************************************************************/
 
-#define NM_SETTING_BRIDGE_PORT_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_BRIDGE_PORT, NMSettingBridgePortPrivate))
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
+	PROP_PRIORITY,
+	PROP_PATH_COST,
+	PROP_HAIRPIN_MODE,
+);
 
 typedef struct {
 	guint16 priority;
@@ -50,11 +55,9 @@ typedef struct {
 	gboolean hairpin_mode;
 } NMSettingBridgePortPrivate;
 
-NM_GOBJECT_PROPERTIES_DEFINE_BASE (
-	PROP_PRIORITY,
-	PROP_PATH_COST,
-	PROP_HAIRPIN_MODE,
-);
+G_DEFINE_TYPE (NMSettingBridgePort, nm_setting_bridge_port, NM_TYPE_SETTING)
+
+#define NM_SETTING_BRIDGE_PORT_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_BRIDGE_PORT, NMSettingBridgePortPrivate))
 
 /*****************************************************************************/
 
@@ -139,22 +142,26 @@ verify (NMSetting *setting, NMConnection *connection, GError **error)
 
 /*****************************************************************************/
 
-/**
- * nm_setting_bridge_port_new:
- *
- * Creates a new #NMSettingBridgePort object with default values.
- *
- * Returns: (transfer full): the new empty #NMSettingBridgePort object
- **/
-NMSetting *
-nm_setting_bridge_port_new (void)
-{
-	return (NMSetting *) g_object_new (NM_TYPE_SETTING_BRIDGE_PORT, NULL);
-}
-
 static void
-nm_setting_bridge_port_init (NMSettingBridgePort *setting)
+get_property (GObject *object, guint prop_id,
+              GValue *value, GParamSpec *pspec)
 {
+	NMSettingBridgePortPrivate *priv = NM_SETTING_BRIDGE_PORT_GET_PRIVATE (object);
+
+	switch (prop_id) {
+	case PROP_PRIORITY:
+		g_value_set_uint (value, priv->priority);
+		break;
+	case PROP_PATH_COST:
+		g_value_set_uint (value, priv->path_cost);
+		break;
+	case PROP_HAIRPIN_MODE:
+		g_value_set_boolean (value, priv->hairpin_mode);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
 }
 
 static void
@@ -179,26 +186,24 @@ set_property (GObject *object, guint prop_id,
 	}
 }
 
-static void
-get_property (GObject *object, guint prop_id,
-              GValue *value, GParamSpec *pspec)
-{
-	NMSettingBridgePortPrivate *priv = NM_SETTING_BRIDGE_PORT_GET_PRIVATE (object);
+/*****************************************************************************/
 
-	switch (prop_id) {
-	case PROP_PRIORITY:
-		g_value_set_uint (value, priv->priority);
-		break;
-	case PROP_PATH_COST:
-		g_value_set_uint (value, priv->path_cost);
-		break;
-	case PROP_HAIRPIN_MODE:
-		g_value_set_boolean (value, priv->hairpin_mode);
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
+static void
+nm_setting_bridge_port_init (NMSettingBridgePort *setting)
+{
+}
+
+/**
+ * nm_setting_bridge_port_new:
+ *
+ * Creates a new #NMSettingBridgePort object with default values.
+ *
+ * Returns: (transfer full): the new empty #NMSettingBridgePort object
+ **/
+NMSetting *
+nm_setting_bridge_port_new (void)
+{
+	return (NMSetting *) g_object_new (NM_TYPE_SETTING_BRIDGE_PORT, NULL);
 }
 
 static void
@@ -209,8 +214,8 @@ nm_setting_bridge_port_class_init (NMSettingBridgePortClass *klass)
 
 	g_type_class_add_private (klass, sizeof (NMSettingBridgePortPrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 
 	setting_class->verify = verify;
 

--- a/libnm-core/nm-setting-bridge-port.c
+++ b/libnm-core/nm-setting-bridge-port.c
@@ -50,13 +50,11 @@ typedef struct {
 	gboolean hairpin_mode;
 } NMSettingBridgePortPrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_PRIORITY,
 	PROP_PATH_COST,
 	PROP_HAIRPIN_MODE,
-	LAST_PROP
-};
+);
 
 /*****************************************************************************/
 
@@ -229,14 +227,13 @@ nm_setting_bridge_port_class_init (NMSettingBridgePortClass *klass)
 	 * description: STP priority.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_PRIORITY,
-		 g_param_spec_uint (NM_SETTING_BRIDGE_PORT_PRIORITY, "", "",
-		                    0, NM_BR_PORT_MAX_PRIORITY, NM_BR_PORT_DEF_PRIORITY,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_INFERRABLE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PRIORITY] =
+	    g_param_spec_uint (NM_SETTING_BRIDGE_PORT_PRIORITY, "", "",
+	                       0, NM_BR_PORT_MAX_PRIORITY, NM_BR_PORT_DEF_PRIORITY,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingBridgePort:path-cost:
@@ -252,13 +249,12 @@ nm_setting_bridge_port_class_init (NMSettingBridgePortClass *klass)
 	 * description: STP cost.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_PATH_COST,
-		 g_param_spec_uint (NM_SETTING_BRIDGE_PORT_PATH_COST, "", "",
-		                    0, NM_BR_PORT_MAX_PATH_COST, 100,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PATH_COST] =
+	    g_param_spec_uint (NM_SETTING_BRIDGE_PORT_PATH_COST, "", "",
+	                       0, NM_BR_PORT_MAX_PATH_COST, 100,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingBridgePort:hairpin-mode:
@@ -273,13 +269,14 @@ nm_setting_bridge_port_class_init (NMSettingBridgePortClass *klass)
 	 * description: Hairpin mode of the bridge port.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_HAIRPIN_MODE,
-		 g_param_spec_boolean (NM_SETTING_BRIDGE_PORT_HAIRPIN_MODE, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       NM_SETTING_PARAM_INFERRABLE |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_HAIRPIN_MODE] =
+	    g_param_spec_boolean (NM_SETTING_BRIDGE_PORT_HAIRPIN_MODE, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          NM_SETTING_PARAM_INFERRABLE |
+	                          G_PARAM_STATIC_STRINGS);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit (setting_class, NM_META_SETTING_TYPE_BRIDGE_PORT);
 }

--- a/libnm-core/nm-setting-bridge.c
+++ b/libnm-core/nm-setting-bridge.c
@@ -21,11 +21,12 @@
 
 #include "nm-default.h"
 
+#include "nm-setting-bridge.h"
+
 #include <string.h>
 #include <ctype.h>
 #include <stdlib.h>
 
-#include "nm-setting-bridge.h"
 #include "nm-connection-private.h"
 #include "nm-utils.h"
 #include "nm-utils-private.h"
@@ -38,21 +39,7 @@
  * necessary for bridging connections.
  **/
 
-G_DEFINE_TYPE (NMSettingBridge, nm_setting_bridge, NM_TYPE_SETTING)
-
-#define NM_SETTING_BRIDGE_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_BRIDGE, NMSettingBridgePrivate))
-
-typedef struct {
-	char *   mac_address;
-	gboolean stp;
-	guint16  priority;
-	guint16  forward_delay;
-	guint16  hello_time;
-	guint16  max_age;
-	guint32  ageing_time;
-	guint16  group_forward_mask;
-	gboolean multicast_snooping;
-} NMSettingBridgePrivate;
+/*****************************************************************************/
 
 NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_MAC_ADDRESS,
@@ -66,18 +53,23 @@ NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_MULTICAST_SNOOPING,
 );
 
-/**
- * nm_setting_bridge_new:
- *
- * Creates a new #NMSettingBridge object with default values.
- *
- * Returns: (transfer full): the new empty #NMSettingBridge object
- **/
-NMSetting *
-nm_setting_bridge_new (void)
-{
-	return (NMSetting *) g_object_new (NM_TYPE_SETTING_BRIDGE, NULL);
-}
+typedef struct {
+	char *   mac_address;
+	gboolean stp;
+	guint16  priority;
+	guint16  forward_delay;
+	guint16  hello_time;
+	guint16  max_age;
+	guint32  ageing_time;
+	guint16  group_forward_mask;
+	gboolean multicast_snooping;
+} NMSettingBridgePrivate;
+
+G_DEFINE_TYPE (NMSettingBridge, nm_setting_bridge, NM_TYPE_SETTING)
+
+#define NM_SETTING_BRIDGE_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_BRIDGE, NMSettingBridgePrivate))
+
+/*****************************************************************************/
 
 /**
  * nm_setting_bridge_get_mac_address:
@@ -290,19 +282,47 @@ verify (NMSetting *setting, NMConnection *connection, GError **error)
 	return _nm_connection_verify_required_interface_name (connection, error);
 }
 
-static void
-nm_setting_bridge_init (NMSettingBridge *setting)
-{
-}
+/*****************************************************************************/
 
 static void
-finalize (GObject *object)
+get_property (GObject *object, guint prop_id,
+              GValue *value, GParamSpec *pspec)
 {
 	NMSettingBridgePrivate *priv = NM_SETTING_BRIDGE_GET_PRIVATE (object);
+	NMSettingBridge *setting = NM_SETTING_BRIDGE (object);
 
-	g_free (priv->mac_address);
-
-	G_OBJECT_CLASS (nm_setting_bridge_parent_class)->finalize (object);
+	switch (prop_id) {
+	case PROP_MAC_ADDRESS:
+		g_value_set_string (value, nm_setting_bridge_get_mac_address (setting));
+		break;
+	case PROP_STP:
+		g_value_set_boolean (value, priv->stp);
+		break;
+	case PROP_PRIORITY:
+		g_value_set_uint (value, priv->priority);
+		break;
+	case PROP_FORWARD_DELAY:
+		g_value_set_uint (value, priv->forward_delay);
+		break;
+	case PROP_HELLO_TIME:
+		g_value_set_uint (value, priv->hello_time);
+		break;
+	case PROP_MAX_AGE:
+		g_value_set_uint (value, priv->max_age);
+		break;
+	case PROP_AGEING_TIME:
+		g_value_set_uint (value, priv->ageing_time);
+		break;
+	case PROP_GROUP_FORWARD_MASK:
+		g_value_set_uint (value, priv->group_forward_mask);
+		break;
+	case PROP_MULTICAST_SNOOPING:
+		g_value_set_boolean (value, priv->multicast_snooping);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
 }
 
 static void
@@ -347,45 +367,34 @@ set_property (GObject *object, guint prop_id,
 	}
 }
 
+/*****************************************************************************/
+
 static void
-get_property (GObject *object, guint prop_id,
-              GValue *value, GParamSpec *pspec)
+nm_setting_bridge_init (NMSettingBridge *setting)
+{
+}
+
+/**
+ * nm_setting_bridge_new:
+ *
+ * Creates a new #NMSettingBridge object with default values.
+ *
+ * Returns: (transfer full): the new empty #NMSettingBridge object
+ **/
+NMSetting *
+nm_setting_bridge_new (void)
+{
+	return (NMSetting *) g_object_new (NM_TYPE_SETTING_BRIDGE, NULL);
+}
+
+static void
+finalize (GObject *object)
 {
 	NMSettingBridgePrivate *priv = NM_SETTING_BRIDGE_GET_PRIVATE (object);
-	NMSettingBridge *setting = NM_SETTING_BRIDGE (object);
 
-	switch (prop_id) {
-	case PROP_MAC_ADDRESS:
-		g_value_set_string (value, nm_setting_bridge_get_mac_address (setting));
-		break;
-	case PROP_STP:
-		g_value_set_boolean (value, priv->stp);
-		break;
-	case PROP_PRIORITY:
-		g_value_set_uint (value, priv->priority);
-		break;
-	case PROP_FORWARD_DELAY:
-		g_value_set_uint (value, priv->forward_delay);
-		break;
-	case PROP_HELLO_TIME:
-		g_value_set_uint (value, priv->hello_time);
-		break;
-	case PROP_MAX_AGE:
-		g_value_set_uint (value, priv->max_age);
-		break;
-	case PROP_AGEING_TIME:
-		g_value_set_uint (value, priv->ageing_time);
-		break;
-	case PROP_GROUP_FORWARD_MASK:
-		g_value_set_uint (value, priv->group_forward_mask);
-		break;
-	case PROP_MULTICAST_SNOOPING:
-		g_value_set_boolean (value, priv->multicast_snooping);
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
+	g_free (priv->mac_address);
+
+	G_OBJECT_CLASS (nm_setting_bridge_parent_class)->finalize (object);
 }
 
 static void
@@ -397,8 +406,8 @@ nm_setting_bridge_class_init (NMSettingBridgeClass *klass)
 
 	g_type_class_add_private (klass, sizeof (NMSettingBridgePrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->verify = verify;

--- a/libnm-core/nm-setting-bridge.c
+++ b/libnm-core/nm-setting-bridge.c
@@ -54,8 +54,7 @@ typedef struct {
 	gboolean multicast_snooping;
 } NMSettingBridgePrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_MAC_ADDRESS,
 	PROP_STP,
 	PROP_PRIORITY,
@@ -65,8 +64,7 @@ enum {
 	PROP_AGEING_TIME,
 	PROP_GROUP_FORWARD_MASK,
 	PROP_MULTICAST_SNOOPING,
-	LAST_PROP
-};
+);
 
 /**
  * nm_setting_bridge_new:
@@ -435,17 +433,15 @@ nm_setting_bridge_class_init (NMSettingBridgeClass *klass)
 	 *   BRIDGE_MACADDR for bridges is an NM extension.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_MAC_ADDRESS,
-		 g_param_spec_string (NM_SETTING_BRIDGE_MAC_ADDRESS, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MAC_ADDRESS] =
+	    g_param_spec_string (NM_SETTING_BRIDGE_MAC_ADDRESS, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_transform (properties_override,
-	                                    g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                  NM_SETTING_BRIDGE_MAC_ADDRESS),
+	                                    obj_properties[PROP_MAC_ADDRESS],
 	                                    G_VARIANT_TYPE_BYTESTRING,
 	                                    _nm_utils_hwaddr_to_dbus,
 	                                    _nm_utils_hwaddr_from_dbus);
@@ -462,14 +458,13 @@ nm_setting_bridge_class_init (NMSettingBridgeClass *klass)
 	 * description: Span tree protocol participation.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_STP,
-		 g_param_spec_boolean (NM_SETTING_BRIDGE_STP, "", "",
-		                       TRUE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       NM_SETTING_PARAM_INFERRABLE |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_STP] =
+	    g_param_spec_boolean (NM_SETTING_BRIDGE_STP, "", "",
+	                          TRUE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          NM_SETTING_PARAM_INFERRABLE |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingBridge:priority:
@@ -486,14 +481,13 @@ nm_setting_bridge_class_init (NMSettingBridgeClass *klass)
 	 * description: STP priority.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_PRIORITY,
-		 g_param_spec_uint (NM_SETTING_BRIDGE_PRIORITY, "", "",
-		                    0, G_MAXUINT16, 0x8000,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_INFERRABLE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PRIORITY] =
+	    g_param_spec_uint (NM_SETTING_BRIDGE_PRIORITY, "", "",
+	                       0, G_MAXUINT16, 0x8000,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingBridge:forward-delay:
@@ -508,14 +502,13 @@ nm_setting_bridge_class_init (NMSettingBridgeClass *klass)
 	 * description: STP forwarding delay.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_FORWARD_DELAY,
-		 g_param_spec_uint (NM_SETTING_BRIDGE_FORWARD_DELAY, "", "",
-		                    0, NM_BR_MAX_FORWARD_DELAY, 15,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_INFERRABLE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_FORWARD_DELAY] =
+	    g_param_spec_uint (NM_SETTING_BRIDGE_FORWARD_DELAY, "", "",
+	                       0, NM_BR_MAX_FORWARD_DELAY, 15,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingBridge:hello-time:
@@ -530,14 +523,13 @@ nm_setting_bridge_class_init (NMSettingBridgeClass *klass)
 	 * description: STP hello time.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_HELLO_TIME,
-		 g_param_spec_uint (NM_SETTING_BRIDGE_HELLO_TIME, "", "",
-		                    0, NM_BR_MAX_HELLO_TIME, 2,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_INFERRABLE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_HELLO_TIME] =
+	    g_param_spec_uint (NM_SETTING_BRIDGE_HELLO_TIME, "", "",
+	                       0, NM_BR_MAX_HELLO_TIME, 2,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingBridge:max-age:
@@ -552,14 +544,13 @@ nm_setting_bridge_class_init (NMSettingBridgeClass *klass)
 	 * description: STP maximum message age.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_MAX_AGE,
-		 g_param_spec_uint (NM_SETTING_BRIDGE_MAX_AGE, "", "",
-		                    0, NM_BR_MAX_MAX_AGE, 20,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_INFERRABLE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MAX_AGE] =
+	    g_param_spec_uint (NM_SETTING_BRIDGE_MAX_AGE, "", "",
+	                       0, NM_BR_MAX_MAX_AGE, 20,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingBridge:ageing-time:
@@ -574,14 +565,13 @@ nm_setting_bridge_class_init (NMSettingBridgeClass *klass)
 	 * description: Ethernet MAC ageing time.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_AGEING_TIME,
-		 g_param_spec_uint (NM_SETTING_BRIDGE_AGEING_TIME, "", "",
-		                    NM_BR_MIN_AGEING_TIME, NM_BR_MAX_AGEING_TIME, 300,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_INFERRABLE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_AGEING_TIME] =
+	    g_param_spec_uint (NM_SETTING_BRIDGE_AGEING_TIME, "", "",
+	                       NM_BR_MIN_AGEING_TIME, NM_BR_MAX_AGEING_TIME, 300,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingBridge:group-forward-mask:
@@ -595,14 +585,13 @@ nm_setting_bridge_class_init (NMSettingBridgeClass *klass)
 	 *
 	 * Since: 1.10
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_GROUP_FORWARD_MASK,
-		 g_param_spec_uint (NM_SETTING_BRIDGE_GROUP_FORWARD_MASK, "", "",
-		                    0, 0xFFFF, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_INFERRABLE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_GROUP_FORWARD_MASK] =
+	    g_param_spec_uint (NM_SETTING_BRIDGE_GROUP_FORWARD_MASK, "", "",
+	                       0, 0xFFFF, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingBridge:multicast-snooping:
@@ -622,14 +611,13 @@ nm_setting_bridge_class_init (NMSettingBridgeClass *klass)
 	 * description: IGMP snooping support.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_MULTICAST_SNOOPING,
-		 g_param_spec_boolean (NM_SETTING_BRIDGE_MULTICAST_SNOOPING, "", "",
-		                       TRUE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       NM_SETTING_PARAM_INFERRABLE |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MULTICAST_SNOOPING] =
+	    g_param_spec_boolean (NM_SETTING_BRIDGE_MULTICAST_SNOOPING, "", "",
+	                          TRUE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          NM_SETTING_PARAM_INFERRABLE |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/* ---dbus---
 	 * property: interface-name
@@ -644,6 +632,8 @@ nm_setting_bridge_class_init (NMSettingBridgeClass *klass)
 	                                    G_VARIANT_TYPE_STRING,
 	                                    _nm_setting_get_deprecated_virtual_interface_name,
 	                                    NULL);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit_full (setting_class, NM_META_SETTING_TYPE_BRIDGE,
 	                               NULL, properties_override);

--- a/libnm-core/nm-setting-cdma.c
+++ b/libnm-core/nm-setting-cdma.c
@@ -21,9 +21,10 @@
 
 #include "nm-default.h"
 
+#include "nm-setting-cdma.h"
+
 #include <string.h>
 
-#include "nm-setting-cdma.h"
 #include "nm-utils.h"
 #include "nm-setting-private.h"
 #include "nm-core-enum-types.h"
@@ -37,17 +38,7 @@
  * networks, including those using CDMA2000/EVDO technology.
  */
 
-G_DEFINE_TYPE (NMSettingCdma, nm_setting_cdma, NM_TYPE_SETTING)
-
-#define NM_SETTING_CDMA_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_CDMA, NMSettingCdmaPrivate))
-
-typedef struct {
-	char *number; /* For dialing, duh */
-	char *username;
-	char *password;
-	NMSettingSecretFlags password_flags;
-	guint32 mtu;
-} NMSettingCdmaPrivate;
+/*****************************************************************************/
 
 NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_NUMBER,
@@ -57,18 +48,19 @@ NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_MTU,
 );
 
-/**
- * nm_setting_cdma_new:
- *
- * Creates a new #NMSettingCdma object with default values.
- *
- * Returns: the new empty #NMSettingCdma object
- **/
-NMSetting *
-nm_setting_cdma_new (void)
-{
-	return (NMSetting *) g_object_new (NM_TYPE_SETTING_CDMA, NULL);
-}
+typedef struct {
+	char *number; /* For dialing, duh */
+	char *username;
+	char *password;
+	NMSettingSecretFlags password_flags;
+	guint32 mtu;
+} NMSettingCdmaPrivate;
+
+G_DEFINE_TYPE (NMSettingCdma, nm_setting_cdma, NM_TYPE_SETTING)
+
+#define NM_SETTING_CDMA_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_CDMA, NMSettingCdmaPrivate))
+
+/*****************************************************************************/
 
 /**
  * nm_setting_cdma_get_number:
@@ -203,21 +195,34 @@ need_secrets (NMSetting *setting)
 	return secrets;
 }
 
-static void
-nm_setting_cdma_init (NMSettingCdma *setting)
-{
-}
+/*****************************************************************************/
 
 static void
-finalize (GObject *object)
+get_property (GObject *object, guint prop_id,
+              GValue *value, GParamSpec *pspec)
 {
-	NMSettingCdmaPrivate *priv = NM_SETTING_CDMA_GET_PRIVATE (object);
+	NMSettingCdma *setting = NM_SETTING_CDMA (object);
 
-	g_free (priv->number);
-	g_free (priv->username);
-	g_free (priv->password);
-
-	G_OBJECT_CLASS (nm_setting_cdma_parent_class)->finalize (object);
+	switch (prop_id) {
+	case PROP_NUMBER:
+		g_value_set_string (value, nm_setting_cdma_get_number (setting));
+		break;
+	case PROP_USERNAME:
+		g_value_set_string (value, nm_setting_cdma_get_username (setting));
+		break;
+	case PROP_PASSWORD:
+		g_value_set_string (value, nm_setting_cdma_get_password (setting));
+		break;
+	case PROP_PASSWORD_FLAGS:
+		g_value_set_flags (value, nm_setting_cdma_get_password_flags (setting));
+		break;
+	case PROP_MTU:
+		g_value_set_uint (value, nm_setting_cdma_get_mtu (setting));
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
 }
 
 static void
@@ -251,32 +256,36 @@ set_property (GObject *object, guint prop_id,
 	}
 }
 
-static void
-get_property (GObject *object, guint prop_id,
-              GValue *value, GParamSpec *pspec)
-{
-	NMSettingCdma *setting = NM_SETTING_CDMA (object);
+/*****************************************************************************/
 
-	switch (prop_id) {
-	case PROP_NUMBER:
-		g_value_set_string (value, nm_setting_cdma_get_number (setting));
-		break;
-	case PROP_USERNAME:
-		g_value_set_string (value, nm_setting_cdma_get_username (setting));
-		break;
-	case PROP_PASSWORD:
-		g_value_set_string (value, nm_setting_cdma_get_password (setting));
-		break;
-	case PROP_PASSWORD_FLAGS:
-		g_value_set_flags (value, nm_setting_cdma_get_password_flags (setting));
-		break;
-	case PROP_MTU:
-		g_value_set_uint (value, nm_setting_cdma_get_mtu (setting));
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
+static void
+nm_setting_cdma_init (NMSettingCdma *setting)
+{
+}
+
+/**
+ * nm_setting_cdma_new:
+ *
+ * Creates a new #NMSettingCdma object with default values.
+ *
+ * Returns: the new empty #NMSettingCdma object
+ **/
+NMSetting *
+nm_setting_cdma_new (void)
+{
+	return (NMSetting *) g_object_new (NM_TYPE_SETTING_CDMA, NULL);
+}
+
+static void
+finalize (GObject *object)
+{
+	NMSettingCdmaPrivate *priv = NM_SETTING_CDMA_GET_PRIVATE (object);
+
+	g_free (priv->number);
+	g_free (priv->username);
+	g_free (priv->password);
+
+	G_OBJECT_CLASS (nm_setting_cdma_parent_class)->finalize (object);
 }
 
 static void
@@ -287,8 +296,8 @@ nm_setting_cdma_class_init (NMSettingCdmaClass *klass)
 
 	g_type_class_add_private (klass, sizeof (NMSettingCdmaPrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->verify         = verify;

--- a/libnm-core/nm-setting-cdma.c
+++ b/libnm-core/nm-setting-cdma.c
@@ -49,16 +49,13 @@ typedef struct {
 	guint32 mtu;
 } NMSettingCdmaPrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_NUMBER,
 	PROP_USERNAME,
 	PROP_PASSWORD,
 	PROP_PASSWORD_FLAGS,
 	PROP_MTU,
-
-	LAST_PROP
-};
+);
 
 /**
  * nm_setting_cdma_new:
@@ -305,12 +302,11 @@ nm_setting_cdma_class_init (NMSettingCdmaClass *klass)
 	 * broadband network, if any.  If not specified, the default number (#777)
 	 * is used when required.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_NUMBER,
-		 g_param_spec_string (NM_SETTING_CDMA_NUMBER, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_NUMBER] =
+	    g_param_spec_string (NM_SETTING_CDMA_NUMBER, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingCdma:username:
@@ -319,12 +315,11 @@ nm_setting_cdma_class_init (NMSettingCdmaClass *klass)
 	 * providers do not require a username, or accept any username.  But if a
 	 * username is required, it is specified here.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_USERNAME,
-		 g_param_spec_string (NM_SETTING_CDMA_USERNAME, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_USERNAME] =
+	    g_param_spec_string (NM_SETTING_CDMA_USERNAME, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingCdma:password:
@@ -333,26 +328,24 @@ nm_setting_cdma_class_init (NMSettingCdmaClass *klass)
 	 * providers do not require a password, or accept any password.  But if a
 	 * password is required, it is specified here.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_PASSWORD,
-		 g_param_spec_string (NM_SETTING_CDMA_PASSWORD, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_SECRET |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PASSWORD] =
+	    g_param_spec_string (NM_SETTING_CDMA_PASSWORD, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_SECRET |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingCdma:password-flags:
 	 *
 	 * Flags indicating how to handle the #NMSettingCdma:password property.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_PASSWORD_FLAGS,
-		 g_param_spec_flags (NM_SETTING_CDMA_PASSWORD_FLAGS, "", "",
-		                     NM_TYPE_SETTING_SECRET_FLAGS,
-		                     NM_SETTING_SECRET_FLAG_NONE,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PASSWORD_FLAGS] =
+	    g_param_spec_flags (NM_SETTING_CDMA_PASSWORD_FLAGS, "", "",
+	                        NM_TYPE_SETTING_SECRET_FLAGS,
+	                        NM_SETTING_SECRET_FLAG_NONE,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingCdma:mtu:
@@ -362,14 +355,15 @@ nm_setting_cdma_class_init (NMSettingCdmaClass *klass)
 	 *
 	 * Since: 1.8
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_MTU,
-		 g_param_spec_uint (NM_SETTING_CDMA_MTU, "", "",
-		                    0, G_MAXUINT32, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_FUZZY_IGNORE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MTU] =
+	    g_param_spec_uint (NM_SETTING_CDMA_MTU, "", "",
+	                       0, G_MAXUINT32, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_FUZZY_IGNORE |
+	                       G_PARAM_STATIC_STRINGS);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit (setting_class, NM_META_SETTING_TYPE_CDMA);
 }

--- a/libnm-core/nm-setting-connection.c
+++ b/libnm-core/nm-setting-connection.c
@@ -45,9 +45,7 @@
  * a #NMSettingConnection setting.
  **/
 
-G_DEFINE_TYPE (NMSettingConnection, nm_setting_connection, NM_TYPE_SETTING)
-
-#define NM_SETTING_CONNECTION_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_CONNECTION, NMSettingConnectionPrivate))
+/*****************************************************************************/
 
 typedef enum {
 	PERM_TYPE_USER = 0,
@@ -57,6 +55,32 @@ typedef struct {
 	guint8 ptype;
 	char *item;
 } Permission;
+
+NM_GOBJECT_PROPERTIES_DEFINE (NMSettingConnection,
+	PROP_ID,
+	PROP_UUID,
+	PROP_INTERFACE_NAME,
+	PROP_TYPE,
+	PROP_PERMISSIONS,
+	PROP_AUTOCONNECT,
+	PROP_AUTOCONNECT_PRIORITY,
+	PROP_AUTOCONNECT_RETRIES,
+	PROP_MULTI_CONNECT,
+	PROP_TIMESTAMP,
+	PROP_READ_ONLY,
+	PROP_ZONE,
+	PROP_MASTER,
+	PROP_SLAVE_TYPE,
+	PROP_AUTOCONNECT_SLAVES,
+	PROP_SECONDARIES,
+	PROP_GATEWAY_PING_TIMEOUT,
+	PROP_METERED,
+	PROP_LLDP,
+	PROP_MDNS,
+	PROP_LLMNR,
+	PROP_STABLE_ID,
+	PROP_AUTH_RETRIES,
+);
 
 typedef struct {
 	char *id;
@@ -84,31 +108,9 @@ typedef struct {
 	int llmnr;
 } NMSettingConnectionPrivate;
 
-NM_GOBJECT_PROPERTIES_DEFINE (NMSettingConnection,
-	PROP_ID,
-	PROP_UUID,
-	PROP_INTERFACE_NAME,
-	PROP_TYPE,
-	PROP_PERMISSIONS,
-	PROP_AUTOCONNECT,
-	PROP_AUTOCONNECT_PRIORITY,
-	PROP_AUTOCONNECT_RETRIES,
-	PROP_MULTI_CONNECT,
-	PROP_TIMESTAMP,
-	PROP_READ_ONLY,
-	PROP_ZONE,
-	PROP_MASTER,
-	PROP_SLAVE_TYPE,
-	PROP_AUTOCONNECT_SLAVES,
-	PROP_SECONDARIES,
-	PROP_GATEWAY_PING_TIMEOUT,
-	PROP_METERED,
-	PROP_LLDP,
-	PROP_MDNS,
-	PROP_LLMNR,
-	PROP_STABLE_ID,
-	PROP_AUTH_RETRIES,
-);
+G_DEFINE_TYPE (NMSettingConnection, nm_setting_connection, NM_TYPE_SETTING)
+
+#define NM_SETTING_CONNECTION_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_CONNECTION, NMSettingConnectionPrivate))
 
 /*****************************************************************************/
 
@@ -192,18 +194,6 @@ permission_free (Permission *p)
 }
 
 /*****************************************************************************/
-
-/**
- * nm_setting_connection_new:
- *
- * Creates a new #NMSettingConnection object with default values.
- *
- * Returns: the new empty #NMSettingConnection object
- **/
-NMSetting *nm_setting_connection_new (void)
-{
-	return (NMSetting *) g_object_new (NM_TYPE_SETTING_CONNECTION, NULL);
-}
 
 /**
  * nm_setting_connection_get_id:
@@ -1300,34 +1290,6 @@ compare_property (const NMSettInfoSetting *sett_info,
 	                                                                                flags);
 }
 
-static void
-nm_setting_connection_init (NMSettingConnection *setting)
-{
-	NMSettingConnectionPrivate *priv = NM_SETTING_CONNECTION_GET_PRIVATE (setting);
-
-	priv->mdns = NM_SETTING_CONNECTION_MDNS_DEFAULT;
-	priv->llmnr = NM_SETTING_CONNECTION_LLMNR_DEFAULT;
-}
-
-static void
-finalize (GObject *object)
-{
-	NMSettingConnectionPrivate *priv = NM_SETTING_CONNECTION_GET_PRIVATE (object);
-
-	g_free (priv->id);
-	g_free (priv->uuid);
-	g_free (priv->stable_id);
-	g_free (priv->interface_name);
-	g_free (priv->type);
-	g_free (priv->zone);
-	g_free (priv->master);
-	g_free (priv->slave_type);
-	g_slist_free_full (priv->permissions, (GDestroyNotify) permission_free);
-	g_slist_free_full (priv->secondaries, g_free);
-
-	G_OBJECT_CLASS (nm_setting_connection_parent_class)->finalize (object);
-}
-
 static GSList *
 perm_strv_to_permlist (char **strv)
 {
@@ -1346,6 +1308,105 @@ perm_strv_to_permlist (char **strv)
 	}
 
 	return list;
+}
+
+static char **
+perm_permlist_to_strv (GSList *permlist)
+{
+	GPtrArray *strings;
+	GSList *iter;
+
+	strings = g_ptr_array_new ();
+	for (iter = permlist; iter; iter = g_slist_next (iter))
+		g_ptr_array_add (strings, permission_to_string ((Permission *) iter->data));
+	g_ptr_array_add (strings, NULL);
+
+	return (char **) g_ptr_array_free (strings, FALSE);
+}
+
+/*****************************************************************************/
+
+static void
+get_property (GObject *object, guint prop_id,
+              GValue *value, GParamSpec *pspec)
+{
+	NMSettingConnection *setting = NM_SETTING_CONNECTION (object);
+	NMSettingConnectionPrivate *priv = NM_SETTING_CONNECTION_GET_PRIVATE (setting);
+
+	switch (prop_id) {
+	case PROP_ID:
+		g_value_set_string (value, nm_setting_connection_get_id (setting));
+		break;
+	case PROP_UUID:
+		g_value_set_string (value, nm_setting_connection_get_uuid (setting));
+		break;
+	case PROP_STABLE_ID:
+		g_value_set_string (value, nm_setting_connection_get_stable_id (setting));
+		break;
+	case PROP_INTERFACE_NAME:
+		g_value_set_string (value, nm_setting_connection_get_interface_name (setting));
+		break;
+	case PROP_TYPE:
+		g_value_set_string (value, nm_setting_connection_get_connection_type (setting));
+		break;
+	case PROP_PERMISSIONS:
+		g_value_take_boxed (value, perm_permlist_to_strv (priv->permissions));
+		break;
+	case PROP_AUTOCONNECT:
+		g_value_set_boolean (value, nm_setting_connection_get_autoconnect (setting));
+		break;
+	case PROP_AUTOCONNECT_PRIORITY:
+		g_value_set_int (value, nm_setting_connection_get_autoconnect_priority (setting));
+		break;
+	case PROP_AUTOCONNECT_RETRIES:
+		g_value_set_int (value, nm_setting_connection_get_autoconnect_retries (setting));
+		break;
+	case PROP_MULTI_CONNECT:
+		g_value_set_int (value, priv->multi_connect);
+		break;
+	case PROP_TIMESTAMP:
+		g_value_set_uint64 (value, nm_setting_connection_get_timestamp (setting));
+		break;
+	case PROP_READ_ONLY:
+		g_value_set_boolean (value, nm_setting_connection_get_read_only (setting));
+		break;
+	case PROP_ZONE:
+		g_value_set_string (value, nm_setting_connection_get_zone (setting));
+		break;
+	case PROP_MASTER:
+		g_value_set_string (value, nm_setting_connection_get_master (setting));
+		break;
+	case PROP_SLAVE_TYPE:
+		g_value_set_string (value, nm_setting_connection_get_slave_type (setting));
+		break;
+	case PROP_AUTOCONNECT_SLAVES:
+		g_value_set_enum (value, nm_setting_connection_get_autoconnect_slaves (setting));
+		break;
+	case PROP_SECONDARIES:
+		g_value_take_boxed (value, _nm_utils_slist_to_strv (priv->secondaries, TRUE));
+		break;
+	case PROP_GATEWAY_PING_TIMEOUT:
+		g_value_set_uint (value, priv->gateway_ping_timeout);
+		break;
+	case PROP_METERED:
+		g_value_set_enum (value, priv->metered);
+		break;
+	case PROP_LLDP:
+		g_value_set_int (value, priv->lldp);
+		break;
+	case PROP_AUTH_RETRIES:
+		g_value_set_int (value, priv->auth_retries);
+		break;
+	case PROP_MDNS:
+		g_value_set_int (value, priv->mdns);
+		break;
+	case PROP_LLMNR:
+		g_value_set_int (value, priv->llmnr);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
 }
 
 static void
@@ -1440,101 +1501,46 @@ set_property (GObject *object, guint prop_id,
 	}
 }
 
-static char **
-perm_permlist_to_strv (GSList *permlist)
+/*****************************************************************************/
+
+static void
+nm_setting_connection_init (NMSettingConnection *setting)
 {
-	GPtrArray *strings;
-	GSList *iter;
+	NMSettingConnectionPrivate *priv = NM_SETTING_CONNECTION_GET_PRIVATE (setting);
 
-	strings = g_ptr_array_new ();
-	for (iter = permlist; iter; iter = g_slist_next (iter))
-		g_ptr_array_add (strings, permission_to_string ((Permission *) iter->data));
-	g_ptr_array_add (strings, NULL);
+	priv->mdns = NM_SETTING_CONNECTION_MDNS_DEFAULT;
+	priv->llmnr = NM_SETTING_CONNECTION_LLMNR_DEFAULT;
+}
 
-	return (char **) g_ptr_array_free (strings, FALSE);
+/**
+ * nm_setting_connection_new:
+ *
+ * Creates a new #NMSettingConnection object with default values.
+ *
+ * Returns: the new empty #NMSettingConnection object
+ **/
+NMSetting *nm_setting_connection_new (void)
+{
+	return (NMSetting *) g_object_new (NM_TYPE_SETTING_CONNECTION, NULL);
 }
 
 static void
-get_property (GObject *object, guint prop_id,
-              GValue *value, GParamSpec *pspec)
+finalize (GObject *object)
 {
-	NMSettingConnection *setting = NM_SETTING_CONNECTION (object);
-	NMSettingConnectionPrivate *priv = NM_SETTING_CONNECTION_GET_PRIVATE (setting);
+	NMSettingConnectionPrivate *priv = NM_SETTING_CONNECTION_GET_PRIVATE (object);
 
-	switch (prop_id) {
-	case PROP_ID:
-		g_value_set_string (value, nm_setting_connection_get_id (setting));
-		break;
-	case PROP_UUID:
-		g_value_set_string (value, nm_setting_connection_get_uuid (setting));
-		break;
-	case PROP_STABLE_ID:
-		g_value_set_string (value, nm_setting_connection_get_stable_id (setting));
-		break;
-	case PROP_INTERFACE_NAME:
-		g_value_set_string (value, nm_setting_connection_get_interface_name (setting));
-		break;
-	case PROP_TYPE:
-		g_value_set_string (value, nm_setting_connection_get_connection_type (setting));
-		break;
-	case PROP_PERMISSIONS:
-		g_value_take_boxed (value, perm_permlist_to_strv (priv->permissions));
-		break;
-	case PROP_AUTOCONNECT:
-		g_value_set_boolean (value, nm_setting_connection_get_autoconnect (setting));
-		break;
-	case PROP_AUTOCONNECT_PRIORITY:
-		g_value_set_int (value, nm_setting_connection_get_autoconnect_priority (setting));
-		break;
-	case PROP_AUTOCONNECT_RETRIES:
-		g_value_set_int (value, nm_setting_connection_get_autoconnect_retries (setting));
-		break;
-	case PROP_MULTI_CONNECT:
-		g_value_set_int (value, priv->multi_connect);
-		break;
-	case PROP_TIMESTAMP:
-		g_value_set_uint64 (value, nm_setting_connection_get_timestamp (setting));
-		break;
-	case PROP_READ_ONLY:
-		g_value_set_boolean (value, nm_setting_connection_get_read_only (setting));
-		break;
-	case PROP_ZONE:
-		g_value_set_string (value, nm_setting_connection_get_zone (setting));
-		break;
-	case PROP_MASTER:
-		g_value_set_string (value, nm_setting_connection_get_master (setting));
-		break;
-	case PROP_SLAVE_TYPE:
-		g_value_set_string (value, nm_setting_connection_get_slave_type (setting));
-		break;
-	case PROP_AUTOCONNECT_SLAVES:
-		g_value_set_enum (value, nm_setting_connection_get_autoconnect_slaves (setting));
-		break;
-	case PROP_SECONDARIES:
-		g_value_take_boxed (value, _nm_utils_slist_to_strv (priv->secondaries, TRUE));
-		break;
-	case PROP_GATEWAY_PING_TIMEOUT:
-		g_value_set_uint (value, priv->gateway_ping_timeout);
-		break;
-	case PROP_METERED:
-		g_value_set_enum (value, priv->metered);
-		break;
-	case PROP_LLDP:
-		g_value_set_int (value, priv->lldp);
-		break;
-	case PROP_AUTH_RETRIES:
-		g_value_set_int (value, priv->auth_retries);
-		break;
-	case PROP_MDNS:
-		g_value_set_int (value, priv->mdns);
-		break;
-	case PROP_LLMNR:
-		g_value_set_int (value, priv->llmnr);
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
+	g_free (priv->id);
+	g_free (priv->uuid);
+	g_free (priv->stable_id);
+	g_free (priv->interface_name);
+	g_free (priv->type);
+	g_free (priv->zone);
+	g_free (priv->master);
+	g_free (priv->slave_type);
+	g_slist_free_full (priv->permissions, (GDestroyNotify) permission_free);
+	g_slist_free_full (priv->secondaries, g_free);
+
+	G_OBJECT_CLASS (nm_setting_connection_parent_class)->finalize (object);
 }
 
 static void
@@ -1546,8 +1552,8 @@ nm_setting_connection_class_init (NMSettingConnectionClass *klass)
 
 	g_type_class_add_private (klass, sizeof (NMSettingConnectionPrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->verify           = verify;

--- a/libnm-core/nm-setting-connection.c
+++ b/libnm-core/nm-setting-connection.c
@@ -84,8 +84,7 @@ typedef struct {
 	int llmnr;
 } NMSettingConnectionPrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE (NMSettingConnection,
 	PROP_ID,
 	PROP_UUID,
 	PROP_INTERFACE_NAME,
@@ -109,9 +108,7 @@ enum {
 	PROP_LLMNR,
 	PROP_STABLE_ID,
 	PROP_AUTH_RETRIES,
-
-	LAST_PROP
-};
+);
 
 /*****************************************************************************/
 
@@ -431,7 +428,7 @@ nm_setting_connection_add_permission (NMSettingConnection *setting,
 	p = permission_new (pitem);
 	g_return_val_if_fail (p != NULL, FALSE);
 	priv->permissions = g_slist_append (priv->permissions, p);
-	g_object_notify (G_OBJECT (setting), NM_SETTING_CONNECTION_PERMISSIONS);
+	_notify (setting, PROP_PERMISSIONS);
 
 	return TRUE;
 }
@@ -458,7 +455,7 @@ nm_setting_connection_remove_permission (NMSettingConnection *setting,
 
 	permission_free ((Permission *) iter->data);
 	priv->permissions = g_slist_delete_link (priv->permissions, iter);
-	g_object_notify (G_OBJECT (setting), NM_SETTING_CONNECTION_PERMISSIONS);
+	_notify (setting, PROP_PERMISSIONS);
 }
 
 /**
@@ -498,7 +495,7 @@ nm_setting_connection_remove_permission_by_value (NMSettingConnection *setting,
 		if (strcmp (pitem, p->item) == 0) {
 			permission_free ((Permission *) iter->data);
 			priv->permissions = g_slist_delete_link (priv->permissions, iter);
-			g_object_notify (G_OBJECT (setting), NM_SETTING_CONNECTION_PERMISSIONS);
+			_notify (setting, PROP_PERMISSIONS);
 			return TRUE;
 		}
 	}
@@ -771,7 +768,7 @@ nm_setting_connection_add_secondary (NMSettingConnection *setting,
 	}
 
 	priv->secondaries = g_slist_append (priv->secondaries, g_strdup (sec_uuid));
-	g_object_notify (G_OBJECT (setting), NM_SETTING_CONNECTION_SECONDARIES);
+	_notify (setting, PROP_SECONDARIES);
 	return TRUE;
 }
 
@@ -796,7 +793,7 @@ nm_setting_connection_remove_secondary (NMSettingConnection *setting, guint32 id
 
 	g_free (elt->data);
 	priv->secondaries = g_slist_delete_link (priv->secondaries, elt);
-	g_object_notify (G_OBJECT (setting), NM_SETTING_CONNECTION_SECONDARIES);
+	_notify (setting, PROP_SECONDARIES);
 }
 
 /**
@@ -823,7 +820,7 @@ nm_setting_connection_remove_secondary_by_value (NMSettingConnection *setting,
 	for (iter = priv->secondaries; iter; iter = g_slist_next (iter)) {
 		if (!strcmp (sec_uuid, (char *) iter->data)) {
 			priv->secondaries = g_slist_delete_link (priv->secondaries, iter);
-			g_object_notify (G_OBJECT (setting), NM_SETTING_CONNECTION_SECONDARIES);
+			_notify (setting, PROP_SECONDARIES);
 			return TRUE;
 		}
 	}
@@ -1568,13 +1565,12 @@ nm_setting_connection_class_init (NMSettingConnectionClass *klass)
 	 * description: User friendly name for the connection profile.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_ID,
-		 g_param_spec_string (NM_SETTING_CONNECTION_ID, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_FUZZY_IGNORE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_ID] =
+	    g_param_spec_string (NM_SETTING_CONNECTION_ID, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_FUZZY_IGNORE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingConnection:uuid:
@@ -1599,13 +1595,12 @@ nm_setting_connection_class_init (NMSettingConnectionClass *klass)
 	 *   creates the UUID itself (by hashing the filename).
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_UUID,
-		 g_param_spec_string (NM_SETTING_CONNECTION_UUID, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_FUZZY_IGNORE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_UUID] =
+	    g_param_spec_string (NM_SETTING_CONNECTION_UUID, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_FUZZY_IGNORE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingConnection:stable-id:
@@ -1653,13 +1648,12 @@ nm_setting_connection_class_init (NMSettingConnectionClass *klass)
 	 * description: Token to generate stable IDs.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_STABLE_ID,
-		 g_param_spec_string (NM_SETTING_CONNECTION_STABLE_ID, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_FUZZY_IGNORE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_STABLE_ID] =
+	    g_param_spec_string (NM_SETTING_CONNECTION_STABLE_ID, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_FUZZY_IGNORE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingConnection:interface-name:
@@ -1684,17 +1678,15 @@ nm_setting_connection_class_init (NMSettingConnectionClass *klass)
 	 *   can be required for some connection types.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_INTERFACE_NAME,
-		 g_param_spec_string (NM_SETTING_CONNECTION_INTERFACE_NAME, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_INTERFACE_NAME] =
+	    g_param_spec_string (NM_SETTING_CONNECTION_INTERFACE_NAME, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_override (properties_override,
-	                                   g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                 NM_SETTING_CONNECTION_INTERFACE_NAME),
+	                                   obj_properties[PROP_INTERFACE_NAME],
 	                                   G_VARIANT_TYPE_STRING,
 	                                   NULL,
 	                                   nm_setting_connection_set_interface_name,
@@ -1718,13 +1710,12 @@ nm_setting_connection_class_init (NMSettingConnectionClass *klass)
 	 * example: TYPE=Ethernet; TYPE=Bond; TYPE=Bridge; DEVICETYPE=TeamPort
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_TYPE,
-		 g_param_spec_string (NM_SETTING_CONNECTION_TYPE, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_TYPE] =
+	    g_param_spec_string (NM_SETTING_CONNECTION_TYPE, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingConnection:permissions:
@@ -1751,12 +1742,11 @@ nm_setting_connection_class_init (NMSettingConnectionClass *klass)
 	 * example: USERS="joe bob"
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_PERMISSIONS,
-		 g_param_spec_boxed (NM_SETTING_CONNECTION_PERMISSIONS, "", "",
-		                     G_TYPE_STRV,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PERMISSIONS] =
+	    g_param_spec_boxed (NM_SETTING_CONNECTION_PERMISSIONS, "", "",
+	                        G_TYPE_STRV,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingConnection:autoconnect:
@@ -1777,14 +1767,13 @@ nm_setting_connection_class_init (NMSettingConnectionClass *klass)
 	 * description: Whether the connection should be autoconnected (not only while booting).
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_AUTOCONNECT,
-		 g_param_spec_boolean (NM_SETTING_CONNECTION_AUTOCONNECT, "", "",
-		                       TRUE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       NM_SETTING_PARAM_FUZZY_IGNORE |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_AUTOCONNECT] =
+	    g_param_spec_boolean (NM_SETTING_CONNECTION_AUTOCONNECT, "", "",
+	                          TRUE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          NM_SETTING_PARAM_FUZZY_IGNORE |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingConnection:autoconnect-priority:
@@ -1803,8 +1792,7 @@ nm_setting_connection_class_init (NMSettingConnectionClass *klass)
 	 * example: AUTOCONNECT_PRIORITY=20
 	 * ---end---
 	 */
-	g_object_class_install_property
-	    (object_class, PROP_AUTOCONNECT_PRIORITY,
+	obj_properties[PROP_AUTOCONNECT_PRIORITY] =
 	     g_param_spec_int (NM_SETTING_CONNECTION_AUTOCONNECT_PRIORITY, "", "",
 	                       NM_SETTING_CONNECTION_AUTOCONNECT_PRIORITY_MIN,
 	                       NM_SETTING_CONNECTION_AUTOCONNECT_PRIORITY_MAX,
@@ -1812,7 +1800,7 @@ nm_setting_connection_class_init (NMSettingConnectionClass *klass)
 	                       G_PARAM_READWRITE |
 	                       G_PARAM_CONSTRUCT |
 	                       NM_SETTING_PARAM_FUZZY_IGNORE |
-	                       G_PARAM_STATIC_STRINGS));
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingConnection:autoconnect-retries:
@@ -1832,14 +1820,13 @@ nm_setting_connection_class_init (NMSettingConnectionClass *klass)
 	 * example: AUTOCONNECT_RETRIES=1
 	 * ---end---
 	 */
-	g_object_class_install_property
-	    (object_class, PROP_AUTOCONNECT_RETRIES,
+	obj_properties[PROP_AUTOCONNECT_RETRIES] =
 	     g_param_spec_int (NM_SETTING_CONNECTION_AUTOCONNECT_RETRIES, "", "",
 	                       -1, G_MAXINT32, -1,
 	                       G_PARAM_READWRITE |
 	                       G_PARAM_CONSTRUCT |
 	                       NM_SETTING_PARAM_FUZZY_IGNORE |
-	                       G_PARAM_STATIC_STRINGS));
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingConnection:multi-connect:
@@ -1857,13 +1844,12 @@ nm_setting_connection_class_init (NMSettingConnectionClass *klass)
 	 * example: ZONE=3
 	 * ---end---
 	 */
-	g_object_class_install_property
-	    (object_class, PROP_MULTI_CONNECT,
+	obj_properties[PROP_MULTI_CONNECT] =
 	     g_param_spec_int (NM_SETTING_CONNECTION_MULTI_CONNECT, "", "",
 	                       G_MININT32, G_MAXINT32, NM_CONNECTION_MULTI_CONNECT_DEFAULT,
 	                       G_PARAM_READWRITE |
 	                       NM_SETTING_PARAM_FUZZY_IGNORE |
-	                       G_PARAM_STATIC_STRINGS));
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingConnection:timestamp:
@@ -1876,14 +1862,13 @@ nm_setting_connection_class_init (NMSettingConnectionClass *klass)
 	 * timestamp. The property is only meant for reading (changes to this
 	 * property will not be preserved).
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_TIMESTAMP,
-		 g_param_spec_uint64 (NM_SETTING_CONNECTION_TIMESTAMP, "", "",
-		                      0, G_MAXUINT64, 0,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_CONSTRUCT |
-		                      NM_SETTING_PARAM_FUZZY_IGNORE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_TIMESTAMP] =
+	    g_param_spec_uint64 (NM_SETTING_CONNECTION_TIMESTAMP, "", "",
+	                         0, G_MAXUINT64, 0,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_CONSTRUCT |
+	                         NM_SETTING_PARAM_FUZZY_IGNORE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingConnection:read-only:
@@ -1892,14 +1877,13 @@ nm_setting_connection_class_init (NMSettingConnectionClass *klass)
 	 * service's D-Bus interface with the right privileges, or %TRUE if the
 	 * connection is read-only and cannot be modified.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_READ_ONLY,
-		 g_param_spec_boolean (NM_SETTING_CONNECTION_READ_ONLY, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       NM_SETTING_PARAM_FUZZY_IGNORE |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_READ_ONLY] =
+	    g_param_spec_boolean (NM_SETTING_CONNECTION_READ_ONLY, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          NM_SETTING_PARAM_FUZZY_IGNORE |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingConnection:zone:
@@ -1920,15 +1904,14 @@ nm_setting_connection_class_init (NMSettingConnectionClass *klass)
 	 * example: ZONE=Work
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_ZONE,
-		 g_param_spec_string (NM_SETTING_CONNECTION_ZONE, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_CONSTRUCT |
-		                      NM_SETTING_PARAM_FUZZY_IGNORE |
-		                      NM_SETTING_PARAM_REAPPLY_IMMEDIATELY |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_ZONE] =
+	    g_param_spec_string (NM_SETTING_CONNECTION_ZONE, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_CONSTRUCT |
+	                         NM_SETTING_PARAM_FUZZY_IGNORE |
+	                         NM_SETTING_PARAM_REAPPLY_IMMEDIATELY |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingConnection:master:
@@ -1944,14 +1927,13 @@ nm_setting_connection_class_init (NMSettingConnectionClass *klass)
 	 *   for compatibility with legacy tooling.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_MASTER,
-		 g_param_spec_string (NM_SETTING_CONNECTION_MASTER, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_FUZZY_IGNORE |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MASTER] =
+	    g_param_spec_string (NM_SETTING_CONNECTION_MASTER, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_FUZZY_IGNORE |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingConnection:slave-type:
@@ -1970,14 +1952,13 @@ nm_setting_connection_class_init (NMSettingConnectionClass *klass)
 	 *   and BRIDGE_UUID for bridging.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_SLAVE_TYPE,
-		 g_param_spec_string (NM_SETTING_CONNECTION_SLAVE_TYPE, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_FUZZY_IGNORE |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_SLAVE_TYPE] =
+	    g_param_spec_string (NM_SETTING_CONNECTION_SLAVE_TYPE, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_FUZZY_IGNORE |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingConnection:autoconnect-slaves:
@@ -2002,15 +1983,14 @@ nm_setting_connection_class_init (NMSettingConnectionClass *klass)
 	 *   when this connection is activated.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_AUTOCONNECT_SLAVES,
-		 g_param_spec_enum (NM_SETTING_CONNECTION_AUTOCONNECT_SLAVES, "", "",
-		                    NM_TYPE_SETTING_CONNECTION_AUTOCONNECT_SLAVES,
-		                    NM_SETTING_CONNECTION_AUTOCONNECT_SLAVES_DEFAULT,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_FUZZY_IGNORE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_AUTOCONNECT_SLAVES] =
+	    g_param_spec_enum (NM_SETTING_CONNECTION_AUTOCONNECT_SLAVES, "", "",
+	                       NM_TYPE_SETTING_CONNECTION_AUTOCONNECT_SLAVES,
+	                       NM_SETTING_CONNECTION_AUTOCONNECT_SLAVES_DEFAULT,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_FUZZY_IGNORE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingConnection:secondaries:
@@ -2026,13 +2006,12 @@ nm_setting_connection_class_init (NMSettingConnectionClass *klass)
 	 *   together with this connection.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_SECONDARIES,
-		 g_param_spec_boxed (NM_SETTING_CONNECTION_SECONDARIES, "", "",
-		                     G_TYPE_STRV,
-		                     G_PARAM_READWRITE |
-		                     NM_SETTING_PARAM_FUZZY_IGNORE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_SECONDARIES] =
+	    g_param_spec_boxed (NM_SETTING_CONNECTION_SECONDARIES, "", "",
+	                        G_TYPE_STRV,
+	                        G_PARAM_READWRITE |
+	                        NM_SETTING_PARAM_FUZZY_IGNORE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingConnection:gateway-ping-timeout:
@@ -2049,13 +2028,12 @@ nm_setting_connection_class_init (NMSettingConnectionClass *klass)
 	 * example: GATEWAY_PING_TIMEOUT=5
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_GATEWAY_PING_TIMEOUT,
-		 g_param_spec_uint (NM_SETTING_CONNECTION_GATEWAY_PING_TIMEOUT, "", "",
-		                    0, 600, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_GATEWAY_PING_TIMEOUT] =
+	    g_param_spec_uint (NM_SETTING_CONNECTION_GATEWAY_PING_TIMEOUT, "", "",
+	                       0, 600, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingConnection:metered:
@@ -2075,14 +2053,13 @@ nm_setting_connection_class_init (NMSettingConnectionClass *klass)
 	 * example: CONNECTION_METERED=yes
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_METERED,
-		 g_param_spec_enum (NM_SETTING_CONNECTION_METERED, "", "",
-		                    NM_TYPE_METERED,
-		                    NM_METERED_UNKNOWN,
-		                    G_PARAM_READWRITE |
-		                    NM_SETTING_PARAM_REAPPLY_IMMEDIATELY |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_METERED] =
+	    g_param_spec_enum (NM_SETTING_CONNECTION_METERED, "", "",
+	                       NM_TYPE_METERED,
+	                       NM_METERED_UNKNOWN,
+	                       G_PARAM_READWRITE |
+	                       NM_SETTING_PARAM_REAPPLY_IMMEDIATELY |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingConnection:lldp:
@@ -2100,14 +2077,13 @@ nm_setting_connection_class_init (NMSettingConnectionClass *klass)
 	 * example: LLDP=no
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_LLDP,
-		 g_param_spec_int (NM_SETTING_CONNECTION_LLDP, "", "",
-		                   G_MININT32, G_MAXINT32, NM_SETTING_CONNECTION_LLDP_DEFAULT,
-		                   NM_SETTING_PARAM_FUZZY_IGNORE |
-		                   G_PARAM_READWRITE |
-		                   G_PARAM_CONSTRUCT |
-		                   G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_LLDP] =
+	    g_param_spec_int (NM_SETTING_CONNECTION_LLDP, "", "",
+	                      G_MININT32, G_MAXINT32, NM_SETTING_CONNECTION_LLDP_DEFAULT,
+	                      NM_SETTING_PARAM_FUZZY_IGNORE |
+	                      G_PARAM_READWRITE |
+	                      G_PARAM_CONSTRUCT |
+	                      G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingConnection:auth-retries:
@@ -2127,14 +2103,13 @@ nm_setting_connection_class_init (NMSettingConnectionClass *klass)
 	 * description: Number of retries for authentication.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_AUTH_RETRIES,
-		 g_param_spec_int (NM_SETTING_CONNECTION_AUTH_RETRIES, "", "",
-		                   -1, G_MAXINT32, -1,
-		                   G_PARAM_READWRITE |
-		                   G_PARAM_CONSTRUCT |
-		                   NM_SETTING_PARAM_FUZZY_IGNORE |
-		                   G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_AUTH_RETRIES] =
+	    g_param_spec_int (NM_SETTING_CONNECTION_AUTH_RETRIES, "", "",
+	                      -1, G_MAXINT32, -1,
+	                      G_PARAM_READWRITE |
+	                      G_PARAM_CONSTRUCT |
+	                      NM_SETTING_PARAM_FUZZY_IGNORE |
+	                      G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingConnection:mdns:
@@ -2159,13 +2134,12 @@ nm_setting_connection_class_init (NMSettingConnectionClass *klass)
 	 * example: MDNS=yes
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_MDNS,
-		 g_param_spec_int (NM_SETTING_CONNECTION_MDNS, "", "",
-		                   G_MININT32, G_MAXINT32,
-		                   NM_SETTING_CONNECTION_MDNS_DEFAULT,
-		                   G_PARAM_READWRITE |
-		                   G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MDNS] =
+	    g_param_spec_int (NM_SETTING_CONNECTION_MDNS, "", "",
+	                      G_MININT32, G_MAXINT32,
+	                      NM_SETTING_CONNECTION_MDNS_DEFAULT,
+	                      G_PARAM_READWRITE |
+	                      G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingConnection:llmnr:
@@ -2193,13 +2167,14 @@ nm_setting_connection_class_init (NMSettingConnectionClass *klass)
 	 * example: LLMNR=yes
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_LLMNR,
-		 g_param_spec_int (NM_SETTING_CONNECTION_LLMNR, "", "",
-		                   G_MININT32, G_MAXINT32,
-		                   NM_SETTING_CONNECTION_LLMNR_DEFAULT,
-		                   G_PARAM_READWRITE |
-		                   G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_LLMNR] =
+	    g_param_spec_int (NM_SETTING_CONNECTION_LLMNR, "", "",
+	                      G_MININT32, G_MAXINT32,
+	                      NM_SETTING_CONNECTION_LLMNR_DEFAULT,
+	                      G_PARAM_READWRITE |
+	                      G_PARAM_STATIC_STRINGS);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit_full (setting_class, NM_META_SETTING_TYPE_CONNECTION,
 	                               NULL, properties_override);

--- a/libnm-core/nm-setting-dcb.c
+++ b/libnm-core/nm-setting-dcb.c
@@ -68,8 +68,8 @@ typedef struct {
 	guint             priority_traffic_class[8];
 } NMSettingDcbPrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE (NMSettingDcb,
+
 	PROP_APP_FCOE_FLAGS,
 	PROP_APP_FCOE_PRIORITY,
 	PROP_APP_FCOE_MODE,
@@ -81,17 +81,15 @@ enum {
 	PROP_APP_FIP_PRIORITY,
 
 	PROP_PFC_FLAGS,
-	PROP_PFC,
+	PROP_PRIORITY_FLOW_CONTROL,
 
 	PROP_PRIORITY_GROUP_FLAGS,
 	PROP_PRIORITY_GROUP_ID,
 	PROP_PRIORITY_GROUP_BANDWIDTH,
 	PROP_PRIORITY_BANDWIDTH,
-	PROP_PRIORITY_STRICT,
+	PROP_PRIORITY_STRICT_BANDWIDTH,
 	PROP_PRIORITY_TRAFFIC_CLASS,
-
-	LAST_PROP
-};
+);
 
 /**
  * nm_setting_dcb_new:
@@ -258,7 +256,7 @@ nm_setting_dcb_set_priority_flow_control (NMSettingDcb *setting,
 	priv = NM_SETTING_DCB_GET_PRIVATE (setting);
 	if (priv->pfc[user_priority] != uint_enabled) {
 		priv->pfc[user_priority] = uint_enabled;
-		g_object_notify (G_OBJECT (setting), NM_SETTING_DCB_PRIORITY_FLOW_CONTROL);
+		_notify (setting, PROP_PRIORITY_FLOW_CONTROL);
 	}
 }
 
@@ -318,7 +316,7 @@ nm_setting_dcb_set_priority_group_id (NMSettingDcb *setting,
 	priv = NM_SETTING_DCB_GET_PRIVATE (setting);
 	if (priv->priority_group_id[user_priority] != group_id) {
 		priv->priority_group_id[user_priority] = group_id;
-		g_object_notify (G_OBJECT (setting), NM_SETTING_DCB_PRIORITY_GROUP_ID);
+		_notify (setting, PROP_PRIORITY_GROUP_ID);
 	}
 }
 
@@ -363,7 +361,7 @@ nm_setting_dcb_set_priority_group_bandwidth (NMSettingDcb *setting,
 	priv = NM_SETTING_DCB_GET_PRIVATE (setting);
 	if (priv->priority_group_bandwidth[group_id] != bandwidth_percent) {
 		priv->priority_group_bandwidth[group_id] = bandwidth_percent;
-		g_object_notify (G_OBJECT (setting), NM_SETTING_DCB_PRIORITY_GROUP_BANDWIDTH);
+		_notify (setting, PROP_PRIORITY_GROUP_BANDWIDTH);
 	}
 }
 
@@ -409,7 +407,7 @@ nm_setting_dcb_set_priority_bandwidth (NMSettingDcb *setting,
 	priv = NM_SETTING_DCB_GET_PRIVATE (setting);
 	if (priv->priority_bandwidth[user_priority] != bandwidth_percent) {
 		priv->priority_bandwidth[user_priority] = bandwidth_percent;
-		g_object_notify (G_OBJECT (setting), NM_SETTING_DCB_PRIORITY_BANDWIDTH);
+		_notify (setting, PROP_PRIORITY_BANDWIDTH);
 	}
 }
 
@@ -455,7 +453,7 @@ nm_setting_dcb_set_priority_strict_bandwidth (NMSettingDcb *setting,
 	priv = NM_SETTING_DCB_GET_PRIVATE (setting);
 	if (priv->priority_strict[user_priority] != uint_strict) {
 		priv->priority_strict[user_priority] = uint_strict;
-		g_object_notify (G_OBJECT (setting), NM_SETTING_DCB_PRIORITY_STRICT_BANDWIDTH);
+		_notify (setting, PROP_PRIORITY_STRICT_BANDWIDTH);
 	}
 }
 
@@ -500,7 +498,7 @@ nm_setting_dcb_set_priority_traffic_class (NMSettingDcb *setting,
 	priv = NM_SETTING_DCB_GET_PRIVATE (setting);
 	if (priv->priority_traffic_class[user_priority] != traffic_class) {
 		priv->priority_traffic_class[user_priority] = traffic_class;
-		g_object_notify (G_OBJECT (setting), NM_SETTING_DCB_PRIORITY_TRAFFIC_CLASS);
+		_notify (setting, PROP_PRIORITY_TRAFFIC_CLASS);
 	}
 }
 
@@ -808,7 +806,7 @@ set_property (GObject *object, guint prop_id,
 	case PROP_PFC_FLAGS:
 		priv->pfc_flags = g_value_get_flags (value);
 		break;
-	case PROP_PFC:
+	case PROP_PRIORITY_FLOW_CONTROL:
 		SET_ARRAY_FROM_GVALUE (value, priv->pfc);
 		break;
 	case PROP_PRIORITY_GROUP_FLAGS:
@@ -823,7 +821,7 @@ set_property (GObject *object, guint prop_id,
 	case PROP_PRIORITY_BANDWIDTH:
 		SET_ARRAY_FROM_GVALUE (value, priv->priority_bandwidth);
 		break;
-	case PROP_PRIORITY_STRICT:
+	case PROP_PRIORITY_STRICT_BANDWIDTH:
 		SET_ARRAY_FROM_GVALUE (value, priv->priority_strict);
 		break;
 	case PROP_PRIORITY_TRAFFIC_CLASS:
@@ -867,7 +865,7 @@ get_property (GObject *object, guint prop_id,
 	case PROP_PFC_FLAGS:
 		g_value_set_flags (value, priv->pfc_flags);
 		break;
-	case PROP_PFC:
+	case PROP_PRIORITY_FLOW_CONTROL:
 		SET_GVALUE_FROM_ARRAY (value, priv->pfc);
 		break;
 	case PROP_PRIORITY_GROUP_FLAGS:
@@ -882,7 +880,7 @@ get_property (GObject *object, guint prop_id,
 	case PROP_PRIORITY_BANDWIDTH:
 		SET_GVALUE_FROM_ARRAY (value, priv->priority_bandwidth);
 		break;
-	case PROP_PRIORITY_STRICT:
+	case PROP_PRIORITY_STRICT_BANDWIDTH:
 		SET_GVALUE_FROM_ARRAY (value, priv->priority_strict);
 		break;
 	case PROP_PRIORITY_TRAFFIC_CLASS:
@@ -934,13 +932,12 @@ nm_setting_dcb_class_init (NMSettingDcbClass *klass)
 	 * example: DCB_APP_FCOE_ENABLE=yes DCB_APP_FCOE_ADVERTISE=yes
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_APP_FCOE_FLAGS,
-		 g_param_spec_flags (NM_SETTING_DCB_APP_FCOE_FLAGS, "", "",
-		                     NM_TYPE_SETTING_DCB_FLAGS,
-		                     NM_SETTING_DCB_FLAG_NONE,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_APP_FCOE_FLAGS] =
+	    g_param_spec_flags (NM_SETTING_DCB_APP_FCOE_FLAGS, "", "",
+	                        NM_TYPE_SETTING_DCB_FLAGS,
+	                        NM_SETTING_DCB_FLAG_NONE,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingDcb:app-fcoe-priority:
@@ -956,13 +953,12 @@ nm_setting_dcb_class_init (NMSettingDcbClass *klass)
 	 * description: Priority of FCoE frames.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_APP_FCOE_PRIORITY,
-		 g_param_spec_int (NM_SETTING_DCB_APP_FCOE_PRIORITY, "", "",
-		                   -1, 7, -1,
-		                   G_PARAM_READWRITE |
-		                   G_PARAM_CONSTRUCT |
-		                   G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_APP_FCOE_PRIORITY] =
+	    g_param_spec_int (NM_SETTING_DCB_APP_FCOE_PRIORITY, "", "",
+	                      -1, 7, -1,
+	                      G_PARAM_READWRITE |
+	                      G_PARAM_CONSTRUCT |
+	                      G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingDcb:app-fcoe-mode:
@@ -978,13 +974,12 @@ nm_setting_dcb_class_init (NMSettingDcbClass *klass)
 	 * description: FCoE controller mode.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_APP_FCOE_MODE,
-		 g_param_spec_string (NM_SETTING_DCB_APP_FCOE_MODE, "", "",
-		                      NM_SETTING_DCB_FCOE_MODE_FABRIC,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_CONSTRUCT |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_APP_FCOE_MODE] =
+	    g_param_spec_string (NM_SETTING_DCB_APP_FCOE_MODE, "", "",
+	                         NM_SETTING_DCB_FCOE_MODE_FABRIC,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_CONSTRUCT |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingDcb:app-iscsi-flags:
@@ -1000,13 +995,12 @@ nm_setting_dcb_class_init (NMSettingDcbClass *klass)
 	 * description: iSCSI flags.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_APP_ISCSI_FLAGS,
-		 g_param_spec_flags (NM_SETTING_DCB_APP_ISCSI_FLAGS, "", "",
-		                     NM_TYPE_SETTING_DCB_FLAGS,
-		                     NM_SETTING_DCB_FLAG_NONE,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_APP_ISCSI_FLAGS] =
+	    g_param_spec_flags (NM_SETTING_DCB_APP_ISCSI_FLAGS, "", "",
+	                        NM_TYPE_SETTING_DCB_FLAGS,
+	                        NM_SETTING_DCB_FLAG_NONE,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingDcb:app-iscsi-priority:
@@ -1022,13 +1016,12 @@ nm_setting_dcb_class_init (NMSettingDcbClass *klass)
 	 * description: Priority of iSCSI frames.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_APP_ISCSI_PRIORITY,
-		 g_param_spec_int (NM_SETTING_DCB_APP_ISCSI_PRIORITY, "", "",
-		                   -1, 7, -1,
-		                   G_PARAM_READWRITE |
-		                   G_PARAM_CONSTRUCT |
-		                   G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_APP_ISCSI_PRIORITY] =
+	    g_param_spec_int (NM_SETTING_DCB_APP_ISCSI_PRIORITY, "", "",
+	                      -1, 7, -1,
+	                      G_PARAM_READWRITE |
+	                      G_PARAM_CONSTRUCT |
+	                      G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingDcb:app-fip-flags:
@@ -1044,13 +1037,12 @@ nm_setting_dcb_class_init (NMSettingDcbClass *klass)
 	 * description: FIP flags.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_APP_FIP_FLAGS,
-		 g_param_spec_flags (NM_SETTING_DCB_APP_FIP_FLAGS, "", "",
-		                     NM_TYPE_SETTING_DCB_FLAGS,
-		                     NM_SETTING_DCB_FLAG_NONE,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_APP_FIP_FLAGS] =
+	    g_param_spec_flags (NM_SETTING_DCB_APP_FIP_FLAGS, "", "",
+	                        NM_TYPE_SETTING_DCB_FLAGS,
+	                        NM_SETTING_DCB_FLAG_NONE,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingDcb:app-fip-priority:
@@ -1066,13 +1058,12 @@ nm_setting_dcb_class_init (NMSettingDcbClass *klass)
 	 * description: Priority of FIP frames.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_APP_FIP_PRIORITY,
-		 g_param_spec_int (NM_SETTING_DCB_APP_FIP_PRIORITY, "", "",
-		                   -1, 7, -1,
-		                   G_PARAM_READWRITE |
-		                   G_PARAM_CONSTRUCT |
-		                   G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_APP_FIP_PRIORITY] =
+	    g_param_spec_int (NM_SETTING_DCB_APP_FIP_PRIORITY, "", "",
+	                      -1, 7, -1,
+	                      G_PARAM_READWRITE |
+	                      G_PARAM_CONSTRUCT |
+	                      G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingDcb:priority-flow-control-flags:
@@ -1088,13 +1079,12 @@ nm_setting_dcb_class_init (NMSettingDcbClass *klass)
 	 * description: Priority flow control flags.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_PFC_FLAGS,
-		 g_param_spec_flags (NM_SETTING_DCB_PRIORITY_FLOW_CONTROL_FLAGS, "", "",
-		                     NM_TYPE_SETTING_DCB_FLAGS,
-		                     NM_SETTING_DCB_FLAG_NONE,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PFC_FLAGS] =
+	    g_param_spec_flags (NM_SETTING_DCB_PRIORITY_FLOW_CONTROL_FLAGS, "", "",
+	                        NM_TYPE_SETTING_DCB_FLAGS,
+	                        NM_SETTING_DCB_FLAG_NONE,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingDcb:priority-flow-control: (type GArray(gboolean))
@@ -1111,19 +1101,17 @@ nm_setting_dcb_class_init (NMSettingDcbClass *klass)
 	 * example: DCB_PFC_UP=01101110
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_PFC,
-		 g_param_spec_boxed (NM_SETTING_DCB_PRIORITY_FLOW_CONTROL, "", "",
-		                     G_TYPE_ARRAY,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PRIORITY_FLOW_CONTROL] =
+	    g_param_spec_boxed (NM_SETTING_DCB_PRIORITY_FLOW_CONTROL, "", "",
+	                        G_TYPE_ARRAY,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_transform (properties_override,
-	                                    g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                  NM_SETTING_DCB_PRIORITY_FLOW_CONTROL),
-	                                    G_VARIANT_TYPE ("au"),
-	                                    _nm_setting_dcb_uint_array_to_dbus,
-	                                    _nm_setting_dcb_uint_array_from_dbus);
+	                                   obj_properties[PROP_PRIORITY_FLOW_CONTROL],
+	                                   G_VARIANT_TYPE ("au"),
+	                                   _nm_setting_dcb_uint_array_to_dbus,
+	                                   _nm_setting_dcb_uint_array_from_dbus);
 
 	/**
 	 * NMSettingDcb:priority-group-flags:
@@ -1139,13 +1127,12 @@ nm_setting_dcb_class_init (NMSettingDcbClass *klass)
 	 * description: Priority groups flags.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_PRIORITY_GROUP_FLAGS,
-		 g_param_spec_flags (NM_SETTING_DCB_PRIORITY_GROUP_FLAGS, "", "",
-		                     NM_TYPE_SETTING_DCB_FLAGS,
-		                     NM_SETTING_DCB_FLAG_NONE,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PRIORITY_GROUP_FLAGS] =
+	    g_param_spec_flags (NM_SETTING_DCB_PRIORITY_GROUP_FLAGS, "", "",
+	                        NM_TYPE_SETTING_DCB_FLAGS,
+	                        NM_SETTING_DCB_FLAG_NONE,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingDcb:priority-group-id: (type GArray(guint))
@@ -1162,19 +1149,17 @@ nm_setting_dcb_class_init (NMSettingDcbClass *klass)
 	 * example: DCB_PG_ID=1205f173
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_PRIORITY_GROUP_ID,
-		 g_param_spec_boxed (NM_SETTING_DCB_PRIORITY_GROUP_ID, "", "",
-		                     G_TYPE_ARRAY,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PRIORITY_GROUP_ID] =
+	    g_param_spec_boxed (NM_SETTING_DCB_PRIORITY_GROUP_ID, "", "",
+	                        G_TYPE_ARRAY,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_transform (properties_override,
-	                                    g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                  NM_SETTING_DCB_PRIORITY_GROUP_ID),
-	                                    G_VARIANT_TYPE ("au"),
-	                                    _nm_setting_dcb_uint_array_to_dbus,
-	                                    _nm_setting_dcb_uint_array_from_dbus);
+	                                   obj_properties[PROP_PRIORITY_GROUP_ID],
+	                                   G_VARIANT_TYPE ("au"),
+	                                   _nm_setting_dcb_uint_array_to_dbus,
+	                                   _nm_setting_dcb_uint_array_from_dbus);
 
 	/**
 	 * NMSettingDcb:priority-group-bandwidth: (type GArray(guint))
@@ -1191,19 +1176,17 @@ nm_setting_dcb_class_init (NMSettingDcbClass *klass)
 	 * example: DCB_PG_PCT=10,5,10,15,10,10,10,30
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_PRIORITY_GROUP_BANDWIDTH,
-		 g_param_spec_boxed (NM_SETTING_DCB_PRIORITY_GROUP_BANDWIDTH, "", "",
-		                     G_TYPE_ARRAY,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PRIORITY_GROUP_BANDWIDTH] =
+	    g_param_spec_boxed (NM_SETTING_DCB_PRIORITY_GROUP_BANDWIDTH, "", "",
+	                        G_TYPE_ARRAY,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_transform (properties_override,
-	                                    g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                  NM_SETTING_DCB_PRIORITY_GROUP_BANDWIDTH),
-	                                    G_VARIANT_TYPE ("au"),
-	                                    _nm_setting_dcb_uint_array_to_dbus,
-	                                    _nm_setting_dcb_uint_array_from_dbus);
+	                                   obj_properties[PROP_PRIORITY_GROUP_BANDWIDTH],
+	                                   G_VARIANT_TYPE ("au"),
+	                                   _nm_setting_dcb_uint_array_to_dbus,
+	                                   _nm_setting_dcb_uint_array_from_dbus);
 
 	/**
 	 * NMSettingDcb:priority-bandwidth: (type GArray(guint))
@@ -1222,19 +1205,17 @@ nm_setting_dcb_class_init (NMSettingDcbClass *klass)
 	 * example: DCB_PG_UPPCT=7,13,10,10,15,15,10,20
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_PRIORITY_BANDWIDTH,
-		 g_param_spec_boxed (NM_SETTING_DCB_PRIORITY_BANDWIDTH, "", "",
-		                     G_TYPE_ARRAY,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PRIORITY_BANDWIDTH] =
+	    g_param_spec_boxed (NM_SETTING_DCB_PRIORITY_BANDWIDTH, "", "",
+	                        G_TYPE_ARRAY,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_transform (properties_override,
-	                                    g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                  NM_SETTING_DCB_PRIORITY_BANDWIDTH),
-	                                    G_VARIANT_TYPE ("au"),
-	                                    _nm_setting_dcb_uint_array_to_dbus,
-	                                    _nm_setting_dcb_uint_array_from_dbus);
+	                                   obj_properties[PROP_PRIORITY_BANDWIDTH],
+	                                   G_VARIANT_TYPE ("au"),
+	                                   _nm_setting_dcb_uint_array_to_dbus,
+	                                   _nm_setting_dcb_uint_array_from_dbus);
 
 	/**
 	 * NMSettingDcb:priority-strict-bandwidth: (type GArray(gboolean))
@@ -1251,19 +1232,17 @@ nm_setting_dcb_class_init (NMSettingDcbClass *klass)
 	 * example: DCB_PG_STRICT=01101110
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_PRIORITY_STRICT,
-		 g_param_spec_boxed (NM_SETTING_DCB_PRIORITY_STRICT_BANDWIDTH, "", "",
-		                     G_TYPE_ARRAY,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PRIORITY_STRICT_BANDWIDTH] =
+	    g_param_spec_boxed (NM_SETTING_DCB_PRIORITY_STRICT_BANDWIDTH, "", "",
+	                        G_TYPE_ARRAY,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_transform (properties_override,
-	                                    g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                  NM_SETTING_DCB_PRIORITY_STRICT_BANDWIDTH),
-	                                    G_VARIANT_TYPE ("au"),
-	                                    _nm_setting_dcb_uint_array_to_dbus,
-	                                    _nm_setting_dcb_uint_array_from_dbus);
+	                                   obj_properties[PROP_PRIORITY_STRICT_BANDWIDTH],
+	                                   G_VARIANT_TYPE ("au"),
+	                                   _nm_setting_dcb_uint_array_to_dbus,
+	                                   _nm_setting_dcb_uint_array_from_dbus);
 
 	/**
 	 * NMSettingDcb:priority-traffic-class: (type GArray(guint))
@@ -1279,19 +1258,19 @@ nm_setting_dcb_class_init (NMSettingDcbClass *klass)
 	 * example: DCB_PG_UP2TC=01623701
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_PRIORITY_TRAFFIC_CLASS,
-		 g_param_spec_boxed (NM_SETTING_DCB_PRIORITY_TRAFFIC_CLASS, "", "",
-		                     G_TYPE_ARRAY,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PRIORITY_TRAFFIC_CLASS] =
+	    g_param_spec_boxed (NM_SETTING_DCB_PRIORITY_TRAFFIC_CLASS, "", "",
+	                        G_TYPE_ARRAY,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_transform (properties_override,
-	                                    g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                  NM_SETTING_DCB_PRIORITY_TRAFFIC_CLASS),
+	                                    obj_properties[PROP_PRIORITY_TRAFFIC_CLASS],
 	                                    G_VARIANT_TYPE ("au"),
 	                                    _nm_setting_dcb_uint_array_to_dbus,
 	                                    _nm_setting_dcb_uint_array_from_dbus);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit_full (setting_class, NM_META_SETTING_TYPE_DCB,
 	                               NULL, properties_override);

--- a/libnm-core/nm-setting-dcb.c
+++ b/libnm-core/nm-setting-dcb.c
@@ -21,9 +21,10 @@
 
 #include "nm-default.h"
 
+#include "nm-setting-dcb.h"
+
 #include <string.h>
 
-#include "nm-setting-dcb.h"
 #include "nm-utils.h"
 #include "nm-utils-private.h"
 #include "nm-setting-private.h"
@@ -40,9 +41,30 @@
  * of storage technologies like Fibre Channel over Ethernet (FCoE) and iSCSI.
  **/
 
-G_DEFINE_TYPE (NMSettingDcb, nm_setting_dcb, NM_TYPE_SETTING)
+/*****************************************************************************/
 
-#define NM_SETTING_DCB_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_DCB, NMSettingDcbPrivate))
+NM_GOBJECT_PROPERTIES_DEFINE (NMSettingDcb,
+
+	PROP_APP_FCOE_FLAGS,
+	PROP_APP_FCOE_PRIORITY,
+	PROP_APP_FCOE_MODE,
+
+	PROP_APP_ISCSI_FLAGS,
+	PROP_APP_ISCSI_PRIORITY,
+
+	PROP_APP_FIP_FLAGS,
+	PROP_APP_FIP_PRIORITY,
+
+	PROP_PFC_FLAGS,
+	PROP_PRIORITY_FLOW_CONTROL,
+
+	PROP_PRIORITY_GROUP_FLAGS,
+	PROP_PRIORITY_GROUP_ID,
+	PROP_PRIORITY_GROUP_BANDWIDTH,
+	PROP_PRIORITY_BANDWIDTH,
+	PROP_PRIORITY_STRICT_BANDWIDTH,
+	PROP_PRIORITY_TRAFFIC_CLASS,
+);
 
 typedef struct {
 	NMSettingDcbFlags app_fcoe_flags;
@@ -68,41 +90,11 @@ typedef struct {
 	guint             priority_traffic_class[8];
 } NMSettingDcbPrivate;
 
-NM_GOBJECT_PROPERTIES_DEFINE (NMSettingDcb,
+G_DEFINE_TYPE (NMSettingDcb, nm_setting_dcb, NM_TYPE_SETTING)
 
-	PROP_APP_FCOE_FLAGS,
-	PROP_APP_FCOE_PRIORITY,
-	PROP_APP_FCOE_MODE,
+#define NM_SETTING_DCB_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_DCB, NMSettingDcbPrivate))
 
-	PROP_APP_ISCSI_FLAGS,
-	PROP_APP_ISCSI_PRIORITY,
-
-	PROP_APP_FIP_FLAGS,
-	PROP_APP_FIP_PRIORITY,
-
-	PROP_PFC_FLAGS,
-	PROP_PRIORITY_FLOW_CONTROL,
-
-	PROP_PRIORITY_GROUP_FLAGS,
-	PROP_PRIORITY_GROUP_ID,
-	PROP_PRIORITY_GROUP_BANDWIDTH,
-	PROP_PRIORITY_BANDWIDTH,
-	PROP_PRIORITY_STRICT_BANDWIDTH,
-	PROP_PRIORITY_TRAFFIC_CLASS,
-);
-
-/**
- * nm_setting_dcb_new:
- *
- * Creates a new #NMSettingDcb object with default values.
- *
- * Returns: (transfer full): the new empty #NMSettingDcb object
- **/
-NMSetting *
-nm_setting_dcb_new (void)
-{
-	return (NMSetting *) g_object_new (NM_TYPE_SETTING_DCB, NULL);
-}
+/*****************************************************************************/
 
 /**
  * nm_setting_dcb_get_app_fcoe_flags:
@@ -722,11 +714,6 @@ verify (NMSetting *setting, NMConnection *connection, GError **error)
 
 /*****************************************************************************/
 
-static void
-nm_setting_dcb_init (NMSettingDcb *setting)
-{
-}
-
 G_STATIC_ASSERT (sizeof (guint) == sizeof (gboolean));
 
 static inline void
@@ -774,64 +761,7 @@ _nm_setting_dcb_uint_array_from_dbus (GVariant *dbus_value,
 	set_gvalue_from_array (prop_value, (guint *) array, length);
 }
 
-static void
-set_property (GObject *object, guint prop_id,
-              const GValue *value, GParamSpec *pspec)
-{
-	NMSettingDcbPrivate *priv = NM_SETTING_DCB_GET_PRIVATE (object);
-
-	switch (prop_id) {
-	case PROP_APP_FCOE_FLAGS:
-		priv->app_fcoe_flags = g_value_get_flags (value);
-		break;
-	case PROP_APP_FCOE_PRIORITY:
-		priv->app_fcoe_priority = g_value_get_int (value);
-		break;
-	case PROP_APP_FCOE_MODE:
-		g_free (priv->app_fcoe_mode);
-		priv->app_fcoe_mode = g_value_dup_string (value);
-		break;
-	case PROP_APP_ISCSI_FLAGS:
-		priv->app_iscsi_flags = g_value_get_flags (value);
-		break;
-	case PROP_APP_ISCSI_PRIORITY:
-		priv->app_iscsi_priority = g_value_get_int (value);
-		break;
-	case PROP_APP_FIP_FLAGS:
-		priv->app_fip_flags = g_value_get_flags (value);
-		break;
-	case PROP_APP_FIP_PRIORITY:
-		priv->app_fip_priority = g_value_get_int (value);
-		break;
-	case PROP_PFC_FLAGS:
-		priv->pfc_flags = g_value_get_flags (value);
-		break;
-	case PROP_PRIORITY_FLOW_CONTROL:
-		SET_ARRAY_FROM_GVALUE (value, priv->pfc);
-		break;
-	case PROP_PRIORITY_GROUP_FLAGS:
-		priv->priority_group_flags = g_value_get_flags (value);
-		break;
-	case PROP_PRIORITY_GROUP_ID:
-		SET_ARRAY_FROM_GVALUE (value, priv->priority_group_id);
-		break;
-	case PROP_PRIORITY_GROUP_BANDWIDTH:
-		SET_ARRAY_FROM_GVALUE (value, priv->priority_group_bandwidth);
-		break;
-	case PROP_PRIORITY_BANDWIDTH:
-		SET_ARRAY_FROM_GVALUE (value, priv->priority_bandwidth);
-		break;
-	case PROP_PRIORITY_STRICT_BANDWIDTH:
-		SET_ARRAY_FROM_GVALUE (value, priv->priority_strict);
-		break;
-	case PROP_PRIORITY_TRAFFIC_CLASS:
-		SET_ARRAY_FROM_GVALUE (value, priv->priority_traffic_class);
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
-}
+/*****************************************************************************/
 
 static void
 get_property (GObject *object, guint prop_id,
@@ -893,6 +823,85 @@ get_property (GObject *object, guint prop_id,
 }
 
 static void
+set_property (GObject *object, guint prop_id,
+              const GValue *value, GParamSpec *pspec)
+{
+	NMSettingDcbPrivate *priv = NM_SETTING_DCB_GET_PRIVATE (object);
+
+	switch (prop_id) {
+	case PROP_APP_FCOE_FLAGS:
+		priv->app_fcoe_flags = g_value_get_flags (value);
+		break;
+	case PROP_APP_FCOE_PRIORITY:
+		priv->app_fcoe_priority = g_value_get_int (value);
+		break;
+	case PROP_APP_FCOE_MODE:
+		g_free (priv->app_fcoe_mode);
+		priv->app_fcoe_mode = g_value_dup_string (value);
+		break;
+	case PROP_APP_ISCSI_FLAGS:
+		priv->app_iscsi_flags = g_value_get_flags (value);
+		break;
+	case PROP_APP_ISCSI_PRIORITY:
+		priv->app_iscsi_priority = g_value_get_int (value);
+		break;
+	case PROP_APP_FIP_FLAGS:
+		priv->app_fip_flags = g_value_get_flags (value);
+		break;
+	case PROP_APP_FIP_PRIORITY:
+		priv->app_fip_priority = g_value_get_int (value);
+		break;
+	case PROP_PFC_FLAGS:
+		priv->pfc_flags = g_value_get_flags (value);
+		break;
+	case PROP_PRIORITY_FLOW_CONTROL:
+		SET_ARRAY_FROM_GVALUE (value, priv->pfc);
+		break;
+	case PROP_PRIORITY_GROUP_FLAGS:
+		priv->priority_group_flags = g_value_get_flags (value);
+		break;
+	case PROP_PRIORITY_GROUP_ID:
+		SET_ARRAY_FROM_GVALUE (value, priv->priority_group_id);
+		break;
+	case PROP_PRIORITY_GROUP_BANDWIDTH:
+		SET_ARRAY_FROM_GVALUE (value, priv->priority_group_bandwidth);
+		break;
+	case PROP_PRIORITY_BANDWIDTH:
+		SET_ARRAY_FROM_GVALUE (value, priv->priority_bandwidth);
+		break;
+	case PROP_PRIORITY_STRICT_BANDWIDTH:
+		SET_ARRAY_FROM_GVALUE (value, priv->priority_strict);
+		break;
+	case PROP_PRIORITY_TRAFFIC_CLASS:
+		SET_ARRAY_FROM_GVALUE (value, priv->priority_traffic_class);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
+}
+
+/*****************************************************************************/
+
+static void
+nm_setting_dcb_init (NMSettingDcb *setting)
+{
+}
+
+/**
+ * nm_setting_dcb_new:
+ *
+ * Creates a new #NMSettingDcb object with default values.
+ *
+ * Returns: (transfer full): the new empty #NMSettingDcb object
+ **/
+NMSetting *
+nm_setting_dcb_new (void)
+{
+	return (NMSetting *) g_object_new (NM_TYPE_SETTING_DCB, NULL);
+}
+
+static void
 finalize (GObject *object)
 {
 	NMSettingDcbPrivate *priv = NM_SETTING_DCB_GET_PRIVATE (object);
@@ -911,9 +920,9 @@ nm_setting_dcb_class_init (NMSettingDcbClass *klass)
 
 	g_type_class_add_private (klass, sizeof (NMSettingDcbPrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
-	object_class->finalize = finalize;
+	object_class->set_property = set_property;
+	object_class->finalize     = finalize;
 
 	setting_class->verify = verify;
 

--- a/libnm-core/nm-setting-dummy.c
+++ b/libnm-core/nm-setting-dummy.c
@@ -34,7 +34,27 @@
  * necessary for connection to dummy devices
  **/
 
+/*****************************************************************************/
+
 G_DEFINE_TYPE (NMSettingDummy, nm_setting_dummy, NM_TYPE_SETTING)
+
+/*****************************************************************************/
+
+static gboolean
+verify (NMSetting *setting, NMConnection *connection, GError **error)
+{
+	if (!_nm_connection_verify_required_interface_name (connection, error))
+		return FALSE;
+
+	return TRUE;
+}
+
+/*****************************************************************************/
+
+static void
+nm_setting_dummy_init (NMSettingDummy *setting)
+{
+}
 
 /**
  * nm_setting_dummy_new:
@@ -49,20 +69,6 @@ NMSetting *
 nm_setting_dummy_new (void)
 {
 	return (NMSetting *) g_object_new (NM_TYPE_SETTING_DUMMY, NULL);
-}
-
-static gboolean
-verify (NMSetting *setting, NMConnection *connection, GError **error)
-{
-	if (!_nm_connection_verify_required_interface_name (connection, error))
-		return FALSE;
-
-	return TRUE;
-}
-
-static void
-nm_setting_dummy_init (NMSettingDummy *setting)
-{
 }
 
 static void

--- a/libnm-core/nm-setting-generic.c
+++ b/libnm-core/nm-setting-generic.c
@@ -22,6 +22,7 @@
 #include "nm-default.h"
 
 #include "nm-setting-generic.h"
+
 #include "nm-setting-private.h"
 
 /**
@@ -36,15 +37,22 @@
  * the "connection type" setting on #NMConnections for generic devices.
  **/
 
-G_DEFINE_TYPE (NMSettingGeneric, nm_setting_generic, NM_TYPE_SETTING)
-
-#define NM_SETTING_GENERIC_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_GENERIC, NMSettingGenericPrivate))
+/*****************************************************************************/
 
 typedef struct {
 	int dummy;
 } NMSettingGenericPrivate;
 
+G_DEFINE_TYPE (NMSettingGeneric, nm_setting_generic, NM_TYPE_SETTING)
+
+#define NM_SETTING_GENERIC_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_GENERIC, NMSettingGenericPrivate))
+
 /*****************************************************************************/
+
+static void
+nm_setting_generic_init (NMSettingGeneric *setting)
+{
+}
 
 /**
  * nm_setting_generic_new:
@@ -57,11 +65,6 @@ NMSetting *
 nm_setting_generic_new (void)
 {
 	return (NMSetting *) g_object_new (NM_TYPE_SETTING_GENERIC, NULL);
-}
-
-static void
-nm_setting_generic_init (NMSettingGeneric *setting)
-{
 }
 
 static void

--- a/libnm-core/nm-setting-gsm.c
+++ b/libnm-core/nm-setting-gsm.c
@@ -22,9 +22,10 @@
 
 #include "nm-default.h"
 
+#include "nm-setting-gsm.h"
+
 #include <string.h>
 
-#include "nm-setting-gsm.h"
 #include "nm-utils.h"
 #include "nm-setting-private.h"
 #include "nm-core-enum-types.h"
@@ -38,9 +39,23 @@
  * networks, including those using GPRS/EDGE and UMTS/HSPA technology.
  */
 
-G_DEFINE_TYPE (NMSettingGsm, nm_setting_gsm, NM_TYPE_SETTING)
+/*****************************************************************************/
 
-#define NM_SETTING_GSM_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_GSM, NMSettingGsmPrivate))
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
+	PROP_NUMBER,
+	PROP_USERNAME,
+	PROP_PASSWORD,
+	PROP_PASSWORD_FLAGS,
+	PROP_APN,
+	PROP_NETWORK_ID,
+	PROP_PIN,
+	PROP_PIN_FLAGS,
+	PROP_HOME_ONLY,
+	PROP_DEVICE_ID,
+	PROP_SIM_ID,
+	PROP_SIM_OPERATOR_ID,
+	PROP_MTU,
+);
 
 typedef struct {
 	char *number; /* For dialing, duh */
@@ -63,34 +78,11 @@ typedef struct {
 	guint32 mtu;
 } NMSettingGsmPrivate;
 
-NM_GOBJECT_PROPERTIES_DEFINE_BASE (
-	PROP_NUMBER,
-	PROP_USERNAME,
-	PROP_PASSWORD,
-	PROP_PASSWORD_FLAGS,
-	PROP_APN,
-	PROP_NETWORK_ID,
-	PROP_PIN,
-	PROP_PIN_FLAGS,
-	PROP_HOME_ONLY,
-	PROP_DEVICE_ID,
-	PROP_SIM_ID,
-	PROP_SIM_OPERATOR_ID,
-	PROP_MTU,
-);
+G_DEFINE_TYPE (NMSettingGsm, nm_setting_gsm, NM_TYPE_SETTING)
 
-/**
- * nm_setting_gsm_new:
- *
- * Creates a new #NMSettingGsm object with default values.
- *
- * Returns: the new empty #NMSettingGsm object
- **/
-NMSetting *
-nm_setting_gsm_new (void)
-{
-	return (NMSetting *) g_object_new (NM_TYPE_SETTING_GSM, NULL);
-}
+#define NM_SETTING_GSM_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_GSM, NMSettingGsmPrivate))
+
+/*****************************************************************************/
 
 /**
  * nm_setting_gsm_get_number:
@@ -457,27 +449,58 @@ need_secrets (NMSetting *setting)
 	return secrets;
 }
 
-static void
-nm_setting_gsm_init (NMSettingGsm *setting)
-{
-}
+/*****************************************************************************/
 
 static void
-finalize (GObject *object)
+get_property (GObject *object, guint prop_id,
+              GValue *value, GParamSpec *pspec)
 {
-	NMSettingGsmPrivate *priv = NM_SETTING_GSM_GET_PRIVATE (object);
+	NMSettingGsm *setting = NM_SETTING_GSM (object);
 
-	g_free (priv->number);
-	g_free (priv->username);
-	g_free (priv->password);
-	g_free (priv->apn);
-	g_free (priv->network_id);
-	g_free (priv->pin);
-	g_free (priv->device_id);
-	g_free (priv->sim_id);
-	g_free (priv->sim_operator_id);
-
-	G_OBJECT_CLASS (nm_setting_gsm_parent_class)->finalize (object);
+	switch (prop_id) {
+	case PROP_NUMBER:
+		g_value_set_string (value, nm_setting_gsm_get_number (setting));
+		break;
+	case PROP_USERNAME:
+		g_value_set_string (value, nm_setting_gsm_get_username (setting));
+		break;
+	case PROP_PASSWORD:
+		g_value_set_string (value, nm_setting_gsm_get_password (setting));
+		break;
+	case PROP_PASSWORD_FLAGS:
+		g_value_set_flags (value, nm_setting_gsm_get_password_flags (setting));
+		break;
+	case PROP_APN:
+		g_value_set_string (value, nm_setting_gsm_get_apn (setting));
+		break;
+	case PROP_NETWORK_ID:
+		g_value_set_string (value, nm_setting_gsm_get_network_id (setting));
+		break;
+	case PROP_PIN:
+		g_value_set_string (value, nm_setting_gsm_get_pin (setting));
+		break;
+	case PROP_PIN_FLAGS:
+		g_value_set_flags (value, nm_setting_gsm_get_pin_flags (setting));
+		break;
+	case PROP_HOME_ONLY:
+		g_value_set_boolean (value, nm_setting_gsm_get_home_only (setting));
+		break;
+	case PROP_DEVICE_ID:
+		g_value_set_string (value, nm_setting_gsm_get_device_id (setting));
+		break;
+	case PROP_SIM_ID:
+		g_value_set_string (value, nm_setting_gsm_get_sim_id (setting));
+		break;
+	case PROP_SIM_OPERATOR_ID:
+		g_value_set_string (value, nm_setting_gsm_get_sim_operator_id (setting));
+		break;
+	case PROP_MTU:
+		g_value_set_uint (value, nm_setting_gsm_get_mtu (setting));
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
 }
 
 static void
@@ -548,56 +571,42 @@ set_property (GObject *object, guint prop_id,
 	}
 }
 
-static void
-get_property (GObject *object, guint prop_id,
-              GValue *value, GParamSpec *pspec)
-{
-	NMSettingGsm *setting = NM_SETTING_GSM (object);
+/*****************************************************************************/
 
-	switch (prop_id) {
-	case PROP_NUMBER:
-		g_value_set_string (value, nm_setting_gsm_get_number (setting));
-		break;
-	case PROP_USERNAME:
-		g_value_set_string (value, nm_setting_gsm_get_username (setting));
-		break;
-	case PROP_PASSWORD:
-		g_value_set_string (value, nm_setting_gsm_get_password (setting));
-		break;
-	case PROP_PASSWORD_FLAGS:
-		g_value_set_flags (value, nm_setting_gsm_get_password_flags (setting));
-		break;
-	case PROP_APN:
-		g_value_set_string (value, nm_setting_gsm_get_apn (setting));
-		break;
-	case PROP_NETWORK_ID:
-		g_value_set_string (value, nm_setting_gsm_get_network_id (setting));
-		break;
-	case PROP_PIN:
-		g_value_set_string (value, nm_setting_gsm_get_pin (setting));
-		break;
-	case PROP_PIN_FLAGS:
-		g_value_set_flags (value, nm_setting_gsm_get_pin_flags (setting));
-		break;
-	case PROP_HOME_ONLY:
-		g_value_set_boolean (value, nm_setting_gsm_get_home_only (setting));
-		break;
-	case PROP_DEVICE_ID:
-		g_value_set_string (value, nm_setting_gsm_get_device_id (setting));
-		break;
-	case PROP_SIM_ID:
-		g_value_set_string (value, nm_setting_gsm_get_sim_id (setting));
-		break;
-	case PROP_SIM_OPERATOR_ID:
-		g_value_set_string (value, nm_setting_gsm_get_sim_operator_id (setting));
-		break;
-	case PROP_MTU:
-		g_value_set_uint (value, nm_setting_gsm_get_mtu (setting));
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
+static void
+nm_setting_gsm_init (NMSettingGsm *setting)
+{
+}
+
+/**
+ * nm_setting_gsm_new:
+ *
+ * Creates a new #NMSettingGsm object with default values.
+ *
+ * Returns: the new empty #NMSettingGsm object
+ **/
+NMSetting *
+nm_setting_gsm_new (void)
+{
+	return (NMSetting *) g_object_new (NM_TYPE_SETTING_GSM, NULL);
+}
+
+static void
+finalize (GObject *object)
+{
+	NMSettingGsmPrivate *priv = NM_SETTING_GSM_GET_PRIVATE (object);
+
+	g_free (priv->number);
+	g_free (priv->username);
+	g_free (priv->password);
+	g_free (priv->apn);
+	g_free (priv->network_id);
+	g_free (priv->pin);
+	g_free (priv->device_id);
+	g_free (priv->sim_id);
+	g_free (priv->sim_operator_id);
+
+	G_OBJECT_CLASS (nm_setting_gsm_parent_class)->finalize (object);
 }
 
 static void
@@ -609,8 +618,8 @@ nm_setting_gsm_class_init (NMSettingGsmClass *klass)
 
 	g_type_class_add_private (klass, sizeof (NMSettingGsmPrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->verify         = verify;

--- a/libnm-core/nm-setting-gsm.c
+++ b/libnm-core/nm-setting-gsm.c
@@ -63,8 +63,7 @@ typedef struct {
 	guint32 mtu;
 } NMSettingGsmPrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_NUMBER,
 	PROP_USERNAME,
 	PROP_PASSWORD,
@@ -78,9 +77,7 @@ enum {
 	PROP_SIM_ID,
 	PROP_SIM_OPERATOR_ID,
 	PROP_MTU,
-
-	LAST_PROP
-};
+);
 
 /**
  * nm_setting_gsm_new:
@@ -628,12 +625,11 @@ nm_setting_gsm_class_init (NMSettingGsmClass *klass)
 	 *
 	 * Deprecated: 1.16: user-provided values for this setting are no longer used.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_NUMBER,
-		 g_param_spec_string (NM_SETTING_GSM_NUMBER, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_NUMBER] =
+	    g_param_spec_string (NM_SETTING_GSM_NUMBER, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingGsm:username:
@@ -642,12 +638,11 @@ nm_setting_gsm_class_init (NMSettingGsmClass *klass)
 	 * providers do not require a username, or accept any username.  But if a
 	 * username is required, it is specified here.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_USERNAME,
-		 g_param_spec_string (NM_SETTING_GSM_USERNAME, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_USERNAME] =
+	    g_param_spec_string (NM_SETTING_GSM_USERNAME, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingGsm:password:
@@ -656,26 +651,24 @@ nm_setting_gsm_class_init (NMSettingGsmClass *klass)
 	 * providers do not require a password, or accept any password.  But if a
 	 * password is required, it is specified here.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_PASSWORD,
-		 g_param_spec_string (NM_SETTING_GSM_PASSWORD, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_SECRET |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PASSWORD] =
+	    g_param_spec_string (NM_SETTING_GSM_PASSWORD, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_SECRET |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingGsm:password-flags:
 	 *
 	 * Flags indicating how to handle the #NMSettingGsm:password property.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_PASSWORD_FLAGS,
-		 g_param_spec_flags (NM_SETTING_GSM_PASSWORD_FLAGS, "", "",
-		                     NM_TYPE_SETTING_SECRET_FLAGS,
-		                     NM_SETTING_SECRET_FLAG_NONE,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PASSWORD_FLAGS] =
+	    g_param_spec_flags (NM_SETTING_GSM_PASSWORD_FLAGS, "", "",
+	                        NM_TYPE_SETTING_SECRET_FLAGS,
+	                        NM_SETTING_SECRET_FLAG_NONE,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingGsm:apn:
@@ -688,12 +681,11 @@ nm_setting_gsm_class_init (NMSettingGsmClass *klass)
 	 * The APN may only be composed of the characters a-z, 0-9, ., and - per GSM
 	 * 03.60 Section 14.9.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_APN,
-		 g_param_spec_string (NM_SETTING_GSM_APN, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_APN] =
+	    g_param_spec_string (NM_SETTING_GSM_APN, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingGsm:network-id:
@@ -704,12 +696,11 @@ nm_setting_gsm_class_init (NMSettingGsmClass *klass)
 	 * This can be used to ensure that the device does not roam when direct
 	 * roaming control of the device is not otherwise possible.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_NETWORK_ID,
-		 g_param_spec_string (NM_SETTING_GSM_NETWORK_ID, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_NETWORK_ID] =
+	    g_param_spec_string (NM_SETTING_GSM_NETWORK_ID, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingGsm:pin:
@@ -718,26 +709,24 @@ nm_setting_gsm_class_init (NMSettingGsmClass *klass)
 	 * operations are requested.  Specify the PIN here to allow operation of the
 	 * device.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_PIN,
-		 g_param_spec_string (NM_SETTING_GSM_PIN, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_SECRET |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PIN] =
+	    g_param_spec_string (NM_SETTING_GSM_PIN, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_SECRET |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingGsm:pin-flags:
 	 *
 	 * Flags indicating how to handle the #NMSettingGsm:pin property.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_PIN_FLAGS,
-		 g_param_spec_flags (NM_SETTING_GSM_PIN_FLAGS, "", "",
-		                     NM_TYPE_SETTING_SECRET_FLAGS,
-		                     NM_SETTING_SECRET_FLAG_NONE,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PIN_FLAGS] =
+	    g_param_spec_flags (NM_SETTING_GSM_PIN_FLAGS, "", "",
+	                        NM_TYPE_SETTING_SECRET_FLAGS,
+	                        NM_SETTING_SECRET_FLAG_NONE,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingGsm:home-only:
@@ -745,12 +734,11 @@ nm_setting_gsm_class_init (NMSettingGsmClass *klass)
 	 * When %TRUE, only connections to the home network will be allowed.
 	 * Connections to roaming networks will not be made.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_HOME_ONLY,
-		 g_param_spec_boolean (NM_SETTING_GSM_HOME_ONLY, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_HOME_ONLY] =
+	    g_param_spec_boolean (NM_SETTING_GSM_HOME_ONLY, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingGsm:device-id:
@@ -761,12 +749,11 @@ nm_setting_gsm_class_init (NMSettingGsmClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_DEVICE_ID,
-		 g_param_spec_string (NM_SETTING_GSM_DEVICE_ID, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_DEVICE_ID] =
+	    g_param_spec_string (NM_SETTING_GSM_DEVICE_ID, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingGsm:sim-id:
@@ -778,12 +765,11 @@ nm_setting_gsm_class_init (NMSettingGsmClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_SIM_ID,
-		 g_param_spec_string (NM_SETTING_GSM_SIM_ID, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_SIM_ID] =
+	    g_param_spec_string (NM_SETTING_GSM_SIM_ID, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingGsm:sim-operator-id:
@@ -796,12 +782,11 @@ nm_setting_gsm_class_init (NMSettingGsmClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_SIM_OPERATOR_ID,
-		 g_param_spec_string (NM_SETTING_GSM_SIM_OPERATOR_ID, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_SIM_OPERATOR_ID] =
+	    g_param_spec_string (NM_SETTING_GSM_SIM_OPERATOR_ID, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingGsm:mtu:
@@ -811,14 +796,13 @@ nm_setting_gsm_class_init (NMSettingGsmClass *klass)
 	 *
 	 * Since: 1.8
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_MTU,
-		 g_param_spec_uint (NM_SETTING_GSM_MTU, "", "",
-		                    0, G_MAXUINT32, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_FUZZY_IGNORE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MTU] =
+	    g_param_spec_uint (NM_SETTING_GSM_MTU, "", "",
+	                       0, G_MAXUINT32, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_FUZZY_IGNORE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/* Ignore incoming deprecated properties */
 	_properties_override_add_dbus_only (properties_override,
@@ -832,6 +816,8 @@ nm_setting_gsm_class_init (NMSettingGsmClass *klass)
 	                                    G_VARIANT_TYPE_INT32,
 	                                    NULL,
 	                                    NULL);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit_full (setting_class, NM_META_SETTING_TYPE_GSM,
 	                               NULL, properties_override);

--- a/libnm-core/nm-setting-infiniband.c
+++ b/libnm-core/nm-setting-infiniband.c
@@ -21,9 +21,10 @@
 
 #include "nm-default.h"
 
+#include "nm-setting-infiniband.h"
+
 #include <stdlib.h>
 
-#include "nm-setting-infiniband.h"
 #include "nm-utils.h"
 #include "nm-utils-private.h"
 #include "nm-setting-private.h"
@@ -37,17 +38,7 @@
  * necessary for connection to IP-over-InfiniBand networks.
  **/
 
-G_DEFINE_TYPE (NMSettingInfiniband, nm_setting_infiniband, NM_TYPE_SETTING)
-
-#define NM_SETTING_INFINIBAND_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_INFINIBAND, NMSettingInfinibandPrivate))
-
-typedef struct {
-	char *mac_address;
-	char *transport_mode;
-	guint32 mtu;
-	int p_key;
-	char *parent, *virtual_iface_name;
-} NMSettingInfinibandPrivate;
+/*****************************************************************************/
 
 NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_MAC_ADDRESS,
@@ -57,18 +48,19 @@ NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_PARENT,
 );
 
-/**
- * nm_setting_infiniband_new:
- *
- * Creates a new #NMSettingInfiniband object with default values.
- *
- * Returns: (transfer full): the new empty #NMSettingInfiniband object
- **/
-NMSetting *
-nm_setting_infiniband_new (void)
-{
-	return (NMSetting *) g_object_new (NM_TYPE_SETTING_INFINIBAND, NULL);
-}
+typedef struct {
+	char *mac_address;
+	char *transport_mode;
+	guint32 mtu;
+	int p_key;
+	char *parent, *virtual_iface_name;
+} NMSettingInfinibandPrivate;
+
+G_DEFINE_TYPE (NMSettingInfiniband, nm_setting_infiniband, NM_TYPE_SETTING)
+
+#define NM_SETTING_INFINIBAND_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_INFINIBAND, NMSettingInfinibandPrivate))
+
+/*****************************************************************************/
 
 /**
  * nm_setting_infiniband_get_mac_address:
@@ -292,22 +284,34 @@ verify (NMSetting *setting, NMConnection *connection, GError **error)
 	return TRUE;
 }
 
-static void
-nm_setting_infiniband_init (NMSettingInfiniband *setting)
-{
-}
+/*****************************************************************************/
 
 static void
-finalize (GObject *object)
+get_property (GObject *object, guint prop_id,
+              GValue *value, GParamSpec *pspec)
 {
-	NMSettingInfinibandPrivate *priv = NM_SETTING_INFINIBAND_GET_PRIVATE (object);
+	NMSettingInfiniband *setting = NM_SETTING_INFINIBAND (object);
 
-	g_free (priv->transport_mode);
-	g_free (priv->mac_address);
-	g_free (priv->parent);
-	g_free (priv->virtual_iface_name);
-
-	G_OBJECT_CLASS (nm_setting_infiniband_parent_class)->finalize (object);
+	switch (prop_id) {
+	case PROP_MAC_ADDRESS:
+		g_value_set_string (value, nm_setting_infiniband_get_mac_address (setting));
+		break;
+	case PROP_MTU:
+		g_value_set_uint (value, nm_setting_infiniband_get_mtu (setting));
+		break;
+	case PROP_TRANSPORT_MODE:
+		g_value_set_string (value, nm_setting_infiniband_get_transport_mode (setting));
+		break;
+	case PROP_P_KEY:
+		g_value_set_int (value, nm_setting_infiniband_get_p_key (setting));
+		break;
+	case PROP_PARENT:
+		g_value_set_string (value, nm_setting_infiniband_get_parent (setting));
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
 }
 
 static void
@@ -344,32 +348,37 @@ set_property (GObject *object, guint prop_id,
 	}
 }
 
-static void
-get_property (GObject *object, guint prop_id,
-              GValue *value, GParamSpec *pspec)
-{
-	NMSettingInfiniband *setting = NM_SETTING_INFINIBAND (object);
+/*****************************************************************************/
 
-	switch (prop_id) {
-	case PROP_MAC_ADDRESS:
-		g_value_set_string (value, nm_setting_infiniband_get_mac_address (setting));
-		break;
-	case PROP_MTU:
-		g_value_set_uint (value, nm_setting_infiniband_get_mtu (setting));
-		break;
-	case PROP_TRANSPORT_MODE:
-		g_value_set_string (value, nm_setting_infiniband_get_transport_mode (setting));
-		break;
-	case PROP_P_KEY:
-		g_value_set_int (value, nm_setting_infiniband_get_p_key (setting));
-		break;
-	case PROP_PARENT:
-		g_value_set_string (value, nm_setting_infiniband_get_parent (setting));
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
+static void
+nm_setting_infiniband_init (NMSettingInfiniband *setting)
+{
+}
+
+/**
+ * nm_setting_infiniband_new:
+ *
+ * Creates a new #NMSettingInfiniband object with default values.
+ *
+ * Returns: (transfer full): the new empty #NMSettingInfiniband object
+ **/
+NMSetting *
+nm_setting_infiniband_new (void)
+{
+	return (NMSetting *) g_object_new (NM_TYPE_SETTING_INFINIBAND, NULL);
+}
+
+static void
+finalize (GObject *object)
+{
+	NMSettingInfinibandPrivate *priv = NM_SETTING_INFINIBAND_GET_PRIVATE (object);
+
+	g_free (priv->transport_mode);
+	g_free (priv->mac_address);
+	g_free (priv->parent);
+	g_free (priv->virtual_iface_name);
+
+	G_OBJECT_CLASS (nm_setting_infiniband_parent_class)->finalize (object);
 }
 
 static void
@@ -381,8 +390,8 @@ nm_setting_infiniband_class_init (NMSettingInfinibandClass *klass)
 
 	g_type_class_add_private (klass, sizeof (NMSettingInfinibandPrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->verify = verify;

--- a/libnm-core/nm-setting-infiniband.c
+++ b/libnm-core/nm-setting-infiniband.c
@@ -49,16 +49,13 @@ typedef struct {
 	char *parent, *virtual_iface_name;
 } NMSettingInfinibandPrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_MAC_ADDRESS,
 	PROP_MTU,
 	PROP_TRANSPORT_MODE,
 	PROP_P_KEY,
 	PROP_PARENT,
-
-	LAST_PROP
-};
+);
 
 /**
  * nm_setting_infiniband_new:
@@ -415,17 +412,15 @@ nm_setting_infiniband_class_init (NMSettingInfinibandClass *klass)
 	 * example: HWADDR=01:02:03:04:05:06:07:08:09:0A:01:02:03:04:05:06:07:08:09:11
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_MAC_ADDRESS,
-		 g_param_spec_string (NM_SETTING_INFINIBAND_MAC_ADDRESS, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MAC_ADDRESS] =
+	    g_param_spec_string (NM_SETTING_INFINIBAND_MAC_ADDRESS, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_transform (properties_override,
-	                                    g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                  NM_SETTING_INFINIBAND_MAC_ADDRESS),
+	                                    obj_properties[PROP_MAC_ADDRESS],
 	                                    G_VARIANT_TYPE_BYTESTRING,
 	                                    _nm_utils_hwaddr_to_dbus,
 	                                    _nm_utils_hwaddr_from_dbus);
@@ -442,14 +437,13 @@ nm_setting_infiniband_class_init (NMSettingInfinibandClass *klass)
 	 * description: MTU of the interface.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_MTU,
-		 g_param_spec_uint (NM_SETTING_INFINIBAND_MTU, "", "",
-		                    0, G_MAXUINT32, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_FUZZY_IGNORE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MTU] =
+	    g_param_spec_uint (NM_SETTING_INFINIBAND_MTU, "", "",
+	                       0, G_MAXUINT32, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_FUZZY_IGNORE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingInfiniband:transport-mode:
@@ -465,14 +459,13 @@ nm_setting_infiniband_class_init (NMSettingInfinibandClass *klass)
 	 *   "datagram" mode
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_TRANSPORT_MODE,
-		 g_param_spec_string (NM_SETTING_INFINIBAND_TRANSPORT_MODE, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_CONSTRUCT |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_TRANSPORT_MODE] =
+	    g_param_spec_string (NM_SETTING_INFINIBAND_TRANSPORT_MODE, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_CONSTRUCT |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingInfiniband:p-key:
@@ -492,14 +485,13 @@ nm_setting_infiniband_class_init (NMSettingInfinibandClass *klass)
 	 * example: PKEY=yes PKEY_ID=2 PHYSDEV=mlx4_ib0 DEVICE=mlx4_ib0.8002
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_P_KEY,
-		 g_param_spec_int (NM_SETTING_INFINIBAND_P_KEY, "", "",
-		                   -1, 0xFFFF, -1,
-		                   G_PARAM_READWRITE |
-		                   G_PARAM_CONSTRUCT |
-		                   NM_SETTING_PARAM_INFERRABLE |
-		                   G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_P_KEY] =
+	    g_param_spec_int (NM_SETTING_INFINIBAND_P_KEY, "", "",
+	                      -1, 0xFFFF, -1,
+	                      G_PARAM_READWRITE |
+	                      G_PARAM_CONSTRUCT |
+	                      NM_SETTING_PARAM_INFERRABLE |
+	                      G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingInfiniband:parent:
@@ -517,14 +509,15 @@ nm_setting_infiniband_class_init (NMSettingInfinibandClass *klass)
 	 * example: PHYSDEV=ib0
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_PARENT,
-		 g_param_spec_string (NM_SETTING_INFINIBAND_PARENT, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_CONSTRUCT |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PARENT] =
+	    g_param_spec_string (NM_SETTING_INFINIBAND_PARENT, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_CONSTRUCT |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit_full (setting_class, NM_META_SETTING_TYPE_INFINIBAND,
 	                               NULL, properties_override);

--- a/libnm-core/nm-setting-ip-config.c
+++ b/libnm-core/nm-setting-ip-config.c
@@ -1407,8 +1407,7 @@ typedef struct {
 	int dhcp_timeout;
 } NMSettingIPConfigPrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE (NMSettingIPConfig,
 	PROP_METHOD,
 	PROP_DNS,
 	PROP_DNS_SEARCH,
@@ -1427,9 +1426,7 @@ enum {
 	PROP_MAY_FAIL,
 	PROP_DAD_TIMEOUT,
 	PROP_DHCP_TIMEOUT,
-
-	LAST_PROP
-};
+);
 
 #define NM_SETTING_IP_CONFIG_GET_FAMILY(setting) (NM_IS_SETTING_IP4_CONFIG (setting) ? AF_INET : AF_INET6)
 
@@ -1515,7 +1512,7 @@ nm_setting_ip_config_add_dns (NMSettingIPConfig *setting, const char *dns)
 	}
 
 	g_ptr_array_add (priv->dns, dns_canonical);
-	g_object_notify (G_OBJECT (setting), NM_SETTING_IP_CONFIG_DNS);
+	_notify (setting, PROP_DNS);
 	return TRUE;
 }
 
@@ -1537,7 +1534,7 @@ nm_setting_ip_config_remove_dns (NMSettingIPConfig *setting, int idx)
 	g_return_if_fail (idx >= 0 && idx < priv->dns->len);
 
 	g_ptr_array_remove_index (priv->dns, idx);
-	g_object_notify (G_OBJECT (setting), NM_SETTING_IP_CONFIG_DNS);
+	_notify (setting, PROP_DNS);
 }
 
 /**
@@ -1566,7 +1563,7 @@ nm_setting_ip_config_remove_dns_by_value (NMSettingIPConfig *setting, const char
 	for (i = 0; i < priv->dns->len; i++) {
 		if (!strcmp (dns_canonical, priv->dns->pdata[i])) {
 			g_ptr_array_remove_index (priv->dns, i);
-			g_object_notify (G_OBJECT (setting), NM_SETTING_IP_CONFIG_DNS);
+			_notify (setting, PROP_DNS);
 			g_free (dns_canonical);
 			return TRUE;
 		}
@@ -1592,7 +1589,7 @@ nm_setting_ip_config_clear_dns (NMSettingIPConfig *setting)
 
 	if (priv->dns->len != 0) {
 		g_ptr_array_set_size (priv->dns, 0);
-		g_object_notify (G_OBJECT (setting), NM_SETTING_IP_CONFIG_DNS);
+		_notify (setting, PROP_DNS);
 	}
 }
 
@@ -1658,7 +1655,7 @@ nm_setting_ip_config_add_dns_search (NMSettingIPConfig *setting,
 	}
 
 	g_ptr_array_add (priv->dns_search, g_strdup (dns_search));
-	g_object_notify (G_OBJECT (setting), NM_SETTING_IP_CONFIG_DNS_SEARCH);
+	_notify (setting, PROP_DNS_SEARCH);
 	return TRUE;
 }
 
@@ -1680,7 +1677,7 @@ nm_setting_ip_config_remove_dns_search (NMSettingIPConfig *setting, int idx)
 	g_return_if_fail (idx >= 0 && idx < priv->dns_search->len);
 
 	g_ptr_array_remove_index (priv->dns_search, idx);
-	g_object_notify (G_OBJECT (setting), NM_SETTING_IP_CONFIG_DNS_SEARCH);
+	_notify (setting, PROP_DNS_SEARCH);
 }
 
 /**
@@ -1707,7 +1704,7 @@ nm_setting_ip_config_remove_dns_search_by_value (NMSettingIPConfig *setting,
 	for (i = 0; i < priv->dns_search->len; i++) {
 		if (!strcmp (dns_search, priv->dns_search->pdata[i])) {
 			g_ptr_array_remove_index (priv->dns_search, i);
-			g_object_notify (G_OBJECT (setting), NM_SETTING_IP_CONFIG_DNS_SEARCH);
+			_notify (setting, PROP_DNS_SEARCH);
 			return TRUE;
 		}
 	}
@@ -1731,7 +1728,7 @@ nm_setting_ip_config_clear_dns_searches (NMSettingIPConfig *setting)
 
 	if (priv->dns_search->len != 0) {
 		g_ptr_array_set_size (priv->dns_search, 0);
-		g_object_notify (G_OBJECT (setting), NM_SETTING_IP_CONFIG_DNS_SEARCH);
+		_notify (setting, PROP_DNS_SEARCH);
 	}
 }
 
@@ -1863,7 +1860,7 @@ nm_setting_ip_config_add_dns_option (NMSettingIPConfig *setting,
 	}
 
 	g_ptr_array_add (priv->dns_options, g_strdup (dns_option));
-	g_object_notify (G_OBJECT (setting), NM_SETTING_IP_CONFIG_DNS_OPTIONS);
+	_notify (setting, PROP_DNS_OPTIONS);
 	return TRUE;
 }
 
@@ -1888,7 +1885,7 @@ nm_setting_ip_config_remove_dns_option (NMSettingIPConfig *setting, int idx)
 	g_return_if_fail (idx >= 0 && idx < priv->dns_options->len);
 
 	g_ptr_array_remove_index (priv->dns_options, idx);
-	g_object_notify (G_OBJECT (setting), NM_SETTING_IP_CONFIG_DNS_OPTIONS);
+	_notify (setting, PROP_DNS_OPTIONS);
 }
 
 /**
@@ -1920,7 +1917,7 @@ nm_setting_ip_config_remove_dns_option_by_value (NMSettingIPConfig *setting,
 	i = _nm_utils_dns_option_find_idx (priv->dns_options, dns_option);
 	if (i >= 0) {
 		g_ptr_array_remove_index (priv->dns_options, i);
-		g_object_notify (G_OBJECT (setting), NM_SETTING_IP_CONFIG_DNS_OPTIONS);
+		_notify (setting, PROP_DNS_OPTIONS);
 		return TRUE;
 	}
 
@@ -1959,7 +1956,7 @@ nm_setting_ip_config_clear_dns_options (NMSettingIPConfig *setting, gboolean is_
 			g_ptr_array_set_size (priv->dns_options, 0);
 		}
 	}
-	g_object_notify (G_OBJECT (setting), NM_SETTING_IP_CONFIG_DNS_OPTIONS);
+	_notify (setting, PROP_DNS_OPTIONS);
 }
 
 /**
@@ -2042,7 +2039,7 @@ nm_setting_ip_config_add_address (NMSettingIPConfig *setting,
 
 	g_ptr_array_add (priv->addresses, nm_ip_address_dup (address));
 
-	g_object_notify (G_OBJECT (setting), NM_SETTING_IP_CONFIG_ADDRESSES);
+	_notify (setting, PROP_ADDRESSES);
 	return TRUE;
 }
 
@@ -2065,7 +2062,7 @@ nm_setting_ip_config_remove_address (NMSettingIPConfig *setting, int idx)
 
 	g_ptr_array_remove_index (priv->addresses, idx);
 
-	g_object_notify (G_OBJECT (setting), NM_SETTING_IP_CONFIG_ADDRESSES);
+	_notify (setting, PROP_ADDRESSES);
 }
 
 /**
@@ -2091,7 +2088,7 @@ nm_setting_ip_config_remove_address_by_value (NMSettingIPConfig *setting,
 	for (i = 0; i < priv->addresses->len; i++) {
 		if (nm_ip_address_equal (priv->addresses->pdata[i], address)) {
 			g_ptr_array_remove_index (priv->addresses, i);
-			g_object_notify (G_OBJECT (setting), NM_SETTING_IP_CONFIG_ADDRESSES);
+			_notify (setting, PROP_ADDRESSES);
 			return TRUE;
 		}
 	}
@@ -2113,7 +2110,7 @@ nm_setting_ip_config_clear_addresses (NMSettingIPConfig *setting)
 
 	if (priv->addresses->len != 0) {
 		g_ptr_array_set_size (priv->addresses, 0);
-		g_object_notify (G_OBJECT (setting), NM_SETTING_IP_CONFIG_ADDRESSES);
+		_notify (setting, PROP_ADDRESSES);
 	}
 }
 
@@ -2200,7 +2197,7 @@ nm_setting_ip_config_add_route (NMSettingIPConfig *setting,
 	}
 
 	g_ptr_array_add (priv->routes, nm_ip_route_dup (route));
-	g_object_notify (G_OBJECT (setting), NM_SETTING_IP_CONFIG_ROUTES);
+	_notify (setting, PROP_ROUTES);
 	return TRUE;
 }
 
@@ -2222,7 +2219,7 @@ nm_setting_ip_config_remove_route (NMSettingIPConfig *setting, int idx)
 	g_return_if_fail (idx >= 0 && idx < priv->routes->len);
 
 	g_ptr_array_remove_index (priv->routes, idx);
-	g_object_notify (G_OBJECT (setting), NM_SETTING_IP_CONFIG_ROUTES);
+	_notify (setting, PROP_ROUTES);
 }
 
 /**
@@ -2250,7 +2247,7 @@ nm_setting_ip_config_remove_route_by_value (NMSettingIPConfig *setting,
 	for (i = 0; i < priv->routes->len; i++) {
 		if (nm_ip_route_equal_full (priv->routes->pdata[i], route, NM_IP_ROUTE_EQUAL_CMP_FLAGS_WITH_ATTRS)) {
 			g_ptr_array_remove_index (priv->routes, i);
-			g_object_notify (G_OBJECT (setting), NM_SETTING_IP_CONFIG_ROUTES);
+			_notify (setting, PROP_ROUTES);
 			return TRUE;
 		}
 	}
@@ -2272,7 +2269,7 @@ nm_setting_ip_config_clear_routes (NMSettingIPConfig *setting)
 
 	if (priv->routes->len != 0) {
 		g_ptr_array_set_size (priv->routes, 0);
-		g_object_notify (G_OBJECT (setting), NM_SETTING_IP_CONFIG_ROUTES);
+		_notify (setting, PROP_ROUTES);
 	}
 }
 
@@ -2891,8 +2888,7 @@ _nm_sett_info_property_override_create_array_ip_config (void)
 	GArray *properties_override = _nm_sett_info_property_override_create_array ();
 
 	_properties_override_add_override (properties_override,
-	                                   g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                 NM_SETTING_IP_CONFIG_GATEWAY),
+	                                   obj_properties[PROP_GATEWAY],
 	                                   G_VARIANT_TYPE_STRING,
 	                                   NULL,
 	                                   ip_gateway_set,
@@ -2939,25 +2935,23 @@ nm_setting_ip_config_class_init (NMSettingIPConfigClass *klass)
 	 * shared method must be configured on the interface which shares the internet
 	 * to a subnet, not on the uplink which is shared.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_METHOD,
-		 g_param_spec_string (NM_SETTING_IP_CONFIG_METHOD, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_METHOD] =
+	    g_param_spec_string (NM_SETTING_IP_CONFIG_METHOD, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPConfig:dns:
 	 *
 	 * Array of IP addresses of DNS servers.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_DNS,
-		 g_param_spec_boxed (NM_SETTING_IP_CONFIG_DNS, "", "",
-		                     G_TYPE_STRV,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_DNS] =
+	    g_param_spec_boxed (NM_SETTING_IP_CONFIG_DNS, "", "",
+	                        G_TYPE_STRV,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPConfig:dns-search:
@@ -2967,12 +2961,11 @@ nm_setting_ip_config_class_init (NMSettingIPConfigClass *klass)
 	 * interface over which a query must be forwarded; they are not used
 	 * to complete unqualified host names.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_DNS_SEARCH,
-		 g_param_spec_boxed (NM_SETTING_IP_CONFIG_DNS_SEARCH, "", "",
-		                     G_TYPE_STRV,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_DNS_SEARCH] =
+	    g_param_spec_boxed (NM_SETTING_IP_CONFIG_DNS_SEARCH, "", "",
+	                        G_TYPE_STRV,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPConfig:dns-options:
@@ -2985,12 +2978,11 @@ nm_setting_ip_config_class_init (NMSettingIPConfigClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_DNS_OPTIONS,
-		 g_param_spec_boxed (NM_SETTING_IP_CONFIG_DNS_OPTIONS, "", "",
-		                     G_TYPE_STRV,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_DNS_OPTIONS] =
+	    g_param_spec_boxed (NM_SETTING_IP_CONFIG_DNS_OPTIONS, "", "",
+	                        G_TYPE_STRV,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPConfig:dns-priority:
@@ -3027,31 +3019,29 @@ nm_setting_ip_config_class_init (NMSettingIPConfigClass *klass)
 	 *
 	 * Since: 1.4
 	 **/
-	g_object_class_install_property
-	    (object_class, PROP_DNS_PRIORITY,
+	obj_properties[PROP_DNS_PRIORITY] =
 	     g_param_spec_int (NM_SETTING_IP_CONFIG_DNS_PRIORITY, "", "",
 	                       G_MININT32, G_MAXINT32, 0,
 	                       G_PARAM_READWRITE |
 	                       G_PARAM_CONSTRUCT |
-	                       G_PARAM_STATIC_STRINGS));
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPConfig:addresses: (type GPtrArray(NMIPAddress))
 	 *
 	 * Array of IP addresses.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_ADDRESSES,
-		 g_param_spec_boxed (NM_SETTING_IP_CONFIG_ADDRESSES, "", "",
-		                     G_TYPE_PTR_ARRAY,
-		                     G_PARAM_READWRITE |
-		                     NM_SETTING_PARAM_INFERRABLE |
-		                     /* "addresses" is a legacy D-Bus property, because the
-		                      * "addresses" GObject property normally gets set from
-		                      * the "address-data" D-Bus property...
-		                      */
-		                     NM_SETTING_PARAM_LEGACY |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_ADDRESSES] =
+	    g_param_spec_boxed (NM_SETTING_IP_CONFIG_ADDRESSES, "", "",
+	                        G_TYPE_PTR_ARRAY,
+	                        G_PARAM_READWRITE |
+	                        NM_SETTING_PARAM_INFERRABLE |
+	                        /* "addresses" is a legacy D-Bus property, because the
+	                         * "addresses" GObject property normally gets set from
+	                         * the "address-data" D-Bus property...
+	                         */
+	                        NM_SETTING_PARAM_LEGACY |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPConfig:gateway:
@@ -3059,28 +3049,26 @@ nm_setting_ip_config_class_init (NMSettingIPConfigClass *klass)
 	 * The gateway associated with this configuration. This is only meaningful
 	 * if #NMSettingIPConfig:addresses is also set.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_GATEWAY,
-		 g_param_spec_string (NM_SETTING_IP_CONFIG_GATEWAY, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_GATEWAY] =
+	    g_param_spec_string (NM_SETTING_IP_CONFIG_GATEWAY, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPConfig:routes: (type GPtrArray(NMIPRoute))
 	 *
 	 * Array of IP routes.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_ROUTES,
-		 g_param_spec_boxed (NM_SETTING_IP_CONFIG_ROUTES, "", "",
-		                     G_TYPE_PTR_ARRAY,
-		                     G_PARAM_READWRITE |
-		                     NM_SETTING_PARAM_INFERRABLE |
-		                     /* See :addresses above Re: LEGACY */
-		                     NM_SETTING_PARAM_LEGACY |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_ROUTES] =
+	    g_param_spec_boxed (NM_SETTING_IP_CONFIG_ROUTES, "", "",
+	                        G_TYPE_PTR_ARRAY,
+	                        G_PARAM_READWRITE |
+	                        NM_SETTING_PARAM_INFERRABLE |
+	                        /* See :addresses above Re: LEGACY */
+	                        NM_SETTING_PARAM_LEGACY |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPConfig:route-metric:
@@ -3096,13 +3084,12 @@ nm_setting_ip_config_class_init (NMSettingIPConfigClass *klass)
 	 * mean setting it to 1024.
 	 * For IPv4, zero is a regular value for the metric.
 	 **/
-	g_object_class_install_property
-	    (object_class, PROP_ROUTE_METRIC,
+	obj_properties[PROP_ROUTE_METRIC] =
 	     g_param_spec_int64 (NM_SETTING_IP_CONFIG_ROUTE_METRIC, "", "",
 	                         -1, G_MAXUINT32, -1,
 	                         G_PARAM_READWRITE |
 	                         G_PARAM_CONSTRUCT |
-	                         G_PARAM_STATIC_STRINGS));
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPConfig:route-table:
@@ -3125,13 +3112,12 @@ nm_setting_ip_config_class_init (NMSettingIPConfigClass *klass)
 	 *
 	 * Since: 1.10
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_ROUTE_TABLE,
-		 g_param_spec_uint (NM_SETTING_IP_CONFIG_ROUTE_TABLE, "", "",
-		                    0, G_MAXUINT32, 0,
-		                    G_PARAM_READWRITE |
-		                    NM_SETTING_PARAM_FUZZY_IGNORE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_ROUTE_TABLE] =
+	    g_param_spec_uint (NM_SETTING_IP_CONFIG_ROUTE_TABLE, "", "",
+	                       0, G_MAXUINT32, 0,
+	                       G_PARAM_READWRITE |
+	                       NM_SETTING_PARAM_FUZZY_IGNORE |
+	                       G_PARAM_STATIC_STRINGS);
 	/**
 	 * NMSettingIPConfig:ignore-auto-routes:
 	 *
@@ -3139,13 +3125,12 @@ nm_setting_ip_config_class_init (NMSettingIPConfigClass *klass)
 	 * %TRUE, automatically configured routes are ignored and only routes
 	 * specified in the #NMSettingIPConfig:routes property, if any, are used.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_IGNORE_AUTO_ROUTES,
-		 g_param_spec_boolean (NM_SETTING_IP_CONFIG_IGNORE_AUTO_ROUTES, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_IGNORE_AUTO_ROUTES] =
+	    g_param_spec_boolean (NM_SETTING_IP_CONFIG_IGNORE_AUTO_ROUTES, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPConfig:ignore-auto-dns:
@@ -3156,13 +3141,12 @@ nm_setting_ip_config_class_init (NMSettingIPConfigClass *klass)
 	 * #NMSettingIPConfig:dns and #NMSettingIPConfig:dns-search properties, if
 	 * any, are used.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_IGNORE_AUTO_DNS,
-		 g_param_spec_boolean (NM_SETTING_IP_CONFIG_IGNORE_AUTO_DNS, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_IGNORE_AUTO_DNS] =
+	    g_param_spec_boolean (NM_SETTING_IP_CONFIG_IGNORE_AUTO_DNS, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPConfig:dhcp-hostname:
@@ -3172,12 +3156,11 @@ nm_setting_ip_config_class_init (NMSettingIPConfigClass *klass)
 	 * This property and #NMSettingIP4Config:dhcp-fqdn are mutually exclusive and
 	 * cannot be set at the same time.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_DHCP_HOSTNAME,
-		 g_param_spec_string (NM_SETTING_IP_CONFIG_DHCP_HOSTNAME, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_DHCP_HOSTNAME] =
+	    g_param_spec_string (NM_SETTING_IP_CONFIG_DHCP_HOSTNAME, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPConfig:dhcp-send-hostname:
@@ -3188,13 +3171,12 @@ nm_setting_ip_config_class_init (NMSettingIPConfigClass *klass)
 	 * #NMSettingIPConfig:dhcp-hostname property is %NULL and this property is
 	 * %TRUE, the current persistent hostname of the computer is sent.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_DHCP_SEND_HOSTNAME,
-		 g_param_spec_boolean (NM_SETTING_IP_CONFIG_DHCP_SEND_HOSTNAME, "", "",
-		                       TRUE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_DHCP_SEND_HOSTNAME] =
+	    g_param_spec_boolean (NM_SETTING_IP_CONFIG_DHCP_SEND_HOSTNAME, "", "",
+	                          TRUE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPConfig:never-default:
@@ -3203,13 +3185,12 @@ nm_setting_ip_config_class_init (NMSettingIPConfigClass *klass)
 	 * IP type, meaning it will never be assigned the default route by
 	 * NetworkManager.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_NEVER_DEFAULT,
-		 g_param_spec_boolean (NM_SETTING_IP_CONFIG_NEVER_DEFAULT, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_NEVER_DEFAULT] =
+	    g_param_spec_boolean (NM_SETTING_IP_CONFIG_NEVER_DEFAULT, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPConfig:may-fail:
@@ -3222,13 +3203,12 @@ nm_setting_ip_config_class_init (NMSettingIPConfigClass *klass)
 	 * to succeed if IPv4 configuration fails but IPv6 configuration completes
 	 * successfully.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_MAY_FAIL,
-		 g_param_spec_boolean (NM_SETTING_IP_CONFIG_MAY_FAIL, "", "",
-		                       TRUE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MAY_FAIL] =
+	    g_param_spec_boolean (NM_SETTING_IP_CONFIG_MAY_FAIL, "", "",
+	                          TRUE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPConfig:dad-timeout:
@@ -3244,25 +3224,25 @@ nm_setting_ip_config_class_init (NMSettingIPConfigClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_DAD_TIMEOUT,
-		 g_param_spec_int (NM_SETTING_IP_CONFIG_DAD_TIMEOUT, "", "",
-		                    -1, NM_SETTING_IP_CONFIG_DAD_TIMEOUT_MAX, -1,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_FUZZY_IGNORE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_DAD_TIMEOUT] =
+	    g_param_spec_int (NM_SETTING_IP_CONFIG_DAD_TIMEOUT, "", "",
+	                       -1, NM_SETTING_IP_CONFIG_DAD_TIMEOUT_MAX, -1,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_FUZZY_IGNORE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPConfig:dhcp-timeout:
 	 *
 	 * A timeout for a DHCP transaction in seconds.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_DHCP_TIMEOUT,
-		 g_param_spec_int (NM_SETTING_IP_CONFIG_DHCP_TIMEOUT, "", "",
-		                   0, G_MAXINT32, 0,
-		                   G_PARAM_READWRITE |
-		                   NM_SETTING_PARAM_FUZZY_IGNORE |
-		                   G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_DHCP_TIMEOUT] =
+	    g_param_spec_int (NM_SETTING_IP_CONFIG_DHCP_TIMEOUT, "", "",
+	                      0, G_MAXINT32, 0,
+	                      G_PARAM_READWRITE |
+	                      NM_SETTING_PARAM_FUZZY_IGNORE |
+	                      G_PARAM_STATIC_STRINGS);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 }

--- a/libnm-core/nm-setting-ip-tunnel.c
+++ b/libnm-core/nm-setting-ip-tunnel.c
@@ -30,9 +30,23 @@
  * @short_description: Describes connection properties for IP tunnel devices
  **/
 
-G_DEFINE_TYPE (NMSettingIPTunnel, nm_setting_ip_tunnel, NM_TYPE_SETTING)
+/*****************************************************************************/
 
-#define NM_SETTING_IP_TUNNEL_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_IP_TUNNEL, NMSettingIPTunnelPrivate))
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
+	PROP_PARENT,
+	PROP_MODE,
+	PROP_LOCAL,
+	PROP_REMOTE,
+	PROP_TTL,
+	PROP_TOS,
+	PROP_PATH_MTU_DISCOVERY,
+	PROP_INPUT_KEY,
+	PROP_OUTPUT_KEY,
+	PROP_ENCAPSULATION_LIMIT,
+	PROP_FLOW_LABEL,
+	PROP_MTU,
+	PROP_FLAGS,
+);
 
 typedef struct {
 	char *parent;
@@ -50,21 +64,11 @@ typedef struct {
 	guint32 flags;
 } NMSettingIPTunnelPrivate;
 
-NM_GOBJECT_PROPERTIES_DEFINE_BASE (
-	PROP_PARENT,
-	PROP_MODE,
-	PROP_LOCAL,
-	PROP_REMOTE,
-	PROP_TTL,
-	PROP_TOS,
-	PROP_PATH_MTU_DISCOVERY,
-	PROP_INPUT_KEY,
-	PROP_OUTPUT_KEY,
-	PROP_ENCAPSULATION_LIMIT,
-	PROP_FLOW_LABEL,
-	PROP_MTU,
-	PROP_FLAGS,
-);
+G_DEFINE_TYPE (NMSettingIPTunnel, nm_setting_ip_tunnel, NM_TYPE_SETTING)
+
+#define NM_SETTING_IP_TUNNEL_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_IP_TUNNEL, NMSettingIPTunnelPrivate))
+
+/*****************************************************************************/
 
 /**
  * nm_setting_ip_tunnel_get_parent:
@@ -471,24 +475,59 @@ verify (NMSetting *setting, NMConnection *connection, GError **error)
 	return TRUE;
 }
 
-/**
- * nm_setting_ip_tunnel_new:
- *
- * Creates a new #NMSettingIPTunnel object with default values.
- *
- * Returns: (transfer full): the new empty #NMSettingIPTunnel object
- *
- * Since: 1.2
- **/
-NMSetting *
-nm_setting_ip_tunnel_new (void)
-{
-	return (NMSetting *) g_object_new (NM_TYPE_SETTING_IP_TUNNEL, NULL);
-}
+/*****************************************************************************/
 
 static void
-nm_setting_ip_tunnel_init (NMSettingIPTunnel *setting)
+get_property (GObject *object, guint prop_id,
+              GValue *value, GParamSpec *pspec)
 {
+	NMSettingIPTunnel *setting = NM_SETTING_IP_TUNNEL (object);
+	NMSettingIPTunnelPrivate *priv = NM_SETTING_IP_TUNNEL_GET_PRIVATE (setting);
+
+	switch (prop_id) {
+	case PROP_PARENT:
+		g_value_set_string (value, priv->parent);
+		break;
+	case PROP_MODE:
+		g_value_set_uint (value, priv->mode);
+		break;
+	case PROP_LOCAL:
+		g_value_set_string (value, priv->local);
+		break;
+	case PROP_REMOTE:
+		g_value_set_string (value, priv->remote);
+		break;
+	case PROP_TTL:
+		g_value_set_uint (value, priv->ttl);
+		break;
+	case PROP_TOS:
+		g_value_set_uint (value, priv->tos);
+		break;
+	case PROP_PATH_MTU_DISCOVERY:
+		g_value_set_boolean (value, priv->path_mtu_discovery);
+		break;
+	case PROP_INPUT_KEY:
+		g_value_set_string (value, priv->input_key);
+		break;
+	case PROP_OUTPUT_KEY:
+		g_value_set_string (value, priv->output_key);
+		break;
+	case PROP_ENCAPSULATION_LIMIT:
+		g_value_set_uint (value, priv->encapsulation_limit);
+		break;
+	case PROP_FLOW_LABEL:
+		g_value_set_uint (value, priv->flow_label);
+		break;
+	case PROP_MTU:
+		g_value_set_uint (value, priv->mtu);
+		break;
+	case PROP_FLAGS:
+		g_value_set_uint (value, priv->flags);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
 }
 
 static void
@@ -549,57 +588,26 @@ set_property (GObject *object, guint prop_id,
 	}
 }
 
-static void
-get_property (GObject *object, guint prop_id,
-              GValue *value, GParamSpec *pspec)
-{
-	NMSettingIPTunnel *setting = NM_SETTING_IP_TUNNEL (object);
-	NMSettingIPTunnelPrivate *priv = NM_SETTING_IP_TUNNEL_GET_PRIVATE (setting);
+/*****************************************************************************/
 
-	switch (prop_id) {
-	case PROP_PARENT:
-		g_value_set_string (value, priv->parent);
-		break;
-	case PROP_MODE:
-		g_value_set_uint (value, priv->mode);
-		break;
-	case PROP_LOCAL:
-		g_value_set_string (value, priv->local);
-		break;
-	case PROP_REMOTE:
-		g_value_set_string (value, priv->remote);
-		break;
-	case PROP_TTL:
-		g_value_set_uint (value, priv->ttl);
-		break;
-	case PROP_TOS:
-		g_value_set_uint (value, priv->tos);
-		break;
-	case PROP_PATH_MTU_DISCOVERY:
-		g_value_set_boolean (value, priv->path_mtu_discovery);
-		break;
-	case PROP_INPUT_KEY:
-		g_value_set_string (value, priv->input_key);
-		break;
-	case PROP_OUTPUT_KEY:
-		g_value_set_string (value, priv->output_key);
-		break;
-	case PROP_ENCAPSULATION_LIMIT:
-		g_value_set_uint (value, priv->encapsulation_limit);
-		break;
-	case PROP_FLOW_LABEL:
-		g_value_set_uint (value, priv->flow_label);
-		break;
-	case PROP_MTU:
-		g_value_set_uint (value, priv->mtu);
-		break;
-	case PROP_FLAGS:
-		g_value_set_uint (value, priv->flags);
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
+static void
+nm_setting_ip_tunnel_init (NMSettingIPTunnel *setting)
+{
+}
+
+/**
+ * nm_setting_ip_tunnel_new:
+ *
+ * Creates a new #NMSettingIPTunnel object with default values.
+ *
+ * Returns: (transfer full): the new empty #NMSettingIPTunnel object
+ *
+ * Since: 1.2
+ **/
+NMSetting *
+nm_setting_ip_tunnel_new (void)
+{
+	return (NMSetting *) g_object_new (NM_TYPE_SETTING_IP_TUNNEL, NULL);
 }
 
 static void
@@ -625,8 +633,8 @@ nm_setting_ip_tunnel_class_init (NMSettingIPTunnelClass *klass)
 
 	g_type_class_add_private (klass, sizeof (NMSettingIPTunnelPrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->verify = verify;

--- a/libnm-core/nm-setting-ip-tunnel.c
+++ b/libnm-core/nm-setting-ip-tunnel.c
@@ -50,8 +50,7 @@ typedef struct {
 	guint32 flags;
 } NMSettingIPTunnelPrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_PARENT,
 	PROP_MODE,
 	PROP_LOCAL,
@@ -65,9 +64,7 @@ enum {
 	PROP_FLOW_LABEL,
 	PROP_MTU,
 	PROP_FLAGS,
-
-	LAST_PROP
-};
+);
 
 /**
  * nm_setting_ip_tunnel_get_parent:
@@ -643,13 +640,12 @@ nm_setting_ip_tunnel_class_init (NMSettingIPTunnelClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_PARENT,
-		 g_param_spec_string (NM_SETTING_IP_TUNNEL_PARENT, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PARENT] =
+	    g_param_spec_string (NM_SETTING_IP_TUNNEL_PARENT, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPTunnel:mode:
@@ -659,13 +655,12 @@ nm_setting_ip_tunnel_class_init (NMSettingIPTunnelClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_MODE,
-		 g_param_spec_uint (NM_SETTING_IP_TUNNEL_MODE, "", "",
-		                    0, G_MAXUINT, 0,
-		                    G_PARAM_READWRITE |
-		                    NM_SETTING_PARAM_INFERRABLE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MODE] =
+	    g_param_spec_uint (NM_SETTING_IP_TUNNEL_MODE, "", "",
+	                       0, G_MAXUINT, 0,
+	                       G_PARAM_READWRITE |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPTunnel:local:
@@ -675,13 +670,12 @@ nm_setting_ip_tunnel_class_init (NMSettingIPTunnelClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_LOCAL,
-		 g_param_spec_string (NM_SETTING_IP_TUNNEL_LOCAL, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_LOCAL] =
+	    g_param_spec_string (NM_SETTING_IP_TUNNEL_LOCAL, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPTunnel:remote:
@@ -691,13 +685,12 @@ nm_setting_ip_tunnel_class_init (NMSettingIPTunnelClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_REMOTE,
-		 g_param_spec_string (NM_SETTING_IP_TUNNEL_REMOTE, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_REMOTE] =
+	    g_param_spec_string (NM_SETTING_IP_TUNNEL_REMOTE, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPTunnel:ttl
@@ -707,14 +700,13 @@ nm_setting_ip_tunnel_class_init (NMSettingIPTunnelClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_TTL,
-		 g_param_spec_uint (NM_SETTING_IP_TUNNEL_TTL, "", "",
-		                    0, 255, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_INFERRABLE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_TTL] =
+	    g_param_spec_uint (NM_SETTING_IP_TUNNEL_TTL, "", "",
+	                       0, 255, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPTunnel:tos
@@ -724,14 +716,13 @@ nm_setting_ip_tunnel_class_init (NMSettingIPTunnelClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_TOS,
-		 g_param_spec_uint (NM_SETTING_IP_TUNNEL_TOS, "", "",
-		                    0, 255, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_INFERRABLE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_TOS] =
+	    g_param_spec_uint (NM_SETTING_IP_TUNNEL_TOS, "", "",
+	                       0, 255, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPTunnel:path-mtu-discovery
@@ -740,14 +731,13 @@ nm_setting_ip_tunnel_class_init (NMSettingIPTunnelClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_PATH_MTU_DISCOVERY,
-		 g_param_spec_boolean (NM_SETTING_IP_TUNNEL_PATH_MTU_DISCOVERY, "", "",
-		                       TRUE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       NM_SETTING_PARAM_INFERRABLE |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PATH_MTU_DISCOVERY] =
+	    g_param_spec_boolean (NM_SETTING_IP_TUNNEL_PATH_MTU_DISCOVERY, "", "",
+	                          TRUE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          NM_SETTING_PARAM_INFERRABLE |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPTunnel:input-key:
@@ -757,13 +747,12 @@ nm_setting_ip_tunnel_class_init (NMSettingIPTunnelClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_INPUT_KEY,
-		 g_param_spec_string (NM_SETTING_IP_TUNNEL_INPUT_KEY, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_INPUT_KEY] =
+	    g_param_spec_string (NM_SETTING_IP_TUNNEL_INPUT_KEY, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPTunnel:output-key:
@@ -773,13 +762,12 @@ nm_setting_ip_tunnel_class_init (NMSettingIPTunnelClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_OUTPUT_KEY,
-		 g_param_spec_string (NM_SETTING_IP_TUNNEL_OUTPUT_KEY, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_OUTPUT_KEY] =
+	    g_param_spec_string (NM_SETTING_IP_TUNNEL_OUTPUT_KEY, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPTunnel:encapsulation-limit:
@@ -789,14 +777,13 @@ nm_setting_ip_tunnel_class_init (NMSettingIPTunnelClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_ENCAPSULATION_LIMIT,
-		 g_param_spec_uint (NM_SETTING_IP_TUNNEL_ENCAPSULATION_LIMIT, "", "",
-		                    0, 255, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_INFERRABLE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_ENCAPSULATION_LIMIT] =
+	    g_param_spec_uint (NM_SETTING_IP_TUNNEL_ENCAPSULATION_LIMIT, "", "",
+	                       0, 255, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPTunnel:flow-label:
@@ -806,14 +793,13 @@ nm_setting_ip_tunnel_class_init (NMSettingIPTunnelClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_FLOW_LABEL,
-		 g_param_spec_uint (NM_SETTING_IP_TUNNEL_FLOW_LABEL, "", "",
-		                    0, (1 << 20) - 1, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_INFERRABLE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_FLOW_LABEL] =
+	    g_param_spec_uint (NM_SETTING_IP_TUNNEL_FLOW_LABEL, "", "",
+	                       0, (1 << 20) - 1, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPTunnel:mtu:
@@ -823,14 +809,13 @@ nm_setting_ip_tunnel_class_init (NMSettingIPTunnelClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_MTU,
-		 g_param_spec_uint (NM_SETTING_IP_TUNNEL_MTU, "", "",
-		                    0, G_MAXUINT, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_FUZZY_IGNORE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MTU] =
+	    g_param_spec_uint (NM_SETTING_IP_TUNNEL_MTU, "", "",
+	                       0, G_MAXUINT, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_FUZZY_IGNORE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIPTunnel:flags:
@@ -843,13 +828,14 @@ nm_setting_ip_tunnel_class_init (NMSettingIPTunnelClass *klass)
 	 *
 	 * Since: 1.12
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_FLAGS,
-		 g_param_spec_uint (NM_SETTING_IP_TUNNEL_FLAGS, "", "",
-		                    0, G_MAXUINT32, 0,
-		                    G_PARAM_READWRITE |
-		                    NM_SETTING_PARAM_FUZZY_IGNORE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_FLAGS] =
+	    g_param_spec_uint (NM_SETTING_IP_TUNNEL_FLAGS, "", "",
+	                       0, G_MAXUINT32, 0,
+	                       G_PARAM_READWRITE |
+	                       NM_SETTING_PARAM_FUZZY_IGNORE |
+	                       G_PARAM_STATIC_STRINGS);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit (setting_class, NM_META_SETTING_TYPE_IP_TUNNEL);
 }

--- a/libnm-core/nm-setting-ip4-config.c
+++ b/libnm-core/nm-setting-ip4-config.c
@@ -59,13 +59,10 @@ typedef struct {
 	char *dhcp_fqdn;
 } NMSettingIP4ConfigPrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_DHCP_CLIENT_ID,
 	PROP_DHCP_FQDN,
-
-	LAST_PROP
-};
+);
 
 /**
  * nm_setting_ip4_config_new:
@@ -747,12 +744,11 @@ nm_setting_ip4_config_class_init (NMSettingIP4ConfigClass *klass)
 	 * example: DHCP_CLIENT_ID=ax-srv-1; DHCP_CLIENT_ID=01:44:44:44:44:44:44
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_DHCP_CLIENT_ID,
-		 g_param_spec_string (NM_SETTING_IP4_CONFIG_DHCP_CLIENT_ID, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_DHCP_CLIENT_ID] =
+	    g_param_spec_string (NM_SETTING_IP4_CONFIG_DHCP_CLIENT_ID, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/* ---ifcfg-rh---
 	 * property: dad-timeout
@@ -791,12 +787,11 @@ nm_setting_ip4_config_class_init (NMSettingIP4ConfigClass *klass)
 	 * example: DHCP_FQDN=foo.bar.com
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_DHCP_FQDN,
-		 g_param_spec_string (NM_SETTING_IP4_CONFIG_DHCP_FQDN, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_DHCP_FQDN] =
+	    g_param_spec_string (NM_SETTING_IP4_CONFIG_DHCP_FQDN, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/* IP4-specific property overrides */
 
@@ -901,6 +896,8 @@ nm_setting_ip4_config_class_init (NMSettingIP4ConfigClass *klass)
 	                                    G_VARIANT_TYPE ("aa{sv}"),
 	                                    ip4_route_data_get,
 	                                    ip4_route_data_set);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit_full (setting_class, NM_META_SETTING_TYPE_IP4_CONFIG,
 	                               NULL, properties_override);

--- a/libnm-core/nm-setting-ip4-config.c
+++ b/libnm-core/nm-setting-ip4-config.c
@@ -21,9 +21,10 @@
 
 #include "nm-default.h"
 
+#include "nm-setting-ip4-config.h"
+
 #include <string.h>
 
-#include "nm-setting-ip4-config.h"
 #include "nm-setting-private.h"
 
 /**
@@ -50,32 +51,23 @@
  * connection.
  **/
 
-G_DEFINE_TYPE (NMSettingIP4Config, nm_setting_ip4_config, NM_TYPE_SETTING_IP_CONFIG)
-
-#define NM_SETTING_IP4_CONFIG_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_IP4_CONFIG, NMSettingIP4ConfigPrivate))
-
-typedef struct {
-	char *dhcp_client_id;
-	char *dhcp_fqdn;
-} NMSettingIP4ConfigPrivate;
+/*****************************************************************************/
 
 NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_DHCP_CLIENT_ID,
 	PROP_DHCP_FQDN,
 );
 
-/**
- * nm_setting_ip4_config_new:
- *
- * Creates a new #NMSettingIP4Config object with default values.
- *
- * Returns: (transfer full): the new empty #NMSettingIP4Config object
- **/
-NMSetting *
-nm_setting_ip4_config_new (void)
-{
-	return (NMSetting *) g_object_new (NM_TYPE_SETTING_IP4_CONFIG, NULL);
-}
+typedef struct {
+	char *dhcp_client_id;
+	char *dhcp_fqdn;
+} NMSettingIP4ConfigPrivate;
+
+G_DEFINE_TYPE (NMSettingIP4Config, nm_setting_ip4_config, NM_TYPE_SETTING_IP_CONFIG)
+
+#define NM_SETTING_IP4_CONFIG_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_IP4_CONFIG, NMSettingIP4ConfigPrivate))
+
+/*****************************************************************************/
 
 /**
  * nm_setting_ip4_config_get_dhcp_client_id:
@@ -247,62 +239,6 @@ verify (NMSetting *setting, NMConnection *connection, GError **error)
 	}
 
 	return TRUE;
-}
-
-static void
-nm_setting_ip4_config_init (NMSettingIP4Config *setting)
-{
-}
-
-static void
-finalize (GObject *object)
-{
-	NMSettingIP4ConfigPrivate *priv = NM_SETTING_IP4_CONFIG_GET_PRIVATE (object);
-
-	g_free (priv->dhcp_client_id);
-	g_free (priv->dhcp_fqdn);
-
-	G_OBJECT_CLASS (nm_setting_ip4_config_parent_class)->finalize (object);
-}
-
-static void
-set_property (GObject *object, guint prop_id,
-              const GValue *value, GParamSpec *pspec)
-{
-	NMSettingIP4ConfigPrivate *priv = NM_SETTING_IP4_CONFIG_GET_PRIVATE (object);
-
-	switch (prop_id) {
-	case PROP_DHCP_CLIENT_ID:
-		g_free (priv->dhcp_client_id);
-		priv->dhcp_client_id = g_value_dup_string (value);
-		break;
-	case PROP_DHCP_FQDN:
-		g_free (priv->dhcp_fqdn);
-		priv->dhcp_fqdn = g_value_dup_string (value);
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
-}
-
-static void
-get_property (GObject *object, guint prop_id,
-              GValue *value, GParamSpec *pspec)
-{
-	NMSettingIP4Config *s_ip4 = NM_SETTING_IP4_CONFIG (object);
-
-	switch (prop_id) {
-	case PROP_DHCP_CLIENT_ID:
-		g_value_set_string (value, nm_setting_ip4_config_get_dhcp_client_id (s_ip4));
-		break;
-	case PROP_DHCP_FQDN:
-		g_value_set_string (value, nm_setting_ip4_config_get_dhcp_fqdn (s_ip4));
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
 }
 
 static GVariant *
@@ -526,6 +462,79 @@ ip4_route_data_set (NMSetting  *setting,
 	return TRUE;
 }
 
+/*****************************************************************************/
+
+static void
+get_property (GObject *object, guint prop_id,
+              GValue *value, GParamSpec *pspec)
+{
+	NMSettingIP4Config *s_ip4 = NM_SETTING_IP4_CONFIG (object);
+
+	switch (prop_id) {
+	case PROP_DHCP_CLIENT_ID:
+		g_value_set_string (value, nm_setting_ip4_config_get_dhcp_client_id (s_ip4));
+		break;
+	case PROP_DHCP_FQDN:
+		g_value_set_string (value, nm_setting_ip4_config_get_dhcp_fqdn (s_ip4));
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
+}
+
+static void
+set_property (GObject *object, guint prop_id,
+              const GValue *value, GParamSpec *pspec)
+{
+	NMSettingIP4ConfigPrivate *priv = NM_SETTING_IP4_CONFIG_GET_PRIVATE (object);
+
+	switch (prop_id) {
+	case PROP_DHCP_CLIENT_ID:
+		g_free (priv->dhcp_client_id);
+		priv->dhcp_client_id = g_value_dup_string (value);
+		break;
+	case PROP_DHCP_FQDN:
+		g_free (priv->dhcp_fqdn);
+		priv->dhcp_fqdn = g_value_dup_string (value);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
+}
+
+/*****************************************************************************/
+
+static void
+nm_setting_ip4_config_init (NMSettingIP4Config *setting)
+{
+}
+
+/**
+ * nm_setting_ip4_config_new:
+ *
+ * Creates a new #NMSettingIP4Config object with default values.
+ *
+ * Returns: (transfer full): the new empty #NMSettingIP4Config object
+ **/
+NMSetting *
+nm_setting_ip4_config_new (void)
+{
+	return (NMSetting *) g_object_new (NM_TYPE_SETTING_IP4_CONFIG, NULL);
+}
+
+static void
+finalize (GObject *object)
+{
+	NMSettingIP4ConfigPrivate *priv = NM_SETTING_IP4_CONFIG_GET_PRIVATE (object);
+
+	g_free (priv->dhcp_client_id);
+	g_free (priv->dhcp_fqdn);
+
+	G_OBJECT_CLASS (nm_setting_ip4_config_parent_class)->finalize (object);
+}
+
 static void
 nm_setting_ip4_config_class_init (NMSettingIP4ConfigClass *klass)
 {
@@ -535,8 +544,8 @@ nm_setting_ip4_config_class_init (NMSettingIP4ConfigClass *klass)
 
 	g_type_class_add_private (setting_class, sizeof (NMSettingIP4ConfigPrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->verify = verify;

--- a/libnm-core/nm-setting-ip6-config.c
+++ b/libnm-core/nm-setting-ip6-config.c
@@ -52,16 +52,7 @@
  * supported.
  **/
 
-G_DEFINE_TYPE (NMSettingIP6Config, nm_setting_ip6_config, NM_TYPE_SETTING_IP_CONFIG)
-
-#define NM_SETTING_IP6_CONFIG_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_IP6_CONFIG, NMSettingIP6ConfigPrivate))
-
-typedef struct {
-	NMSettingIP6ConfigPrivacy ip6_privacy;
-	NMSettingIP6ConfigAddrGenMode addr_gen_mode;
-	char *token;
-	char *dhcp_duid;
-} NMSettingIP6ConfigPrivate;
+/*****************************************************************************/
 
 NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_IP6_PRIVACY,
@@ -70,18 +61,18 @@ NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_DHCP_DUID,
 );
 
-/**
- * nm_setting_ip6_config_new:
- *
- * Creates a new #NMSettingIP6Config object with default values.
- *
- * Returns: (transfer full): the new empty #NMSettingIP6Config object
- **/
-NMSetting *
-nm_setting_ip6_config_new (void)
-{
-	return (NMSetting *) g_object_new (NM_TYPE_SETTING_IP6_CONFIG, NULL);
-}
+typedef struct {
+	NMSettingIP6ConfigPrivacy ip6_privacy;
+	NMSettingIP6ConfigAddrGenMode addr_gen_mode;
+	char *token;
+	char *dhcp_duid;
+} NMSettingIP6ConfigPrivate;
+
+G_DEFINE_TYPE (NMSettingIP6Config, nm_setting_ip6_config, NM_TYPE_SETTING_IP_CONFIG)
+
+#define NM_SETTING_IP6_CONFIG_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_IP6_CONFIG, NMSettingIP6ConfigPrivate))
+
+/*****************************************************************************/
 
 /**
  * nm_setting_ip6_config_get_ip6_privacy:
@@ -309,11 +300,6 @@ verify (NMSetting *setting, NMConnection *connection, GError **error)
 	return TRUE;
 }
 
-static void
-nm_setting_ip6_config_init (NMSettingIP6Config *setting)
-{
-}
-
 static GVariant *
 ip6_dns_to_dbus (const GValue *prop_value)
 {
@@ -481,32 +467,7 @@ ip6_route_data_set (NMSetting  *setting,
 	return TRUE;
 }
 
-static void
-set_property (GObject *object, guint prop_id,
-              const GValue *value, GParamSpec *pspec)
-{
-	NMSettingIP6ConfigPrivate *priv = NM_SETTING_IP6_CONFIG_GET_PRIVATE (object);
-
-	switch (prop_id) {
-	case PROP_IP6_PRIVACY:
-		priv->ip6_privacy = g_value_get_enum (value);
-		break;
-	case PROP_ADDR_GEN_MODE:
-		priv->addr_gen_mode = g_value_get_int (value);
-		break;
-	case PROP_TOKEN:
-		g_free (priv->token);
-		priv->token = g_value_dup_string (value);
-		break;
-	case PROP_DHCP_DUID:
-		g_free (priv->dhcp_duid);
-		priv->dhcp_duid = g_value_dup_string (value);
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
-}
+/*****************************************************************************/
 
 static void
 get_property (GObject *object, guint prop_id,
@@ -534,6 +495,53 @@ get_property (GObject *object, guint prop_id,
 }
 
 static void
+set_property (GObject *object, guint prop_id,
+              const GValue *value, GParamSpec *pspec)
+{
+	NMSettingIP6ConfigPrivate *priv = NM_SETTING_IP6_CONFIG_GET_PRIVATE (object);
+
+	switch (prop_id) {
+	case PROP_IP6_PRIVACY:
+		priv->ip6_privacy = g_value_get_enum (value);
+		break;
+	case PROP_ADDR_GEN_MODE:
+		priv->addr_gen_mode = g_value_get_int (value);
+		break;
+	case PROP_TOKEN:
+		g_free (priv->token);
+		priv->token = g_value_dup_string (value);
+		break;
+	case PROP_DHCP_DUID:
+		g_free (priv->dhcp_duid);
+		priv->dhcp_duid = g_value_dup_string (value);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
+}
+
+/*****************************************************************************/
+
+static void
+nm_setting_ip6_config_init (NMSettingIP6Config *setting)
+{
+}
+
+/**
+ * nm_setting_ip6_config_new:
+ *
+ * Creates a new #NMSettingIP6Config object with default values.
+ *
+ * Returns: (transfer full): the new empty #NMSettingIP6Config object
+ **/
+NMSetting *
+nm_setting_ip6_config_new (void)
+{
+	return (NMSetting *) g_object_new (NM_TYPE_SETTING_IP6_CONFIG, NULL);
+}
+
+static void
 finalize (GObject *object)
 {
 	NMSettingIP6Config *self = NM_SETTING_IP6_CONFIG (object);
@@ -554,8 +562,8 @@ nm_setting_ip6_config_class_init (NMSettingIP6ConfigClass *klass)
 
 	g_type_class_add_private (klass, sizeof (NMSettingIP6ConfigPrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->verify = verify;

--- a/libnm-core/nm-setting-ip6-config.c
+++ b/libnm-core/nm-setting-ip6-config.c
@@ -63,15 +63,12 @@ typedef struct {
 	char *dhcp_duid;
 } NMSettingIP6ConfigPrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_IP6_PRIVACY,
 	PROP_ADDR_GEN_MODE,
 	PROP_TOKEN,
 	PROP_DHCP_DUID,
-
-	LAST_PROP
-};
+);
 
 /**
  * nm_setting_ip6_config_new:
@@ -749,14 +746,13 @@ nm_setting_ip6_config_class_init (NMSettingIP6ConfigClass *klass)
 	 * example: IPV6_PRIVACY=rfc3041 IPV6_PRIVACY_PREFER_PUBLIC_IP=yes
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_IP6_PRIVACY,
-		 g_param_spec_enum (NM_SETTING_IP6_CONFIG_IP6_PRIVACY, "", "",
-		                    NM_TYPE_SETTING_IP6_CONFIG_PRIVACY,
-		                    NM_SETTING_IP6_CONFIG_PRIVACY_UNKNOWN,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_IP6_PRIVACY] =
+	    g_param_spec_enum (NM_SETTING_IP6_CONFIG_IP6_PRIVACY, "", "",
+	                       NM_TYPE_SETTING_IP6_CONFIG_PRIVACY,
+	                       NM_SETTING_IP6_CONFIG_PRIVACY_UNKNOWN,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIP6Config:addr-gen-mode:
@@ -799,14 +795,13 @@ nm_setting_ip6_config_class_init (NMSettingIP6ConfigClass *klass)
 	 * example: IPV6_ADDR_GEN_MODE=stable-privacy
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_ADDR_GEN_MODE,
-		 g_param_spec_int (NM_SETTING_IP6_CONFIG_ADDR_GEN_MODE, "", "",
-		                   G_MININT, G_MAXINT,
-		                   NM_SETTING_IP6_CONFIG_ADDR_GEN_MODE_STABLE_PRIVACY,
-		                   G_PARAM_READWRITE |
-		                   G_PARAM_CONSTRUCT |
-		                   G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_ADDR_GEN_MODE] =
+	    g_param_spec_int (NM_SETTING_IP6_CONFIG_ADDR_GEN_MODE, "", "",
+	                      G_MININT, G_MAXINT,
+	                      NM_SETTING_IP6_CONFIG_ADDR_GEN_MODE_STABLE_PRIVACY,
+	                      G_PARAM_READWRITE |
+	                      G_PARAM_CONSTRUCT |
+	                      G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIP6Config:token:
@@ -823,13 +818,12 @@ nm_setting_ip6_config_class_init (NMSettingIP6ConfigClass *klass)
 	 * example: IPV6_TOKEN=::53
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_TOKEN,
-		 g_param_spec_string (NM_SETTING_IP6_CONFIG_TOKEN, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_TOKEN] =
+	    g_param_spec_string (NM_SETTING_IP6_CONFIG_TOKEN, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingIP6Config:dhcp-duid:
@@ -876,12 +870,11 @@ nm_setting_ip6_config_class_init (NMSettingIP6ConfigClass *klass)
 	 * example: DHCPV6_DUID=LL; DHCPV6_DUID=0301deadbeef0001; DHCPV6_DUID=03:01:de:ad:be:ef:00:01
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_DHCP_DUID,
-		 g_param_spec_string (NM_SETTING_IP6_CONFIG_DHCP_DUID, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_DHCP_DUID] =
+	    g_param_spec_string (NM_SETTING_IP6_CONFIG_DHCP_DUID, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/* IP6-specific property overrides */
 
@@ -975,6 +968,8 @@ nm_setting_ip6_config_class_init (NMSettingIP6ConfigClass *klass)
 	                                    G_VARIANT_TYPE ("aa{sv}"),
 	                                    ip6_route_data_get,
 	                                    ip6_route_data_set);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit_full (setting_class, NM_META_SETTING_TYPE_IP6_CONFIG,
 	                               NULL, properties_override);

--- a/libnm-core/nm-setting-macsec.c
+++ b/libnm-core/nm-setting-macsec.c
@@ -42,21 +42,7 @@
  * necessary for connection to MACsec (IEEE 802.1AE) interfaces.
  **/
 
-G_DEFINE_TYPE (NMSettingMacsec, nm_setting_macsec, NM_TYPE_SETTING)
-
-#define NM_SETTING_MACSEC_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_MACSEC, NMSettingMacsecPrivate))
-
-typedef struct {
-	char *parent;
-	NMSettingMacsecMode mode;
-	bool encrypt:1;
-	bool send_sci:1;
-	char *mka_cak;
-	NMSettingSecretFlags mka_cak_flags;
-	char *mka_ckn;
-	int port;
-	NMSettingMacsecValidation validation;
-} NMSettingMacsecPrivate;
+/*****************************************************************************/
 
 NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_PARENT,
@@ -70,20 +56,23 @@ NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_SEND_SCI,
 );
 
-/**
- * nm_setting_macsec_new:
- *
- * Creates a new #NMSettingMacsec object with default values.
- *
- * Returns: (transfer full): the new empty #NMSettingMacsec object
- *
- * Since: 1.6
- **/
-NMSetting *
-nm_setting_macsec_new (void)
-{
-	return (NMSetting *) g_object_new (NM_TYPE_SETTING_MACSEC, NULL);
-}
+typedef struct {
+	char *parent;
+	NMSettingMacsecMode mode;
+	bool encrypt:1;
+	bool send_sci:1;
+	char *mka_cak;
+	NMSettingSecretFlags mka_cak_flags;
+	char *mka_ckn;
+	int port;
+	NMSettingMacsecValidation validation;
+} NMSettingMacsecPrivate;
+
+G_DEFINE_TYPE (NMSettingMacsec, nm_setting_macsec, NM_TYPE_SETTING)
+
+#define NM_SETTING_MACSEC_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_MACSEC, NMSettingMacsecPrivate))
+
+/*****************************************************************************/
 
 /**
  * nm_setting_macsec_get_parent:
@@ -395,9 +384,47 @@ verify (NMSetting *setting, NMConnection *connection, GError **error)
 	return TRUE;
 }
 
+/*****************************************************************************/
+
 static void
-nm_setting_macsec_init (NMSettingMacsec *setting)
+get_property (GObject *object, guint prop_id,
+              GValue *value, GParamSpec *pspec)
 {
+	NMSettingMacsec *setting = NM_SETTING_MACSEC (object);
+	NMSettingMacsecPrivate *priv = NM_SETTING_MACSEC_GET_PRIVATE (setting);
+
+	switch (prop_id) {
+	case PROP_PARENT:
+		g_value_set_string (value, priv->parent);
+		break;
+	case PROP_MODE:
+		g_value_set_int (value, priv->mode);
+		break;
+	case PROP_ENCRYPT:
+		g_value_set_boolean (value, priv->encrypt);
+		break;
+	case PROP_MKA_CAK:
+		g_value_set_string (value, priv->mka_cak);
+		break;
+	case PROP_MKA_CAK_FLAGS:
+		g_value_set_flags (value, priv->mka_cak_flags);
+		break;
+	case PROP_MKA_CKN:
+		g_value_set_string (value, priv->mka_ckn);
+		break;
+	case PROP_PORT:
+		g_value_set_int (value, priv->port);
+		break;
+	case PROP_VALIDATION:
+		g_value_set_int (value, priv->validation);
+		break;
+	case PROP_SEND_SCI:
+		g_value_set_boolean (value, priv->send_sci);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
 }
 
 static void
@@ -444,45 +471,26 @@ set_property (GObject *object, guint prop_id,
 	}
 }
 
-static void
-get_property (GObject *object, guint prop_id,
-              GValue *value, GParamSpec *pspec)
-{
-	NMSettingMacsec *setting = NM_SETTING_MACSEC (object);
-	NMSettingMacsecPrivate *priv = NM_SETTING_MACSEC_GET_PRIVATE (setting);
+/*****************************************************************************/
 
-	switch (prop_id) {
-	case PROP_PARENT:
-		g_value_set_string (value, priv->parent);
-		break;
-	case PROP_MODE:
-		g_value_set_int (value, priv->mode);
-		break;
-	case PROP_ENCRYPT:
-		g_value_set_boolean (value, priv->encrypt);
-		break;
-	case PROP_MKA_CAK:
-		g_value_set_string (value, priv->mka_cak);
-		break;
-	case PROP_MKA_CAK_FLAGS:
-		g_value_set_flags (value, priv->mka_cak_flags);
-		break;
-	case PROP_MKA_CKN:
-		g_value_set_string (value, priv->mka_ckn);
-		break;
-	case PROP_PORT:
-		g_value_set_int (value, priv->port);
-		break;
-	case PROP_VALIDATION:
-		g_value_set_int (value, priv->validation);
-		break;
-	case PROP_SEND_SCI:
-		g_value_set_boolean (value, priv->send_sci);
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
+static void
+nm_setting_macsec_init (NMSettingMacsec *setting)
+{
+}
+
+/**
+ * nm_setting_macsec_new:
+ *
+ * Creates a new #NMSettingMacsec object with default values.
+ *
+ * Returns: (transfer full): the new empty #NMSettingMacsec object
+ *
+ * Since: 1.6
+ **/
+NMSetting *
+nm_setting_macsec_new (void)
+{
+	return (NMSetting *) g_object_new (NM_TYPE_SETTING_MACSEC, NULL);
 }
 
 static void
@@ -506,8 +514,8 @@ nm_setting_macsec_class_init (NMSettingMacsecClass *klass)
 
 	g_type_class_add_private (klass, sizeof (NMSettingMacsecPrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->verify       = verify;

--- a/libnm-core/nm-setting-macvlan.c
+++ b/libnm-core/nm-setting-macvlan.c
@@ -50,14 +50,12 @@ typedef struct {
 	gboolean tap;
 } NMSettingMacvlanPrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_PARENT,
 	PROP_MODE,
 	PROP_PROMISCUOUS,
 	PROP_TAP,
-	LAST_PROP
-};
+);
 
 /**
  * nm_setting_macvlan_new:
@@ -281,14 +279,13 @@ nm_setting_macvlan_class_init (NMSettingMacvlanClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_PARENT,
-		 g_param_spec_string (NM_SETTING_MACVLAN_PARENT, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_CONSTRUCT |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PARENT] =
+	    g_param_spec_string (NM_SETTING_MACVLAN_PARENT, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_CONSTRUCT |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingMacvlan:mode:
@@ -298,14 +295,13 @@ nm_setting_macvlan_class_init (NMSettingMacvlanClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_MODE,
-		 g_param_spec_uint (NM_SETTING_MACVLAN_MODE, "", "",
-		                    0, G_MAXUINT, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_INFERRABLE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MODE] =
+	    g_param_spec_uint (NM_SETTING_MACVLAN_MODE, "", "",
+	                       0, G_MAXUINT, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingMacvlan:promiscuous:
@@ -314,14 +310,13 @@ nm_setting_macvlan_class_init (NMSettingMacvlanClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_PROMISCUOUS,
-		 g_param_spec_boolean (NM_SETTING_MACVLAN_PROMISCUOUS, "", "",
-		                       TRUE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       NM_SETTING_PARAM_INFERRABLE |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PROMISCUOUS] =
+	    g_param_spec_boolean (NM_SETTING_MACVLAN_PROMISCUOUS, "", "",
+	                          TRUE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          NM_SETTING_PARAM_INFERRABLE |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingMacvlan:tap:
@@ -330,14 +325,15 @@ nm_setting_macvlan_class_init (NMSettingMacvlanClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_TAP,
-		 g_param_spec_boolean (NM_SETTING_MACVLAN_TAP, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       NM_SETTING_PARAM_INFERRABLE |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_TAP] =
+	    g_param_spec_boolean (NM_SETTING_MACVLAN_TAP, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          NM_SETTING_PARAM_INFERRABLE |
+	                          G_PARAM_STATIC_STRINGS);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit (setting_class, NM_META_SETTING_TYPE_MACVLAN);
 }

--- a/libnm-core/nm-setting-macvlan.c
+++ b/libnm-core/nm-setting-macvlan.c
@@ -21,10 +21,11 @@
 
 #include "nm-default.h"
 
+#include "nm-setting-macvlan.h"
+
 #include <stdlib.h>
 #include <string.h>
 
-#include "nm-setting-macvlan.h"
 #include "nm-utils.h"
 #include "nm-setting-connection.h"
 #include "nm-setting-private.h"
@@ -39,16 +40,7 @@
  * necessary for connection to macvlan interfaces.
  **/
 
-G_DEFINE_TYPE (NMSettingMacvlan, nm_setting_macvlan, NM_TYPE_SETTING)
-
-#define NM_SETTING_MACVLAN_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_MACVLAN, NMSettingMacvlanPrivate))
-
-typedef struct {
-	char *parent;
-	NMSettingMacvlanMode mode;
-	gboolean promiscuous;
-	gboolean tap;
-} NMSettingMacvlanPrivate;
+/*****************************************************************************/
 
 NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_PARENT,
@@ -57,20 +49,18 @@ NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_TAP,
 );
 
-/**
- * nm_setting_macvlan_new:
- *
- * Creates a new #NMSettingMacvlan object with default values.
- *
- * Returns: (transfer full): the new empty #NMSettingMacvlan object
- *
- * Since: 1.2
- **/
-NMSetting *
-nm_setting_macvlan_new (void)
-{
-	return (NMSetting *) g_object_new (NM_TYPE_SETTING_MACVLAN, NULL);
-}
+typedef struct {
+	char *parent;
+	NMSettingMacvlanMode mode;
+	gboolean promiscuous;
+	gboolean tap;
+} NMSettingMacvlanPrivate;
+
+G_DEFINE_TYPE (NMSettingMacvlan, nm_setting_macvlan, NM_TYPE_SETTING)
+
+#define NM_SETTING_MACVLAN_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_MACVLAN, NMSettingMacvlanPrivate))
+
+/*****************************************************************************/
 
 /**
  * nm_setting_macvlan_get_parent:
@@ -134,11 +124,6 @@ nm_setting_macvlan_get_tap (NMSettingMacvlan *setting)
 
 /*****************************************************************************/
 
-static void
-nm_setting_macvlan_init (NMSettingMacvlan *setting)
-{
-}
-
 static gboolean
 verify (NMSetting *setting, NMConnection *connection, GError **error)
 {
@@ -191,32 +176,7 @@ verify (NMSetting *setting, NMConnection *connection, GError **error)
 	return TRUE;
 }
 
-static void
-set_property (GObject *object, guint prop_id,
-              const GValue *value, GParamSpec *pspec)
-{
-	NMSettingMacvlan *setting = NM_SETTING_MACVLAN (object);
-	NMSettingMacvlanPrivate *priv = NM_SETTING_MACVLAN_GET_PRIVATE (setting);
-
-	switch (prop_id) {
-	case PROP_PARENT:
-		g_free (priv->parent);
-		priv->parent = g_value_dup_string (value);
-		break;
-	case PROP_MODE:
-		priv->mode = g_value_get_uint (value);
-		break;
-	case PROP_PROMISCUOUS:
-		priv->promiscuous = g_value_get_boolean (value);
-		break;
-	case PROP_TAP:
-		priv->tap = g_value_get_boolean (value);
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
-}
+/*****************************************************************************/
 
 static void
 get_property (GObject *object, guint prop_id,
@@ -245,6 +205,55 @@ get_property (GObject *object, guint prop_id,
 }
 
 static void
+set_property (GObject *object, guint prop_id,
+              const GValue *value, GParamSpec *pspec)
+{
+	NMSettingMacvlan *setting = NM_SETTING_MACVLAN (object);
+	NMSettingMacvlanPrivate *priv = NM_SETTING_MACVLAN_GET_PRIVATE (setting);
+
+	switch (prop_id) {
+	case PROP_PARENT:
+		g_free (priv->parent);
+		priv->parent = g_value_dup_string (value);
+		break;
+	case PROP_MODE:
+		priv->mode = g_value_get_uint (value);
+		break;
+	case PROP_PROMISCUOUS:
+		priv->promiscuous = g_value_get_boolean (value);
+		break;
+	case PROP_TAP:
+		priv->tap = g_value_get_boolean (value);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
+}
+
+/*****************************************************************************/
+
+static void
+nm_setting_macvlan_init (NMSettingMacvlan *setting)
+{
+}
+
+/**
+ * nm_setting_macvlan_new:
+ *
+ * Creates a new #NMSettingMacvlan object with default values.
+ *
+ * Returns: (transfer full): the new empty #NMSettingMacvlan object
+ *
+ * Since: 1.2
+ **/
+NMSetting *
+nm_setting_macvlan_new (void)
+{
+	return (NMSetting *) g_object_new (NM_TYPE_SETTING_MACVLAN, NULL);
+}
+
+static void
 finalize (GObject *object)
 {
 	NMSettingMacvlan *setting = NM_SETTING_MACVLAN (object);
@@ -263,8 +272,8 @@ nm_setting_macvlan_class_init (NMSettingMacvlanClass *klass)
 
 	g_type_class_add_private (klass, sizeof (NMSettingMacvlanPrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->verify = verify;

--- a/libnm-core/nm-setting-match.c
+++ b/libnm-core/nm-setting-match.c
@@ -15,6 +15,7 @@
 #include "nm-default.h"
 
 #include "nm-setting-match.h"
+
 #include "nm-setting-private.h"
 #include "nm-utils-private.h"
 
@@ -23,6 +24,12 @@
  * @short_description: Properties to match a connection with a device.
  * @include: nm-setting-match.h
  **/
+
+/*****************************************************************************/
+
+NM_GOBJECT_PROPERTIES_DEFINE (NMSettingMatch,
+	PROP_INTERFACE_NAME,
+);
 
 /**
  * NMSettingMatch:
@@ -41,10 +48,6 @@ struct _NMSettingMatchClass {
 };
 
 G_DEFINE_TYPE (NMSettingMatch, nm_setting_match, NM_TYPE_SETTING)
-
-NM_GOBJECT_PROPERTIES_DEFINE (NMSettingMatch,
-	PROP_INTERFACE_NAME,
-);
 
 /*****************************************************************************/
 
@@ -194,6 +197,8 @@ nm_setting_match_get_interface_names (NMSettingMatch *setting, guint *length)
 	return (const char *const *) setting->interface_name->pdata;
 }
 
+/*****************************************************************************/
+
 static void
 get_property (GObject *object, guint prop_id,
               GValue *value, GParamSpec *pspec)
@@ -226,6 +231,8 @@ set_property (GObject *object, guint prop_id,
 		break;
 	}
 }
+
+/*****************************************************************************/
 
 static void
 nm_setting_match_init (NMSettingMatch *setting)
@@ -264,9 +271,9 @@ nm_setting_match_class_init (NMSettingMatchClass *klass)
 	GObjectClass *object_class = G_OBJECT_CLASS (klass);
 	NMSettingClass *setting_class = NM_SETTING_CLASS (klass);
 
-	object_class->finalize     = finalize;
 	object_class->get_property = get_property;
 	object_class->set_property = set_property;
+	object_class->finalize     = finalize;
 
 	/**
 	 * NMSettingMatch:interface-name

--- a/libnm-core/nm-setting-olpc-mesh.c
+++ b/libnm-core/nm-setting-olpc-mesh.c
@@ -22,9 +22,10 @@
 
 #include "nm-default.h"
 
+#include "nm-setting-olpc-mesh.h"
+
 #include <string.h>
 
-#include "nm-setting-olpc-mesh.h"
 #include "nm-utils.h"
 #include "nm-utils-private.h"
 #include "nm-setting-private.h"
@@ -37,17 +38,7 @@
  * necessary for connection to OLPC-Mesh devices.
  **/
 
-static void nm_setting_olpc_mesh_init (NMSettingOlpcMesh *setting);
-
-G_DEFINE_TYPE (NMSettingOlpcMesh, nm_setting_olpc_mesh, NM_TYPE_SETTING)
-
-#define NM_SETTING_OLPC_MESH_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_OLPC_MESH, NMSettingOlpcMeshPrivate))
-
-typedef struct {
-	GBytes *ssid;
-	guint32 channel;
-	char *dhcp_anycast_addr;
-} NMSettingOlpcMeshPrivate;
+/*****************************************************************************/
 
 NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_SSID,
@@ -55,22 +46,17 @@ NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_DHCP_ANYCAST_ADDRESS,
 );
 
-/**
- * nm_setting_olpc_mesh_new:
- *
- * Creates a new #NMSettingOlpcMesh object with default values.
- *
- * Returns: the new empty #NMSettingOlpcMesh object
- **/
-NMSetting *nm_setting_olpc_mesh_new (void)
-{
-	return (NMSetting *) g_object_new (NM_TYPE_SETTING_OLPC_MESH, NULL);
-}
+typedef struct {
+	GBytes *ssid;
+	guint32 channel;
+	char *dhcp_anycast_addr;
+} NMSettingOlpcMeshPrivate;
 
-static void
-nm_setting_olpc_mesh_init (NMSettingOlpcMesh *setting)
-{
-}
+G_DEFINE_TYPE (NMSettingOlpcMesh, nm_setting_olpc_mesh, NM_TYPE_SETTING)
+
+#define NM_SETTING_OLPC_MESH_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_OLPC_MESH, NMSettingOlpcMeshPrivate))
+
+/*****************************************************************************/
 
 /**
  * nm_setting_olpc_mesh_get_ssid:
@@ -149,16 +135,28 @@ verify (NMSetting *setting, NMConnection *connection, GError **error)
 	return TRUE;
 }
 
+/*****************************************************************************/
+
 static void
-finalize (GObject *object)
+get_property (GObject *object, guint prop_id,
+              GValue *value, GParamSpec *pspec)
 {
-	NMSettingOlpcMeshPrivate *priv = NM_SETTING_OLPC_MESH_GET_PRIVATE (object);
+	NMSettingOlpcMesh *setting = NM_SETTING_OLPC_MESH (object);
 
-	if (priv->ssid)
-		g_bytes_unref (priv->ssid);
-	g_free (priv->dhcp_anycast_addr);
-
-	G_OBJECT_CLASS (nm_setting_olpc_mesh_parent_class)->finalize (object);
+	switch (prop_id) {
+	case PROP_SSID:
+		g_value_set_boxed (value, nm_setting_olpc_mesh_get_ssid (setting));
+		break;
+	case PROP_CHANNEL:
+		g_value_set_uint (value, nm_setting_olpc_mesh_get_channel (setting));
+		break;
+	case PROP_DHCP_ANYCAST_ADDRESS:
+		g_value_set_string (value, nm_setting_olpc_mesh_get_dhcp_anycast_address (setting));
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
 }
 
 static void
@@ -186,26 +184,35 @@ set_property (GObject *object, guint prop_id,
 	}
 }
 
-static void
-get_property (GObject *object, guint prop_id,
-              GValue *value, GParamSpec *pspec)
-{
-	NMSettingOlpcMesh *setting = NM_SETTING_OLPC_MESH (object);
+/*****************************************************************************/
 
-	switch (prop_id) {
-	case PROP_SSID:
-		g_value_set_boxed (value, nm_setting_olpc_mesh_get_ssid (setting));
-		break;
-	case PROP_CHANNEL:
-		g_value_set_uint (value, nm_setting_olpc_mesh_get_channel (setting));
-		break;
-	case PROP_DHCP_ANYCAST_ADDRESS:
-		g_value_set_string (value, nm_setting_olpc_mesh_get_dhcp_anycast_address (setting));
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
+static void
+nm_setting_olpc_mesh_init (NMSettingOlpcMesh *setting)
+{
+}
+
+/**
+ * nm_setting_olpc_mesh_new:
+ *
+ * Creates a new #NMSettingOlpcMesh object with default values.
+ *
+ * Returns: the new empty #NMSettingOlpcMesh object
+ **/
+NMSetting *nm_setting_olpc_mesh_new (void)
+{
+	return (NMSetting *) g_object_new (NM_TYPE_SETTING_OLPC_MESH, NULL);
+}
+
+static void
+finalize (GObject *object)
+{
+	NMSettingOlpcMeshPrivate *priv = NM_SETTING_OLPC_MESH_GET_PRIVATE (object);
+
+	if (priv->ssid)
+		g_bytes_unref (priv->ssid);
+	g_free (priv->dhcp_anycast_addr);
+
+	G_OBJECT_CLASS (nm_setting_olpc_mesh_parent_class)->finalize (object);
 }
 
 static void
@@ -217,8 +224,8 @@ nm_setting_olpc_mesh_class_init (NMSettingOlpcMeshClass *klass)
 
 	g_type_class_add_private (klass, sizeof (NMSettingOlpcMeshPrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->verify = verify;

--- a/libnm-core/nm-setting-olpc-mesh.c
+++ b/libnm-core/nm-setting-olpc-mesh.c
@@ -49,14 +49,11 @@ typedef struct {
 	char *dhcp_anycast_addr;
 } NMSettingOlpcMeshPrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_SSID,
 	PROP_CHANNEL,
 	PROP_DHCP_ANYCAST_ADDRESS,
-
-	LAST_PROP
-};
+);
 
 /**
  * nm_setting_olpc_mesh_new:
@@ -231,27 +228,25 @@ nm_setting_olpc_mesh_class_init (NMSettingOlpcMeshClass *klass)
 	 *
 	 * SSID of the mesh network to join.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_SSID,
-		 g_param_spec_boxed (NM_SETTING_OLPC_MESH_SSID, "", "",
-		                     G_TYPE_BYTES,
-		                     G_PARAM_READWRITE |
-		                     NM_SETTING_PARAM_INFERRABLE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_SSID] =
+	    g_param_spec_boxed (NM_SETTING_OLPC_MESH_SSID, "", "",
+	                        G_TYPE_BYTES,
+	                        G_PARAM_READWRITE |
+	                        NM_SETTING_PARAM_INFERRABLE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingOlpcMesh:channel:
 	 *
 	 * Channel on which the mesh network to join is located.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_CHANNEL,
-		 g_param_spec_uint (NM_SETTING_OLPC_MESH_CHANNEL, "", "",
-		                    0, G_MAXUINT32, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_INFERRABLE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_CHANNEL] =
+	    g_param_spec_uint (NM_SETTING_OLPC_MESH_CHANNEL, "", "",
+	                       0, G_MAXUINT32, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingOlpcMesh:dhcp-anycast-address:
@@ -260,19 +255,19 @@ nm_setting_olpc_mesh_class_init (NMSettingOlpcMeshClass *klass)
 	 * The specific anycast address used determines which DHCP server class
 	 * answers the request.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_DHCP_ANYCAST_ADDRESS,
-		 g_param_spec_string (NM_SETTING_OLPC_MESH_DHCP_ANYCAST_ADDRESS, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_DHCP_ANYCAST_ADDRESS] =
+	    g_param_spec_string (NM_SETTING_OLPC_MESH_DHCP_ANYCAST_ADDRESS, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_transform (properties_override,
-	                                    g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                  NM_SETTING_OLPC_MESH_DHCP_ANYCAST_ADDRESS),
+	                                    obj_properties[PROP_DHCP_ANYCAST_ADDRESS],
 	                                    G_VARIANT_TYPE_BYTESTRING,
 	                                    _nm_utils_hwaddr_to_dbus,
 	                                    _nm_utils_hwaddr_from_dbus);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit_full (setting_class, NM_META_SETTING_TYPE_OLPC_MESH,
 	                               NULL, properties_override);

--- a/libnm-core/nm-setting-ovs-bridge.c
+++ b/libnm-core/nm-setting-ovs-bridge.c
@@ -34,6 +34,8 @@
  * necessary for Open vSwitch bridges.
  **/
 
+/*****************************************************************************/
+
 NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_FAIL_MODE,
 	PROP_MCAST_SNOOPING_ENABLE,
@@ -265,8 +267,8 @@ nm_setting_ovs_bridge_class_init (NMSettingOvsBridgeClass *klass)
 	GObjectClass *object_class = G_OBJECT_CLASS (klass);
 	NMSettingClass *setting_class = NM_SETTING_CLASS (klass);
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->verify = verify;

--- a/libnm-core/nm-setting-ovs-bridge.c
+++ b/libnm-core/nm-setting-ovs-bridge.c
@@ -34,14 +34,12 @@
  * necessary for Open vSwitch bridges.
  **/
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_FAIL_MODE,
 	PROP_MCAST_SNOOPING_ENABLE,
 	PROP_RSTP_ENABLE,
 	PROP_STP_ENABLE,
-	LAST_PROP
-};
+);
 
 /**
  * NMSettingOvsBridge:
@@ -280,14 +278,13 @@ nm_setting_ovs_bridge_class_init (NMSettingOvsBridgeClass *klass)
 	 *
 	 * Since: 1.10
 	 **/
-	g_object_class_install_property
-	        (object_class, PROP_FAIL_MODE,
-	         g_param_spec_string (NM_SETTING_OVS_BRIDGE_FAIL_MODE, "", "",
-	                              NULL,
-	                              G_PARAM_READWRITE |
-	                              G_PARAM_CONSTRUCT |
-	                              NM_SETTING_PARAM_INFERRABLE |
-	                              G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_FAIL_MODE] =
+	    g_param_spec_string (NM_SETTING_OVS_BRIDGE_FAIL_MODE, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_CONSTRUCT |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingOvsBridge:mcast-snooping-enable:
@@ -296,13 +293,12 @@ nm_setting_ovs_bridge_class_init (NMSettingOvsBridgeClass *klass)
 	 *
 	 * Since: 1.10
 	 **/
-	g_object_class_install_property
-	        (object_class, PROP_MCAST_SNOOPING_ENABLE,
-	         g_param_spec_boolean (NM_SETTING_OVS_BRIDGE_MCAST_SNOOPING_ENABLE, "", "",
-	                               FALSE,
-	                               G_PARAM_READWRITE |
-	                               G_PARAM_CONSTRUCT |
-	                               G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MCAST_SNOOPING_ENABLE] =
+	    g_param_spec_boolean (NM_SETTING_OVS_BRIDGE_MCAST_SNOOPING_ENABLE, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingOvsBridge:rstp-enable:
@@ -311,13 +307,12 @@ nm_setting_ovs_bridge_class_init (NMSettingOvsBridgeClass *klass)
 	 *
 	 * Since: 1.10
 	 **/
-	g_object_class_install_property
-	        (object_class, PROP_RSTP_ENABLE,
-	         g_param_spec_boolean (NM_SETTING_OVS_BRIDGE_RSTP_ENABLE, "", "",
-	                               FALSE,
-	                               G_PARAM_READWRITE |
-	                               G_PARAM_CONSTRUCT |
-	                               G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_RSTP_ENABLE] =
+	    g_param_spec_boolean (NM_SETTING_OVS_BRIDGE_RSTP_ENABLE, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingOvsBridge:stp-enable:
@@ -326,13 +321,14 @@ nm_setting_ovs_bridge_class_init (NMSettingOvsBridgeClass *klass)
 	 *
 	 * Since: 1.10
 	 **/
-	g_object_class_install_property
-	        (object_class, PROP_STP_ENABLE,
-	         g_param_spec_boolean (NM_SETTING_OVS_BRIDGE_STP_ENABLE, "", "",
-	                               FALSE,
-	                               G_PARAM_READWRITE |
-	                               G_PARAM_CONSTRUCT |
-	                               G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_STP_ENABLE] =
+	    g_param_spec_boolean (NM_SETTING_OVS_BRIDGE_STP_ENABLE, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          G_PARAM_STATIC_STRINGS);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit (setting_class, NM_META_SETTING_TYPE_OVS_BRIDGE);
 }

--- a/libnm-core/nm-setting-ovs-interface.c
+++ b/libnm-core/nm-setting-ovs-interface.c
@@ -33,11 +33,9 @@
  * necessary for Open vSwitch interfaces.
  **/
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_TYPE,
-	LAST_PROP
-};
+);
 
 /**
  * NMSettingOvsInterface:
@@ -379,14 +377,15 @@ nm_setting_ovs_interface_class_init (NMSettingOvsInterfaceClass *klass)
 	 *
 	 * Since: 1.10
 	 **/
-	g_object_class_install_property
-	        (object_class, PROP_TYPE,
-	         g_param_spec_string (NM_SETTING_OVS_INTERFACE_TYPE, "", "",
-	                              NULL,
-	                              G_PARAM_READWRITE |
-	                              G_PARAM_CONSTRUCT |
-	                              NM_SETTING_PARAM_INFERRABLE |
-	                              G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_TYPE] =
+	    g_param_spec_string (NM_SETTING_OVS_INTERFACE_TYPE, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_CONSTRUCT |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit (setting_class, NM_META_SETTING_TYPE_OVS_INTERFACE);
 }

--- a/libnm-core/nm-setting-ovs-interface.c
+++ b/libnm-core/nm-setting-ovs-interface.c
@@ -33,6 +33,8 @@
  * necessary for Open vSwitch interfaces.
  **/
 
+/*****************************************************************************/
+
 NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_TYPE,
 );
@@ -364,8 +366,8 @@ nm_setting_ovs_interface_class_init (NMSettingOvsInterfaceClass *klass)
 	GObjectClass *object_class = G_OBJECT_CLASS (klass);
 	NMSettingClass *setting_class = NM_SETTING_CLASS (klass);
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->verify = verify;

--- a/libnm-core/nm-setting-ovs-patch.c
+++ b/libnm-core/nm-setting-ovs-patch.c
@@ -34,11 +34,9 @@
  * necessary for Open vSwitch interfaces of type "patch".
  **/
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_PEER,
-	LAST_PROP
-};
+);
 
 /**
  * NMSettingOvsPatch:
@@ -199,14 +197,15 @@ nm_setting_ovs_patch_class_init (NMSettingOvsPatchClass *klass)
 	 *
 	 * Since: 1.10
 	 **/
-	g_object_class_install_property
-	        (object_class, PROP_PEER,
-	         g_param_spec_string (NM_SETTING_OVS_PATCH_PEER, "", "",
-	                              NULL,
-	                              G_PARAM_READWRITE |
-	                              G_PARAM_CONSTRUCT |
-	                              NM_SETTING_PARAM_INFERRABLE |
-	                              G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PEER] =
+	    g_param_spec_string (NM_SETTING_OVS_PATCH_PEER, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_CONSTRUCT |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit (setting_class, NM_META_SETTING_TYPE_OVS_PATCH);
 }

--- a/libnm-core/nm-setting-ovs-patch.c
+++ b/libnm-core/nm-setting-ovs-patch.c
@@ -34,6 +34,8 @@
  * necessary for Open vSwitch interfaces of type "patch".
  **/
 
+/*****************************************************************************/
+
 NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_PEER,
 );

--- a/libnm-core/nm-setting-ovs-port.c
+++ b/libnm-core/nm-setting-ovs-port.c
@@ -34,16 +34,16 @@
  * necessary for Open vSwitch ports.
  **/
 
-enum {
-	PROP_0,
+/*****************************************************************************/
+
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_VLAN_MODE,
 	PROP_TAG,
 	PROP_LACP,
 	PROP_BOND_MODE,
 	PROP_BOND_UPDELAY,
 	PROP_BOND_DOWNDELAY,
-	LAST_PROP
-};
+);
 
 /**
  * NMSettingOvsPort:
@@ -364,8 +364,8 @@ nm_setting_ovs_port_class_init (NMSettingOvsPortClass *klass)
 	GObjectClass *object_class = G_OBJECT_CLASS (klass);
 	NMSettingClass *setting_class = NM_SETTING_CLASS (klass);
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->verify = verify;
@@ -378,14 +378,13 @@ nm_setting_ovs_port_class_init (NMSettingOvsPortClass *klass)
 	 *
 	 * Since: 1.10
 	 **/
-	g_object_class_install_property
-	        (object_class, PROP_VLAN_MODE,
-	         g_param_spec_string (NM_SETTING_OVS_PORT_VLAN_MODE, "", "",
-	                              NULL,
-	                              G_PARAM_READWRITE |
-	                              G_PARAM_CONSTRUCT |
-	                              NM_SETTING_PARAM_INFERRABLE |
-	                              G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_VLAN_MODE] =
+	    g_param_spec_string (NM_SETTING_OVS_PORT_VLAN_MODE, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_CONSTRUCT |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingOvsPort:tag:
@@ -394,14 +393,13 @@ nm_setting_ovs_port_class_init (NMSettingOvsPortClass *klass)
 	 *
 	 * Since: 1.10
 	 **/
-	g_object_class_install_property
-	        (object_class, PROP_TAG,
-	         g_param_spec_uint (NM_SETTING_OVS_PORT_TAG, "", "",
-	                            0, 4095, 0,
-	                            G_PARAM_READWRITE |
-	                            G_PARAM_CONSTRUCT |
-	                            NM_SETTING_PARAM_INFERRABLE |
-	                            G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_TAG] =
+	    g_param_spec_uint (NM_SETTING_OVS_PORT_TAG, "", "",
+	                       0, 4095, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingOvsPort:lacp:
@@ -410,14 +408,13 @@ nm_setting_ovs_port_class_init (NMSettingOvsPortClass *klass)
 	 *
 	 * Since: 1.10
 	 **/
-	g_object_class_install_property
-	        (object_class, PROP_LACP,
-	         g_param_spec_string (NM_SETTING_OVS_PORT_LACP, "", "",
-	                              NULL,
-	                              G_PARAM_READWRITE |
-	                              G_PARAM_CONSTRUCT |
-	                              NM_SETTING_PARAM_INFERRABLE |
-	                              G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_LACP] =
+	    g_param_spec_string (NM_SETTING_OVS_PORT_LACP, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_CONSTRUCT |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingOvsPort:bond-mode:
@@ -426,14 +423,13 @@ nm_setting_ovs_port_class_init (NMSettingOvsPortClass *klass)
 	 *
 	 * Since: 1.10
 	 **/
-	g_object_class_install_property
-	        (object_class, PROP_BOND_MODE,
-	         g_param_spec_string (NM_SETTING_OVS_PORT_BOND_MODE, "", "",
-	                              NULL,
-	                              G_PARAM_READWRITE |
-	                              G_PARAM_CONSTRUCT |
-	                              NM_SETTING_PARAM_INFERRABLE |
-	                              G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_BOND_MODE] =
+	    g_param_spec_string (NM_SETTING_OVS_PORT_BOND_MODE, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_CONSTRUCT |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingOvsPort:bond-updelay:
@@ -442,14 +438,13 @@ nm_setting_ovs_port_class_init (NMSettingOvsPortClass *klass)
 	 *
 	 * Since: 1.10
 	 **/
-	g_object_class_install_property
-	        (object_class, PROP_BOND_UPDELAY,
-	         g_param_spec_uint (NM_SETTING_OVS_PORT_BOND_UPDELAY, "", "",
-	                            0, G_MAXUINT, 0,
-	                            G_PARAM_READWRITE |
-	                            G_PARAM_CONSTRUCT |
-	                            NM_SETTING_PARAM_INFERRABLE |
-	                            G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_BOND_UPDELAY] =
+	    g_param_spec_uint (NM_SETTING_OVS_PORT_BOND_UPDELAY, "", "",
+	                       0, G_MAXUINT, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingOvsPort:bond-downdelay:
@@ -458,14 +453,15 @@ nm_setting_ovs_port_class_init (NMSettingOvsPortClass *klass)
 	 *
 	 * Since: 1.10
 	 **/
-	g_object_class_install_property
-	        (object_class, PROP_BOND_DOWNDELAY,
-	         g_param_spec_uint (NM_SETTING_OVS_PORT_BOND_DOWNDELAY, "", "",
-	                            0, G_MAXUINT, 0,
-	                            G_PARAM_READWRITE |
-	                            G_PARAM_CONSTRUCT |
-	                            NM_SETTING_PARAM_INFERRABLE |
-	                            G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_BOND_DOWNDELAY] =
+	    g_param_spec_uint (NM_SETTING_OVS_PORT_BOND_DOWNDELAY, "", "",
+	                       0, G_MAXUINT, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit (setting_class, NM_META_SETTING_TYPE_OVS_PORT);
 }

--- a/libnm-core/nm-setting-ppp.c
+++ b/libnm-core/nm-setting-ppp.c
@@ -60,8 +60,7 @@ typedef struct {
 	guint32 lcp_echo_interval;
 } NMSettingPppPrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_NOAUTH,
 	PROP_REFUSE_EAP,
 	PROP_REFUSE_PAP,
@@ -80,9 +79,7 @@ enum {
 	PROP_MTU,
 	PROP_LCP_ECHO_FAILURE,
 	PROP_LCP_ECHO_INTERVAL,
-
-	LAST_PROP
-};
+);
 
 /**
  * nm_setting_ppp_new:
@@ -542,120 +539,111 @@ nm_setting_ppp_class_init (NMSettingPppClass *klass)
 	 * authenticate itself to the client.  If %FALSE, require authentication
 	 * from the remote side.  In almost all cases, this should be %TRUE.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_NOAUTH,
-		 g_param_spec_boolean (NM_SETTING_PPP_NOAUTH, "", "",
-		                       TRUE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_NOAUTH] =
+	    g_param_spec_boolean (NM_SETTING_PPP_NOAUTH, "", "",
+	                          TRUE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingPpp:refuse-eap:
 	 *
 	 * If %TRUE, the EAP authentication method will not be used.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_REFUSE_EAP,
-		 g_param_spec_boolean (NM_SETTING_PPP_REFUSE_EAP, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_REFUSE_EAP] =
+	    g_param_spec_boolean (NM_SETTING_PPP_REFUSE_EAP, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingPpp:refuse-pap:
 	 *
 	 * If %TRUE, the PAP authentication method will not be used.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_REFUSE_PAP,
-		 g_param_spec_boolean (NM_SETTING_PPP_REFUSE_PAP, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_REFUSE_PAP] =
+	    g_param_spec_boolean (NM_SETTING_PPP_REFUSE_PAP, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingPpp:refuse-chap:
 	 *
 	 * If %TRUE, the CHAP authentication method will not be used.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_REFUSE_CHAP,
-		 g_param_spec_boolean (NM_SETTING_PPP_REFUSE_CHAP, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_REFUSE_CHAP] =
+	    g_param_spec_boolean (NM_SETTING_PPP_REFUSE_CHAP, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingPpp:refuse-mschap:
 	 *
 	 * If %TRUE, the MSCHAP authentication method will not be used.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_REFUSE_MSCHAP,
-		 g_param_spec_boolean (NM_SETTING_PPP_REFUSE_MSCHAP, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_REFUSE_MSCHAP] =
+	    g_param_spec_boolean (NM_SETTING_PPP_REFUSE_MSCHAP, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingPpp:refuse-mschapv2:
 	 *
 	 * If %TRUE, the MSCHAPv2 authentication method will not be used.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_REFUSE_MSCHAPV2,
-		 g_param_spec_boolean (NM_SETTING_PPP_REFUSE_MSCHAPV2, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_REFUSE_MSCHAPV2] =
+	    g_param_spec_boolean (NM_SETTING_PPP_REFUSE_MSCHAPV2, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingPpp:nobsdcomp:
 	 *
 	 * If %TRUE, BSD compression will not be requested.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_NOBSDCOMP,
-		 g_param_spec_boolean (NM_SETTING_PPP_NOBSDCOMP, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       NM_SETTING_PARAM_FUZZY_IGNORE |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_NOBSDCOMP] =
+	    g_param_spec_boolean (NM_SETTING_PPP_NOBSDCOMP, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          NM_SETTING_PARAM_FUZZY_IGNORE |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingPpp:nodeflate:
 	 *
 	 * If %TRUE, "deflate" compression will not be requested.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_NODEFLATE,
-		 g_param_spec_boolean (NM_SETTING_PPP_NODEFLATE, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       NM_SETTING_PARAM_FUZZY_IGNORE |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_NODEFLATE] =
+	    g_param_spec_boolean (NM_SETTING_PPP_NODEFLATE, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          NM_SETTING_PARAM_FUZZY_IGNORE |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingPpp:no-vj-comp:
 	 *
 	 * If %TRUE, Van Jacobsen TCP header compression will not be requested.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_NO_VJ_COMP,
-		 g_param_spec_boolean (NM_SETTING_PPP_NO_VJ_COMP, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       NM_SETTING_PARAM_FUZZY_IGNORE |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_NO_VJ_COMP] =
+	    g_param_spec_boolean (NM_SETTING_PPP_NO_VJ_COMP, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          NM_SETTING_PARAM_FUZZY_IGNORE |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingPpp:require-mppe:
@@ -665,13 +653,12 @@ nm_setting_ppp_class_init (NMSettingPppClass *klass)
 	 * session will fail.  Note that MPPE is not used on mobile broadband
 	 * connections.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_REQUIRE_MPPE,
-		 g_param_spec_boolean (NM_SETTING_PPP_REQUIRE_MPPE, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_REQUIRE_MPPE] =
+	    g_param_spec_boolean (NM_SETTING_PPP_REQUIRE_MPPE, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingPpp:require-mppe-128:
@@ -680,12 +667,11 @@ nm_setting_ppp_class_init (NMSettingPppClass *klass)
 	 * required for the PPP session, and the "require-mppe" property must also
 	 * be set to %TRUE.  If 128-bit MPPE is not available the session will fail.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_REQUIRE_MPPE_128,
-		 g_param_spec_boolean (NM_SETTING_PPP_REQUIRE_MPPE_128, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE  | G_PARAM_CONSTRUCT |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_REQUIRE_MPPE_128] =
+	    g_param_spec_boolean (NM_SETTING_PPP_REQUIRE_MPPE_128, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE  | G_PARAM_CONSTRUCT |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingPpp:mppe-stateful:
@@ -693,13 +679,12 @@ nm_setting_ppp_class_init (NMSettingPppClass *klass)
 	 * If %TRUE, stateful MPPE is used.  See pppd documentation for more
 	 * information on stateful MPPE.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_MPPE_STATEFUL,
-		 g_param_spec_boolean (NM_SETTING_PPP_MPPE_STATEFUL, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MPPE_STATEFUL] =
+	    g_param_spec_boolean (NM_SETTING_PPP_MPPE_STATEFUL, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingPpp:crtscts:
@@ -708,13 +693,12 @@ nm_setting_ppp_class_init (NMSettingPppClass *klass)
 	 * flow control with RTS and CTS signals.  This value should normally be set
 	 * to %FALSE.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_CRTSCTS,
-		 g_param_spec_boolean (NM_SETTING_PPP_CRTSCTS, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_CRTSCTS] =
+	    g_param_spec_boolean (NM_SETTING_PPP_CRTSCTS, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingPpp:baud:
@@ -723,14 +707,13 @@ nm_setting_ppp_class_init (NMSettingPppClass *klass)
 	 * baudrate.  This value should normally be left as 0 to automatically
 	 * choose the speed.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_BAUD,
-		 g_param_spec_uint (NM_SETTING_PPP_BAUD, "", "",
-		                    0, G_MAXUINT32, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_FUZZY_IGNORE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_BAUD] =
+	    g_param_spec_uint (NM_SETTING_PPP_BAUD, "", "",
+	                       0, G_MAXUINT32, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_FUZZY_IGNORE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingPpp:mru:
@@ -739,13 +722,12 @@ nm_setting_ppp_class_init (NMSettingPppClass *klass)
 	 * larger than the specified size.  If non-zero, the MRU should be between
 	 * 128 and 16384.
 	 */
-	g_object_class_install_property
-		(object_class, PROP_MRU,
-		 g_param_spec_uint (NM_SETTING_PPP_MRU, "", "",
-		                    0, 16384, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MRU] =
+	    g_param_spec_uint (NM_SETTING_PPP_MRU, "", "",
+	                       0, 16384, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingPpp:mtu:
@@ -753,14 +735,13 @@ nm_setting_ppp_class_init (NMSettingPppClass *klass)
 	 * If non-zero, instruct pppd to send packets no larger than the specified
 	 * size.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_MTU,
-		 g_param_spec_uint (NM_SETTING_PPP_MTU, "", "",
-		                    0, G_MAXUINT32, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_FUZZY_IGNORE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MTU] =
+	    g_param_spec_uint (NM_SETTING_PPP_MTU, "", "",
+	                       0, G_MAXUINT32, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_FUZZY_IGNORE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingPpp:lcp-echo-failure:
@@ -770,14 +751,13 @@ nm_setting_ppp_class_init (NMSettingPppClass *klass)
 	 * peer.  The "lcp-echo-interval" property must also be set to a non-zero
 	 * value if this property is used.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_LCP_ECHO_FAILURE,
-		 g_param_spec_uint (NM_SETTING_PPP_LCP_ECHO_FAILURE, "", "",
-		                    0, G_MAXUINT32, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_FUZZY_IGNORE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_LCP_ECHO_FAILURE] =
+	    g_param_spec_uint (NM_SETTING_PPP_LCP_ECHO_FAILURE, "", "",
+	                       0, G_MAXUINT32, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_FUZZY_IGNORE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingPpp:lcp-echo-interval:
@@ -787,14 +767,15 @@ nm_setting_ppp_class_init (NMSettingPppClass *klass)
 	 * peers will respond to echo requests and some will not, and it is not
 	 * possible to autodetect this.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_LCP_ECHO_INTERVAL,
-		 g_param_spec_uint (NM_SETTING_PPP_LCP_ECHO_INTERVAL, "", "",
-		                    0, G_MAXUINT32, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_FUZZY_IGNORE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_LCP_ECHO_INTERVAL] =
+	    g_param_spec_uint (NM_SETTING_PPP_LCP_ECHO_INTERVAL, "", "",
+	                       0, G_MAXUINT32, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_FUZZY_IGNORE |
+	                       G_PARAM_STATIC_STRINGS);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit (setting_class, NM_META_SETTING_TYPE_PPP);
 }

--- a/libnm-core/nm-setting-ppp.c
+++ b/libnm-core/nm-setting-ppp.c
@@ -23,6 +23,7 @@
 #include "nm-default.h"
 
 #include "nm-setting-ppp.h"
+
 #include "nm-setting-private.h"
 
 /**
@@ -35,30 +36,7 @@
  * cable and DSL modems and some mobile broadband devices.
  **/
 
-G_DEFINE_TYPE (NMSettingPpp, nm_setting_ppp, NM_TYPE_SETTING)
-
-#define NM_SETTING_PPP_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_PPP, NMSettingPppPrivate))
-
-typedef struct {
-	gboolean noauth;
-	gboolean refuse_eap;
-	gboolean refuse_pap;
-	gboolean refuse_chap;
-	gboolean refuse_mschap;
-	gboolean refuse_mschapv2;
-	gboolean nobsdcomp;
-	gboolean nodeflate;
-	gboolean no_vj_comp;
-	gboolean require_mppe;
-	gboolean require_mppe_128;
-	gboolean mppe_stateful;
-	gboolean crtscts;
-	guint32 baud;
-	guint32 mru;
-	guint32 mtu;
-	guint32 lcp_echo_failure;
-	guint32 lcp_echo_interval;
-} NMSettingPppPrivate;
+/*****************************************************************************/
 
 NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_NOAUTH,
@@ -81,18 +59,32 @@ NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_LCP_ECHO_INTERVAL,
 );
 
-/**
- * nm_setting_ppp_new:
- *
- * Creates a new #NMSettingPpp object with default values.
- *
- * Returns: (transfer full): the new empty #NMSettingPpp object
- **/
-NMSetting *
-nm_setting_ppp_new (void)
-{
-	return (NMSetting *) g_object_new (NM_TYPE_SETTING_PPP, NULL);
-}
+typedef struct {
+	gboolean noauth;
+	gboolean refuse_eap;
+	gboolean refuse_pap;
+	gboolean refuse_chap;
+	gboolean refuse_mschap;
+	gboolean refuse_mschapv2;
+	gboolean nobsdcomp;
+	gboolean nodeflate;
+	gboolean no_vj_comp;
+	gboolean require_mppe;
+	gboolean require_mppe_128;
+	gboolean mppe_stateful;
+	gboolean crtscts;
+	guint32 baud;
+	guint32 mru;
+	guint32 mtu;
+	guint32 lcp_echo_failure;
+	guint32 lcp_echo_interval;
+} NMSettingPppPrivate;
+
+G_DEFINE_TYPE (NMSettingPpp, nm_setting_ppp, NM_TYPE_SETTING)
+
+#define NM_SETTING_PPP_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_PPP, NMSettingPppPrivate))
+
+/*****************************************************************************/
 
 /**
  * nm_setting_ppp_get_noauth:
@@ -380,77 +372,7 @@ verify (NMSetting *setting, NMConnection *connection, GError **error)
 	return TRUE;
 }
 
-static void
-nm_setting_ppp_init (NMSettingPpp *setting)
-{
-}
-
-static void
-set_property (GObject *object, guint prop_id,
-              const GValue *value, GParamSpec *pspec)
-{
-	NMSettingPppPrivate *priv = NM_SETTING_PPP_GET_PRIVATE (object);
-
-	switch (prop_id) {
-	case PROP_NOAUTH:
-		priv->noauth = g_value_get_boolean (value);
-		break;
-	case PROP_REFUSE_EAP:
-		priv->refuse_eap = g_value_get_boolean (value);
-		break;
-	case PROP_REFUSE_PAP:
-		priv->refuse_pap = g_value_get_boolean (value);
-		break;
-	case PROP_REFUSE_CHAP:
-		priv->refuse_chap = g_value_get_boolean (value);
-		break;
-	case PROP_REFUSE_MSCHAP:
-		priv->refuse_mschap = g_value_get_boolean (value);
-		break;
-	case PROP_REFUSE_MSCHAPV2:
-		priv->refuse_mschapv2 = g_value_get_boolean (value);
-		break;
-	case PROP_NOBSDCOMP:
-		priv->nobsdcomp = g_value_get_boolean (value);
-		break;
-	case PROP_NODEFLATE:
-		priv->nodeflate = g_value_get_boolean (value);
-		break;
-	case PROP_NO_VJ_COMP:
-		priv->no_vj_comp = g_value_get_boolean (value);
-		break;
-	case PROP_REQUIRE_MPPE:
-		priv->require_mppe = g_value_get_boolean (value);
-		break;
-	case PROP_REQUIRE_MPPE_128:
-		priv->require_mppe_128 = g_value_get_boolean (value);
-		break;
-	case PROP_MPPE_STATEFUL:
-		priv->mppe_stateful = g_value_get_boolean (value);
-		break;
-	case PROP_CRTSCTS:
-		priv->crtscts = g_value_get_boolean (value);
-		break;
-	case PROP_BAUD:
-		priv->baud = g_value_get_uint (value);
-		break;
-	case PROP_MRU:
-		priv->mru = g_value_get_uint (value);
-		break;
-	case PROP_MTU:
-		priv->mtu = g_value_get_uint (value);
-		break;
-	case PROP_LCP_ECHO_FAILURE:
-		priv->lcp_echo_failure = g_value_get_uint (value);
-		break;
-	case PROP_LCP_ECHO_INTERVAL:
-		priv->lcp_echo_interval = g_value_get_uint (value);
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
-}
+/*****************************************************************************/
 
 static void
 get_property (GObject *object, guint prop_id,
@@ -520,6 +442,93 @@ get_property (GObject *object, guint prop_id,
 }
 
 static void
+set_property (GObject *object, guint prop_id,
+              const GValue *value, GParamSpec *pspec)
+{
+	NMSettingPppPrivate *priv = NM_SETTING_PPP_GET_PRIVATE (object);
+
+	switch (prop_id) {
+	case PROP_NOAUTH:
+		priv->noauth = g_value_get_boolean (value);
+		break;
+	case PROP_REFUSE_EAP:
+		priv->refuse_eap = g_value_get_boolean (value);
+		break;
+	case PROP_REFUSE_PAP:
+		priv->refuse_pap = g_value_get_boolean (value);
+		break;
+	case PROP_REFUSE_CHAP:
+		priv->refuse_chap = g_value_get_boolean (value);
+		break;
+	case PROP_REFUSE_MSCHAP:
+		priv->refuse_mschap = g_value_get_boolean (value);
+		break;
+	case PROP_REFUSE_MSCHAPV2:
+		priv->refuse_mschapv2 = g_value_get_boolean (value);
+		break;
+	case PROP_NOBSDCOMP:
+		priv->nobsdcomp = g_value_get_boolean (value);
+		break;
+	case PROP_NODEFLATE:
+		priv->nodeflate = g_value_get_boolean (value);
+		break;
+	case PROP_NO_VJ_COMP:
+		priv->no_vj_comp = g_value_get_boolean (value);
+		break;
+	case PROP_REQUIRE_MPPE:
+		priv->require_mppe = g_value_get_boolean (value);
+		break;
+	case PROP_REQUIRE_MPPE_128:
+		priv->require_mppe_128 = g_value_get_boolean (value);
+		break;
+	case PROP_MPPE_STATEFUL:
+		priv->mppe_stateful = g_value_get_boolean (value);
+		break;
+	case PROP_CRTSCTS:
+		priv->crtscts = g_value_get_boolean (value);
+		break;
+	case PROP_BAUD:
+		priv->baud = g_value_get_uint (value);
+		break;
+	case PROP_MRU:
+		priv->mru = g_value_get_uint (value);
+		break;
+	case PROP_MTU:
+		priv->mtu = g_value_get_uint (value);
+		break;
+	case PROP_LCP_ECHO_FAILURE:
+		priv->lcp_echo_failure = g_value_get_uint (value);
+		break;
+	case PROP_LCP_ECHO_INTERVAL:
+		priv->lcp_echo_interval = g_value_get_uint (value);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
+}
+
+/*****************************************************************************/
+
+static void
+nm_setting_ppp_init (NMSettingPpp *setting)
+{
+}
+
+/**
+ * nm_setting_ppp_new:
+ *
+ * Creates a new #NMSettingPpp object with default values.
+ *
+ * Returns: (transfer full): the new empty #NMSettingPpp object
+ **/
+NMSetting *
+nm_setting_ppp_new (void)
+{
+	return (NMSetting *) g_object_new (NM_TYPE_SETTING_PPP, NULL);
+}
+
+static void
 nm_setting_ppp_class_init (NMSettingPppClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS (klass);
@@ -527,8 +536,8 @@ nm_setting_ppp_class_init (NMSettingPppClass *klass)
 
 	g_type_class_add_private (klass, sizeof (NMSettingPppPrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 
 	setting_class->verify = verify;
 

--- a/libnm-core/nm-setting-pppoe.c
+++ b/libnm-core/nm-setting-pppoe.c
@@ -22,9 +22,10 @@
 
 #include "nm-default.h"
 
+#include "nm-setting-pppoe.h"
+
 #include <string.h>
 
-#include "nm-setting-pppoe.h"
 #include "nm-setting-ppp.h"
 #include "nm-setting-private.h"
 #include "nm-core-enum-types.h"
@@ -38,17 +39,7 @@
  * to provide IP transport, for example cable or DSL modems.
  **/
 
-G_DEFINE_TYPE (NMSettingPppoe, nm_setting_pppoe, NM_TYPE_SETTING)
-
-#define NM_SETTING_PPPOE_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_PPPOE, NMSettingPppoePrivate))
-
-typedef struct {
-	char *parent;
-	char *service;
-	char *username;
-	char *password;
-	NMSettingSecretFlags password_flags;
-} NMSettingPppoePrivate;
+/*****************************************************************************/
 
 NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_PARENT,
@@ -58,18 +49,19 @@ NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_PASSWORD_FLAGS,
 );
 
-/**
- * nm_setting_pppoe_new:
- *
- * Creates a new #NMSettingPppoe object with default values.
- *
- * Returns: (transfer full): the new empty #NMSettingPppoe object
- **/
-NMSetting *
-nm_setting_pppoe_new (void)
-{
-	return (NMSetting *) g_object_new (NM_TYPE_SETTING_PPPOE, NULL);
-}
+typedef struct {
+	char *parent;
+	char *service;
+	char *username;
+	char *password;
+	NMSettingSecretFlags password_flags;
+} NMSettingPppoePrivate;
+
+G_DEFINE_TYPE (NMSettingPppoe, nm_setting_pppoe, NM_TYPE_SETTING)
+
+#define NM_SETTING_PPPOE_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_PPPOE, NMSettingPppoePrivate))
+
+/*****************************************************************************/
 
 /**
  * nm_setting_pppoe_get_parent:
@@ -204,9 +196,34 @@ need_secrets (NMSetting *setting)
 	return secrets;
 }
 
+/*****************************************************************************/
+
 static void
-nm_setting_pppoe_init (NMSettingPppoe *setting)
+get_property (GObject *object, guint prop_id,
+              GValue *value, GParamSpec *pspec)
 {
+	NMSettingPppoe *setting = NM_SETTING_PPPOE (object);
+
+	switch (prop_id) {
+	case PROP_PARENT:
+		g_value_set_string (value, nm_setting_pppoe_get_parent (setting));
+		break;
+	case PROP_SERVICE:
+		g_value_set_string (value, nm_setting_pppoe_get_service (setting));
+		break;
+	case PROP_USERNAME:
+		g_value_set_string (value, nm_setting_pppoe_get_username (setting));
+		break;
+	case PROP_PASSWORD:
+		g_value_set_string (value, nm_setting_pppoe_get_password (setting));
+		break;
+	case PROP_PASSWORD_FLAGS:
+		g_value_set_flags (value, nm_setting_pppoe_get_password_flags (setting));
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
 }
 
 static void
@@ -241,32 +258,24 @@ set_property (GObject *object, guint prop_id,
 	}
 }
 
-static void
-get_property (GObject *object, guint prop_id,
-              GValue *value, GParamSpec *pspec)
-{
-	NMSettingPppoe *setting = NM_SETTING_PPPOE (object);
+/*****************************************************************************/
 
-	switch (prop_id) {
-	case PROP_PARENT:
-		g_value_set_string (value, nm_setting_pppoe_get_parent (setting));
-		break;
-	case PROP_SERVICE:
-		g_value_set_string (value, nm_setting_pppoe_get_service (setting));
-		break;
-	case PROP_USERNAME:
-		g_value_set_string (value, nm_setting_pppoe_get_username (setting));
-		break;
-	case PROP_PASSWORD:
-		g_value_set_string (value, nm_setting_pppoe_get_password (setting));
-		break;
-	case PROP_PASSWORD_FLAGS:
-		g_value_set_flags (value, nm_setting_pppoe_get_password_flags (setting));
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
+static void
+nm_setting_pppoe_init (NMSettingPppoe *setting)
+{
+}
+
+/**
+ * nm_setting_pppoe_new:
+ *
+ * Creates a new #NMSettingPppoe object with default values.
+ *
+ * Returns: (transfer full): the new empty #NMSettingPppoe object
+ **/
+NMSetting *
+nm_setting_pppoe_new (void)
+{
+	return (NMSetting *) g_object_new (NM_TYPE_SETTING_PPPOE, NULL);
 }
 
 static void
@@ -290,8 +299,8 @@ nm_setting_pppoe_class_init (NMSettingPppoeClass *klass)
 
 	g_type_class_add_private (klass, sizeof (NMSettingPppoePrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->verify       = verify;

--- a/libnm-core/nm-setting-pppoe.c
+++ b/libnm-core/nm-setting-pppoe.c
@@ -50,16 +50,13 @@ typedef struct {
 	NMSettingSecretFlags password_flags;
 } NMSettingPppoePrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_PARENT,
 	PROP_SERVICE,
 	PROP_USERNAME,
 	PROP_PASSWORD,
 	PROP_PASSWORD_FLAGS,
-
-	LAST_PROP
-};
+);
 
 /**
  * nm_setting_pppoe_new:
@@ -310,14 +307,13 @@ nm_setting_pppoe_class_init (NMSettingPppoeClass *klass)
 	 *
 	 * Since: 1.10
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_PARENT,
-		 g_param_spec_string (NM_SETTING_PPPOE_PARENT, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_CONSTRUCT |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PARENT] =
+	    g_param_spec_string (NM_SETTING_PPPOE_PARENT, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_CONSTRUCT |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingPppoe:service:
@@ -327,50 +323,48 @@ nm_setting_pppoe_class_init (NMSettingPppoeClass *klass)
 	 * this should be left blank.  It is only required if there are multiple
 	 * access concentrators or a specific service is known to be required.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_SERVICE,
-		 g_param_spec_string (NM_SETTING_PPPOE_SERVICE, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_SERVICE] =
+	    g_param_spec_string (NM_SETTING_PPPOE_SERVICE, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingPppoe:username:
 	 *
 	 * Username used to authenticate with the PPPoE service.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_USERNAME,
-		 g_param_spec_string (NM_SETTING_PPPOE_USERNAME, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_USERNAME] =
+	    g_param_spec_string (NM_SETTING_PPPOE_USERNAME, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingPppoe:password:
 	 *
 	 * Password used to authenticate with the PPPoE service.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_PASSWORD,
-		 g_param_spec_string (NM_SETTING_PPPOE_PASSWORD, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_SECRET |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PASSWORD] =
+	    g_param_spec_string (NM_SETTING_PPPOE_PASSWORD, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_SECRET |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingPppoe:password-flags:
 	 *
 	 * Flags indicating how to handle the #NMSettingPppoe:password property.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_PASSWORD_FLAGS,
-		 g_param_spec_flags (NM_SETTING_PPPOE_PASSWORD_FLAGS, "", "",
-		                     NM_TYPE_SETTING_SECRET_FLAGS,
-		                     NM_SETTING_SECRET_FLAG_NONE,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PASSWORD_FLAGS] =
+	    g_param_spec_flags (NM_SETTING_PPPOE_PASSWORD_FLAGS, "", "",
+	                        NM_TYPE_SETTING_SECRET_FLAGS,
+	                        NM_SETTING_SECRET_FLAG_NONE,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit (setting_class, NM_META_SETTING_TYPE_PPPOE);
 }

--- a/libnm-core/nm-setting-proxy.c
+++ b/libnm-core/nm-setting-proxy.c
@@ -50,15 +50,12 @@ typedef struct {
 	char *pac_script;
 } NMSettingProxyPrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_METHOD,
 	PROP_BROWSER_ONLY,
 	PROP_PAC_URL,
 	PROP_PAC_SCRIPT,
-
-	LAST_PROP
-};
+);
 
 /**
  * nm_setting_proxy_new:
@@ -312,13 +309,12 @@ nm_setting_proxy_class_init (NMSettingProxyClass *klass)
 	 * values: none, auto
 	 * ---end---
 	 */
-	g_object_class_install_property
-	    (object_class, PROP_METHOD,
-	     g_param_spec_int (NM_SETTING_PROXY_METHOD, "", "",
-	                       G_MININT32, G_MAXINT32, NM_SETTING_PROXY_METHOD_NONE,
-	                       G_PARAM_READWRITE |
-	                       G_PARAM_CONSTRUCT |
-	                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_METHOD] =
+	    g_param_spec_int (NM_SETTING_PROXY_METHOD, "", "",
+	                      G_MININT32, G_MAXINT32, NM_SETTING_PROXY_METHOD_NONE,
+	                      G_PARAM_READWRITE |
+	                      G_PARAM_CONSTRUCT |
+	                      G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingProxy:browser-only:
@@ -334,12 +330,11 @@ nm_setting_proxy_class_init (NMSettingProxyClass *klass)
 	 * description: Whether the proxy configuration is for browser only.
 	 * ---end---
 	 */
-	g_object_class_install_property
-	    (object_class, PROP_BROWSER_ONLY,
-	     g_param_spec_boolean (NM_SETTING_PROXY_BROWSER_ONLY, "", "",
-	                           FALSE,
-	                           G_PARAM_READWRITE |
-	                           G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_BROWSER_ONLY] =
+	    g_param_spec_boolean (NM_SETTING_PROXY_BROWSER_ONLY, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingProxy:pac-url:
@@ -355,12 +350,11 @@ nm_setting_proxy_class_init (NMSettingProxyClass *klass)
 	 * example: PAC_URL=http://wpad.mycompany.com/wpad.dat
 	 * ---end---
 	 */
-	g_object_class_install_property
-	    (object_class, PROP_PAC_URL,
-	     g_param_spec_string (NM_SETTING_PROXY_PAC_URL, "", "",
-	                          NULL,
-	                          G_PARAM_READWRITE |
-	                          G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PAC_URL] =
+	    g_param_spec_string (NM_SETTING_PROXY_PAC_URL, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingProxy:pac-script:
@@ -376,12 +370,13 @@ nm_setting_proxy_class_init (NMSettingProxyClass *klass)
 	 * example: PAC_SCRIPT=/home/joe/proxy.pac
 	 * ---end---
 	 */
-	g_object_class_install_property
-	    (object_class, PROP_PAC_SCRIPT,
-	     g_param_spec_string (NM_SETTING_PROXY_PAC_SCRIPT, "", "",
-	                          NULL,
-	                          G_PARAM_READWRITE |
-	                          G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PAC_SCRIPT] =
+	    g_param_spec_string (NM_SETTING_PROXY_PAC_SCRIPT, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit (setting_class, NM_META_SETTING_TYPE_PROXY);
 }

--- a/libnm-core/nm-setting-proxy.c
+++ b/libnm-core/nm-setting-proxy.c
@@ -22,6 +22,7 @@
 #include "nm-default.h"
 
 #include "nm-setting-proxy.h"
+
 #include "nm-utils.h"
 #include "nm-setting-private.h"
 
@@ -39,16 +40,7 @@
  * to fulfill client queries.
  **/
 
-G_DEFINE_TYPE (NMSettingProxy, nm_setting_proxy, NM_TYPE_SETTING)
-
-#define NM_SETTING_PROXY_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_PROXY, NMSettingProxyPrivate))
-
-typedef struct {
-	NMSettingProxyMethod method;
-	gboolean browser_only;
-	char *pac_url;
-	char *pac_script;
-} NMSettingProxyPrivate;
+/*****************************************************************************/
 
 NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_METHOD,
@@ -57,20 +49,18 @@ NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_PAC_SCRIPT,
 );
 
-/**
- * nm_setting_proxy_new:
- *
- * Creates a new #NMSettingProxy object.
- *
- * Returns: the new empty #NMSettingProxy object
- *
- * Since: 1.6
- **/
-NMSetting *
-nm_setting_proxy_new (void)
-{
-	return (NMSetting *) g_object_new (NM_TYPE_SETTING_PROXY, NULL);
-}
+typedef struct {
+	NMSettingProxyMethod method;
+	gboolean browser_only;
+	char *pac_url;
+	char *pac_script;
+} NMSettingProxyPrivate;
+
+G_DEFINE_TYPE (NMSettingProxy, nm_setting_proxy, NM_TYPE_SETTING)
+
+#define NM_SETTING_PROXY_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_PROXY, NMSettingProxyPrivate))
+
+/*****************************************************************************/
 
 /**
  * nm_setting_proxy_get_method:
@@ -210,22 +200,7 @@ verify (NMSetting *setting, NMConnection *connection, GError **error)
 	return TRUE;
 }
 
-static void
-nm_setting_proxy_init (NMSettingProxy *setting)
-{
-}
-
-static void
-finalize (GObject *object)
-{
-	NMSettingProxy *self = NM_SETTING_PROXY (object);
-	NMSettingProxyPrivate *priv = NM_SETTING_PROXY_GET_PRIVATE (self);
-
-	g_free (priv->pac_url);
-	g_free (priv->pac_script);
-
-	G_OBJECT_CLASS (nm_setting_proxy_parent_class)->finalize (object);
-}
+/*****************************************************************************/
 
 static void
 get_property (GObject *object, guint prop_id,
@@ -279,6 +254,40 @@ set_property (GObject *object, guint prop_id,
 	}
 }
 
+/*****************************************************************************/
+
+static void
+nm_setting_proxy_init (NMSettingProxy *setting)
+{
+}
+
+/**
+ * nm_setting_proxy_new:
+ *
+ * Creates a new #NMSettingProxy object.
+ *
+ * Returns: the new empty #NMSettingProxy object
+ *
+ * Since: 1.6
+ **/
+NMSetting *
+nm_setting_proxy_new (void)
+{
+	return (NMSetting *) g_object_new (NM_TYPE_SETTING_PROXY, NULL);
+}
+
+static void
+finalize (GObject *object)
+{
+	NMSettingProxy *self = NM_SETTING_PROXY (object);
+	NMSettingProxyPrivate *priv = NM_SETTING_PROXY_GET_PRIVATE (self);
+
+	g_free (priv->pac_url);
+	g_free (priv->pac_script);
+
+	G_OBJECT_CLASS (nm_setting_proxy_parent_class)->finalize (object);
+}
+
 static void
 nm_setting_proxy_class_init (NMSettingProxyClass *klass)
 {
@@ -287,8 +296,8 @@ nm_setting_proxy_class_init (NMSettingProxyClass *klass)
 
 	g_type_class_add_private (klass, sizeof (NMSettingProxyPrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->verify = verify;

--- a/libnm-core/nm-setting-serial.c
+++ b/libnm-core/nm-setting-serial.c
@@ -49,16 +49,13 @@ typedef struct {
 	guint64 send_delay;
 } NMSettingSerialPrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_BAUD,
 	PROP_BITS,
 	PROP_PARITY,
 	PROP_STOPBITS,
 	PROP_SEND_DELAY,
-
-	LAST_PROP
-};
+);
 
 /**
  * nm_setting_serial_new:
@@ -254,26 +251,24 @@ nm_setting_serial_class_init (NMSettingSerialClass *klass)
 	 * value usually has no effect for mobile broadband modems as they generally
 	 * ignore speed settings and use the highest available speed.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_BAUD,
-		 g_param_spec_uint (NM_SETTING_SERIAL_BAUD, "", "",
-		                    0, G_MAXUINT, 57600,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_BAUD] =
+	    g_param_spec_uint (NM_SETTING_SERIAL_BAUD, "", "",
+	                       0, G_MAXUINT, 57600,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingSerial:bits:
 	 *
 	 * Byte-width of the serial communication. The 8 in "8n1" for example.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_BITS,
-		 g_param_spec_uint (NM_SETTING_SERIAL_BITS, "", "",
-		                    5, 8, 8,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_BITS] =
+	    g_param_spec_uint (NM_SETTING_SERIAL_BITS, "", "",
+	                       5, 8, 8,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingSerial:parity:
@@ -295,18 +290,16 @@ nm_setting_serial_class_init (NMSettingSerialClass *klass)
 	 *   111 (ASCII 'o') for odd, 110 (ASCII 'n') for none.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_PARITY,
-		 g_param_spec_enum (NM_SETTING_SERIAL_PARITY, "", "",
-		                    NM_TYPE_SETTING_SERIAL_PARITY,
-		                    NM_SETTING_SERIAL_PARITY_NONE,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PARITY] =
+	    g_param_spec_enum (NM_SETTING_SERIAL_PARITY, "", "",
+	                       NM_TYPE_SETTING_SERIAL_PARITY,
+	                       NM_SETTING_SERIAL_PARITY_NONE,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_transform (properties_override,
-	                                    g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                  NM_SETTING_SERIAL_PARITY),
+	                                    obj_properties[PROP_PARITY],
 	                                    G_VARIANT_TYPE_BYTE,
 	                                    parity_to_dbus,
 	                                    parity_from_dbus);
@@ -317,26 +310,26 @@ nm_setting_serial_class_init (NMSettingSerialClass *klass)
 	 * Number of stop bits for communication on the serial port.  Either 1 or 2.
 	 * The 1 in "8n1" for example.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_STOPBITS,
-		 g_param_spec_uint (NM_SETTING_SERIAL_STOPBITS, "", "",
-		                    1, 2, 1,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_STOPBITS] =
+	    g_param_spec_uint (NM_SETTING_SERIAL_STOPBITS, "", "",
+	                       1, 2, 1,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingSerial:send-delay:
 	 *
 	 * Time to delay between each byte sent to the modem, in microseconds.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_SEND_DELAY,
-		 g_param_spec_uint64 (NM_SETTING_SERIAL_SEND_DELAY, "", "",
-		                      0, G_MAXUINT64, 0,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_CONSTRUCT |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_SEND_DELAY] =
+	    g_param_spec_uint64 (NM_SETTING_SERIAL_SEND_DELAY, "", "",
+	                         0, G_MAXUINT64, 0,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_CONSTRUCT |
+	                         G_PARAM_STATIC_STRINGS);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit_full (setting_class, NM_META_SETTING_TYPE_SERIAL,
 	                               NULL, properties_override);

--- a/libnm-core/nm-setting-serial.c
+++ b/libnm-core/nm-setting-serial.c
@@ -22,9 +22,10 @@
 
 #include "nm-default.h"
 
+#include "nm-setting-serial.h"
+
 #include <string.h>
 
-#include "nm-setting-serial.h"
 #include "nm-setting-private.h"
 
 /**
@@ -37,17 +38,7 @@
  * such as mobile broadband or analog telephone connections.
  **/
 
-G_DEFINE_TYPE (NMSettingSerial, nm_setting_serial, NM_TYPE_SETTING)
-
-#define NM_SETTING_SERIAL_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_SERIAL, NMSettingSerialPrivate))
-
-typedef struct {
-	guint baud;
-	guint bits;
-	char parity;
-	guint stopbits;
-	guint64 send_delay;
-} NMSettingSerialPrivate;
+/*****************************************************************************/
 
 NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_BAUD,
@@ -57,18 +48,19 @@ NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_SEND_DELAY,
 );
 
-/**
- * nm_setting_serial_new:
- *
- * Creates a new #NMSettingSerial object with default values.
- *
- * Returns: (transfer full): the new empty #NMSettingSerial object
- **/
-NMSetting *
-nm_setting_serial_new (void)
-{
-	return (NMSetting *) g_object_new (NM_TYPE_SETTING_SERIAL, NULL);
-}
+typedef struct {
+	guint baud;
+	guint bits;
+	char parity;
+	guint stopbits;
+	guint64 send_delay;
+} NMSettingSerialPrivate;
+
+G_DEFINE_TYPE (NMSettingSerial, nm_setting_serial, NM_TYPE_SETTING)
+
+#define NM_SETTING_SERIAL_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_SERIAL, NMSettingSerialPrivate))
+
+/*****************************************************************************/
 
 /**
  * nm_setting_serial_get_baud:
@@ -140,11 +132,6 @@ nm_setting_serial_get_send_delay (NMSettingSerial *setting)
 	return NM_SETTING_SERIAL_GET_PRIVATE (setting)->send_delay;
 }
 
-static void
-nm_setting_serial_init (NMSettingSerial *setting)
-{
-}
-
 static GVariant *
 parity_to_dbus (const GValue *from)
 {
@@ -172,6 +159,36 @@ parity_from_dbus (GVariant *from, GValue *to)
 	case 'n':
 	default:
 		g_value_set_enum (to, NM_SETTING_SERIAL_PARITY_NONE);
+		break;
+	}
+}
+
+/*****************************************************************************/
+
+static void
+get_property (GObject *object, guint prop_id,
+              GValue *value, GParamSpec *pspec)
+{
+	NMSettingSerial *setting = NM_SETTING_SERIAL (object);
+
+	switch (prop_id) {
+	case PROP_BAUD:
+		g_value_set_uint (value, nm_setting_serial_get_baud (setting));
+		break;
+	case PROP_BITS:
+		g_value_set_uint (value, nm_setting_serial_get_bits (setting));
+		break;
+	case PROP_PARITY:
+		g_value_set_enum (value, nm_setting_serial_get_parity (setting));
+		break;
+	case PROP_STOPBITS:
+		g_value_set_uint (value, nm_setting_serial_get_stopbits (setting));
+		break;
+	case PROP_SEND_DELAY:
+		g_value_set_uint64 (value, nm_setting_serial_get_send_delay (setting));
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
 		break;
 	}
 }
@@ -204,32 +221,24 @@ set_property (GObject *object, guint prop_id,
 	}
 }
 
-static void
-get_property (GObject *object, guint prop_id,
-              GValue *value, GParamSpec *pspec)
-{
-	NMSettingSerial *setting = NM_SETTING_SERIAL (object);
+/*****************************************************************************/
 
-	switch (prop_id) {
-	case PROP_BAUD:
-		g_value_set_uint (value, nm_setting_serial_get_baud (setting));
-		break;
-	case PROP_BITS:
-		g_value_set_uint (value, nm_setting_serial_get_bits (setting));
-		break;
-	case PROP_PARITY:
-		g_value_set_enum (value, nm_setting_serial_get_parity (setting));
-		break;
-	case PROP_STOPBITS:
-		g_value_set_uint (value, nm_setting_serial_get_stopbits (setting));
-		break;
-	case PROP_SEND_DELAY:
-		g_value_set_uint64 (value, nm_setting_serial_get_send_delay (setting));
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
+static void
+nm_setting_serial_init (NMSettingSerial *setting)
+{
+}
+
+/**
+ * nm_setting_serial_new:
+ *
+ * Creates a new #NMSettingSerial object with default values.
+ *
+ * Returns: (transfer full): the new empty #NMSettingSerial object
+ **/
+NMSetting *
+nm_setting_serial_new (void)
+{
+	return (NMSetting *) g_object_new (NM_TYPE_SETTING_SERIAL, NULL);
 }
 
 static void
@@ -241,8 +250,8 @@ nm_setting_serial_class_init (NMSettingSerialClass *klass)
 
 	g_type_class_add_private (klass, sizeof (NMSettingSerialPrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 
 	/**
 	 * NMSettingSerial:baud:

--- a/libnm-core/nm-setting-sriov.c
+++ b/libnm-core/nm-setting-sriov.c
@@ -44,14 +44,11 @@ struct _NMSettingSriovClass {
 
 G_DEFINE_TYPE (NMSettingSriov, nm_setting_sriov, NM_TYPE_SETTING)
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE (NMSettingSriov,
 	PROP_TOTAL_VFS,
 	PROP_VFS,
 	PROP_AUTOPROBE_DRIVERS,
-
-	LAST_PROP
-};
+);
 
 /*****************************************************************************/
 
@@ -790,7 +787,7 @@ nm_setting_sriov_add_vf (NMSettingSriov *setting, NMSriovVF *vf)
 	g_return_if_fail (vf->refcount > 0);
 
 	g_ptr_array_add (setting->vfs, nm_sriov_vf_dup (vf));
-	g_object_notify (G_OBJECT (setting), NM_SETTING_SRIOV_VFS);
+	_notify (setting, PROP_VFS);
 }
 
 /**
@@ -809,7 +806,7 @@ nm_setting_sriov_remove_vf (NMSettingSriov *setting, guint idx)
 	g_return_if_fail (idx < setting->vfs->len);
 
 	g_ptr_array_remove_index (setting->vfs, idx);
-	g_object_notify (G_OBJECT (setting), NM_SETTING_SRIOV_VFS);
+	_notify (setting, PROP_VFS);
 }
 
 /**
@@ -834,7 +831,7 @@ nm_setting_sriov_remove_vf_by_index (NMSettingSriov *setting,
 	for (i = 0; i < setting->vfs->len; i++) {
 		if (nm_sriov_vf_get_index  (setting->vfs->pdata[i]) == index) {
 			g_ptr_array_remove_index (setting->vfs, i);
-			g_object_notify (G_OBJECT (setting), NM_SETTING_SRIOV_VFS);
+			_notify (setting, PROP_VFS);
 			return TRUE;
 		}
 	}
@@ -856,7 +853,7 @@ nm_setting_sriov_clear_vfs (NMSettingSriov *setting)
 
 	if (setting->vfs->len != 0) {
 		g_ptr_array_set_size (setting->vfs, 0);
-		g_object_notify (G_OBJECT (setting), NM_SETTING_SRIOV_VFS);
+		_notify (setting, PROP_VFS);
 	}
 }
 
@@ -1270,14 +1267,13 @@ nm_setting_sriov_class_init (NMSettingSriovClass *klass)
 	 * example: SRIOV_TOTAL_VFS=16
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_TOTAL_VFS,
-		 g_param_spec_uint (NM_SETTING_SRIOV_TOTAL_VFS, "", "",
-		                    0, G_MAXUINT32, 0,
-		                    NM_SETTING_PARAM_FUZZY_IGNORE |
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_TOTAL_VFS] =
+	    g_param_spec_uint (NM_SETTING_SRIOV_TOTAL_VFS, "", "",
+	                       0, G_MAXUINT32, 0,
+	                       NM_SETTING_PARAM_FUZZY_IGNORE |
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingSriov:vfs: (type GPtrArray(NMSriovVF))
@@ -1318,17 +1314,15 @@ nm_setting_sriov_class_init (NMSettingSriovClass *klass)
 	 * example: SRIOV_VF10="mac=00:11:22:33:44:55", ...
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_VFS,
-		 g_param_spec_boxed (NM_SETTING_SRIOV_VFS, "", "",
-		                     G_TYPE_PTR_ARRAY,
-		                     G_PARAM_READWRITE |
-		                     NM_SETTING_PARAM_INFERRABLE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_VFS] =
+	    g_param_spec_boxed (NM_SETTING_SRIOV_VFS, "", "",
+	                        G_TYPE_PTR_ARRAY,
+	                        G_PARAM_READWRITE |
+	                        NM_SETTING_PARAM_INFERRABLE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_override (properties_override,
-	                                   g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                 NM_SETTING_SRIOV_VFS),
+	                                   obj_properties[PROP_VFS],
 	                                   G_VARIANT_TYPE ("aa{sv}"),
 	                                   vfs_to_dbus,
 	                                   vfs_from_dbus,
@@ -1360,15 +1354,16 @@ nm_setting_sriov_class_init (NMSettingSriovClass *klass)
 	 * example: SRIOV_AUTOPROBE_DRIVERS=0,1
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_AUTOPROBE_DRIVERS,
-		 g_param_spec_enum (NM_SETTING_SRIOV_AUTOPROBE_DRIVERS, "", "",
-		                    nm_ternary_get_type (),
-		                    NM_TERNARY_DEFAULT,
-		                    NM_SETTING_PARAM_FUZZY_IGNORE |
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_AUTOPROBE_DRIVERS] =
+	    g_param_spec_enum (NM_SETTING_SRIOV_AUTOPROBE_DRIVERS, "", "",
+	                       nm_ternary_get_type (),
+	                       NM_TERNARY_DEFAULT,
+	                       NM_SETTING_PARAM_FUZZY_IGNORE |
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       G_PARAM_STATIC_STRINGS);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit_full (setting_class, NM_META_SETTING_TYPE_SRIOV,
 	                               NULL, properties_override);

--- a/libnm-core/nm-setting-tc-config.c
+++ b/libnm-core/nm-setting-tc-config.c
@@ -809,13 +809,10 @@ nm_tc_tfilter_set_action (NMTCTfilter *tfilter, NMTCAction *action)
 
 /*****************************************************************************/
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE (NMSettingTCConfig,
 	PROP_QDISCS,
 	PROP_TFILTERS,
-
-	LAST_PROP
-};
+);
 
 /**
  * NMSettingTCConfig:
@@ -914,7 +911,7 @@ nm_setting_tc_config_add_qdisc (NMSettingTCConfig *self,
 	}
 
 	g_ptr_array_add (self->qdiscs, nm_tc_qdisc_dup (qdisc));
-	g_object_notify (G_OBJECT (self), NM_SETTING_TC_CONFIG_QDISCS);
+	_notify (self, PROP_QDISCS);
 	return TRUE;
 }
 
@@ -935,7 +932,7 @@ nm_setting_tc_config_remove_qdisc (NMSettingTCConfig *self, guint idx)
 	g_return_if_fail (idx < self->qdiscs->len);
 
 	g_ptr_array_remove_index (self->qdiscs, idx);
-	g_object_notify (G_OBJECT (self), NM_SETTING_TC_CONFIG_QDISCS);
+	_notify (self, PROP_QDISCS);
 }
 
 /**
@@ -961,7 +958,7 @@ nm_setting_tc_config_remove_qdisc_by_value (NMSettingTCConfig *self,
 	for (i = 0; i < self->qdiscs->len; i++) {
 		if (nm_tc_qdisc_equal (self->qdiscs->pdata[i], qdisc)) {
 			g_ptr_array_remove_index (self->qdiscs, i);
-			g_object_notify (G_OBJECT (self), NM_SETTING_TC_CONFIG_QDISCS);
+			_notify (self, PROP_QDISCS);
 			return TRUE;
 		}
 	}
@@ -983,7 +980,7 @@ nm_setting_tc_config_clear_qdiscs (NMSettingTCConfig *self)
 
 	if (self->qdiscs->len != 0) {
 		g_ptr_array_set_size (self->qdiscs, 0);
-		g_object_notify (G_OBJECT (self), NM_SETTING_TC_CONFIG_QDISCS);
+		_notify (self, PROP_QDISCS);
 	}
 }
 
@@ -1051,7 +1048,7 @@ nm_setting_tc_config_add_tfilter (NMSettingTCConfig *self,
 	}
 
 	g_ptr_array_add (self->tfilters, nm_tc_tfilter_dup (tfilter));
-	g_object_notify (G_OBJECT (self), NM_SETTING_TC_CONFIG_TFILTERS);
+	_notify (self, PROP_TFILTERS);
 	return TRUE;
 }
 
@@ -1071,7 +1068,7 @@ nm_setting_tc_config_remove_tfilter (NMSettingTCConfig *self, guint idx)
 	g_return_if_fail (idx < self->tfilters->len);
 
 	g_ptr_array_remove_index (self->tfilters, idx);
-	g_object_notify (G_OBJECT (self), NM_SETTING_TC_CONFIG_TFILTERS);
+	_notify (self, PROP_TFILTERS);
 }
 
 /**
@@ -1097,7 +1094,7 @@ nm_setting_tc_config_remove_tfilter_by_value (NMSettingTCConfig *self,
 	for (i = 0; i < self->tfilters->len; i++) {
 		if (nm_tc_tfilter_equal (self->tfilters->pdata[i], tfilter)) {
 			g_ptr_array_remove_index (self->tfilters, i);
-			g_object_notify (G_OBJECT (self), NM_SETTING_TC_CONFIG_TFILTERS);
+			_notify (self, PROP_TFILTERS);
 			return TRUE;
 		}
 	}
@@ -1119,7 +1116,7 @@ nm_setting_tc_config_clear_tfilters (NMSettingTCConfig *self)
 
 	if (self->tfilters->len != 0) {
 		g_ptr_array_set_size (self->tfilters, 0);
-		g_object_notify (G_OBJECT (self), NM_SETTING_TC_CONFIG_TFILTERS);
+		_notify (self, PROP_TFILTERS);
 	}
 }
 
@@ -1619,17 +1616,15 @@ nm_setting_tc_config_class_init (NMSettingTCConfigClass *klass)
 	 * example: QDISC1=ingress, QDISC2="root handle 1234: fq_codel"
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_QDISCS,
-		 g_param_spec_boxed (NM_SETTING_TC_CONFIG_QDISCS, "", "",
-		                     G_TYPE_PTR_ARRAY,
-		                     G_PARAM_READWRITE |
-		                     NM_SETTING_PARAM_INFERRABLE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_QDISCS] =
+	    g_param_spec_boxed (NM_SETTING_TC_CONFIG_QDISCS, "", "",
+	                        G_TYPE_PTR_ARRAY,
+	                        G_PARAM_READWRITE |
+	                        NM_SETTING_PARAM_INFERRABLE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_override (properties_override,
-	                                   g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                 NM_SETTING_TC_CONFIG_QDISCS),
+	                                   obj_properties[PROP_QDISCS],
 	                                   G_VARIANT_TYPE ("aa{sv}"),
 	                                   tc_qdiscs_get,
 	                                   tc_qdiscs_set,
@@ -1647,21 +1642,21 @@ nm_setting_tc_config_class_init (NMSettingTCConfigClass *klass)
 	 * example: FILTER1="parent ffff: matchall action simple sdata Input", ...
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_TFILTERS,
-		 g_param_spec_boxed (NM_SETTING_TC_CONFIG_TFILTERS, "", "",
-		                     G_TYPE_PTR_ARRAY,
-		                     G_PARAM_READWRITE |
-		                     NM_SETTING_PARAM_INFERRABLE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_TFILTERS] =
+	    g_param_spec_boxed (NM_SETTING_TC_CONFIG_TFILTERS, "", "",
+	                        G_TYPE_PTR_ARRAY,
+	                        G_PARAM_READWRITE |
+	                        NM_SETTING_PARAM_INFERRABLE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_override (properties_override,
-	                                   g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                 NM_SETTING_TC_CONFIG_TFILTERS),
+	                                   obj_properties[PROP_TFILTERS],
 	                                   G_VARIANT_TYPE ("aa{sv}"),
 	                                   tc_tfilters_get,
 	                                   tc_tfilters_set,
 	                                   NULL);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit_full (setting_class, NM_META_SETTING_TYPE_TC_CONFIG,
 	                               NULL, properties_override);

--- a/libnm-core/nm-setting-tc-config.c
+++ b/libnm-core/nm-setting-tc-config.c
@@ -19,9 +19,10 @@
 
 #include "nm-default.h"
 
+#include "nm-setting-tc-config.h"
+
 #include <linux/pkt_sched.h>
 
-#include "nm-setting-tc-config.h"
 #include "nm-setting-private.h"
 
 /**
@@ -833,20 +834,7 @@ struct _NMSettingTCConfigClass {
 
 G_DEFINE_TYPE (NMSettingTCConfig, nm_setting_tc_config, NM_TYPE_SETTING)
 
-/**
- * nm_setting_tc_config_new:
- *
- * Creates a new #NMSettingTCConfig object with default values.
- *
- * Returns: (transfer full): the new empty #NMSettingTCConfig object
- *
- * Since: 1.12
- **/
-NMSetting *
-nm_setting_tc_config_new (void)
-{
-	return (NMSetting *) g_object_new (NM_TYPE_SETTING_TC_CONFIG, NULL);
-}
+/*****************************************************************************/
 
 /**
  * nm_setting_tc_config_get_num_qdiscs:
@@ -1122,65 +1110,6 @@ nm_setting_tc_config_clear_tfilters (NMSettingTCConfig *self)
 
 /*****************************************************************************/
 
-static void
-set_property (GObject *object, guint prop_id,
-              const GValue *value, GParamSpec *pspec)
-{
-	NMSettingTCConfig *self = NM_SETTING_TC_CONFIG (object);
-
-	switch (prop_id) {
-	case PROP_QDISCS:
-		g_ptr_array_unref (self->qdiscs);
-		self->qdiscs = _nm_utils_copy_array (g_value_get_boxed (value),
-		                                     (NMUtilsCopyFunc) nm_tc_qdisc_dup,
-		                                     (GDestroyNotify) nm_tc_qdisc_unref);
-		break;
-	case PROP_TFILTERS:
-		g_ptr_array_unref (self->tfilters);
-		self->tfilters = _nm_utils_copy_array (g_value_get_boxed (value),
-		                                       (NMUtilsCopyFunc) nm_tc_tfilter_dup,
-		                                       (GDestroyNotify) nm_tc_tfilter_unref);
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
-}
-
-static void
-get_property (GObject *object, guint prop_id,
-              GValue *value, GParamSpec *pspec)
-{
-	NMSettingTCConfig *self = NM_SETTING_TC_CONFIG (object);
-
-	switch (prop_id) {
-	case PROP_QDISCS:
-		g_value_take_boxed (value, _nm_utils_copy_array (self->qdiscs,
-		                                                 (NMUtilsCopyFunc) nm_tc_qdisc_dup,
-		                                                 (GDestroyNotify) nm_tc_qdisc_unref));
-		break;
-	case PROP_TFILTERS:
-		g_value_take_boxed (value, _nm_utils_copy_array (self->tfilters,
-		                                                 (NMUtilsCopyFunc) nm_tc_tfilter_dup,
-		                                                 (GDestroyNotify) nm_tc_tfilter_unref));
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
-}
-
-static void
-finalize (GObject *object)
-{
-	NMSettingTCConfig *self = NM_SETTING_TC_CONFIG (object);
-
-	g_ptr_array_unref (self->qdiscs);
-	g_ptr_array_unref (self->tfilters);
-
-	G_OBJECT_CLASS (nm_setting_tc_config_parent_class)->finalize (object);
-}
-
 static gboolean
 verify (NMSetting *setting, NMConnection *connection, GError **error)
 {
@@ -1270,13 +1199,6 @@ compare_property (const NMSettInfoSetting *sett_info,
 	                                                                               setting,
 	                                                                               other,
 	                                                                               flags);
-}
-
-static void
-nm_setting_tc_config_init (NMSettingTCConfig *self)
-{
-	self->qdiscs = g_ptr_array_new_with_free_func ((GDestroyNotify) nm_tc_qdisc_unref);
-	self->tfilters = g_ptr_array_new_with_free_func ((GDestroyNotify) nm_tc_tfilter_unref);
 }
 
 /**
@@ -1590,6 +1512,91 @@ tc_tfilters_set (NMSetting *setting,
 	return TRUE;
 }
 
+/*****************************************************************************/
+
+static void
+get_property (GObject *object, guint prop_id,
+              GValue *value, GParamSpec *pspec)
+{
+	NMSettingTCConfig *self = NM_SETTING_TC_CONFIG (object);
+
+	switch (prop_id) {
+	case PROP_QDISCS:
+		g_value_take_boxed (value, _nm_utils_copy_array (self->qdiscs,
+		                                                 (NMUtilsCopyFunc) nm_tc_qdisc_dup,
+		                                                 (GDestroyNotify) nm_tc_qdisc_unref));
+		break;
+	case PROP_TFILTERS:
+		g_value_take_boxed (value, _nm_utils_copy_array (self->tfilters,
+		                                                 (NMUtilsCopyFunc) nm_tc_tfilter_dup,
+		                                                 (GDestroyNotify) nm_tc_tfilter_unref));
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
+}
+
+static void
+set_property (GObject *object, guint prop_id,
+              const GValue *value, GParamSpec *pspec)
+{
+	NMSettingTCConfig *self = NM_SETTING_TC_CONFIG (object);
+
+	switch (prop_id) {
+	case PROP_QDISCS:
+		g_ptr_array_unref (self->qdiscs);
+		self->qdiscs = _nm_utils_copy_array (g_value_get_boxed (value),
+		                                     (NMUtilsCopyFunc) nm_tc_qdisc_dup,
+		                                     (GDestroyNotify) nm_tc_qdisc_unref);
+		break;
+	case PROP_TFILTERS:
+		g_ptr_array_unref (self->tfilters);
+		self->tfilters = _nm_utils_copy_array (g_value_get_boxed (value),
+		                                       (NMUtilsCopyFunc) nm_tc_tfilter_dup,
+		                                       (GDestroyNotify) nm_tc_tfilter_unref);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
+}
+
+/*****************************************************************************/
+
+static void
+nm_setting_tc_config_init (NMSettingTCConfig *self)
+{
+	self->qdiscs = g_ptr_array_new_with_free_func ((GDestroyNotify) nm_tc_qdisc_unref);
+	self->tfilters = g_ptr_array_new_with_free_func ((GDestroyNotify) nm_tc_tfilter_unref);
+}
+
+/**
+ * nm_setting_tc_config_new:
+ *
+ * Creates a new #NMSettingTCConfig object with default values.
+ *
+ * Returns: (transfer full): the new empty #NMSettingTCConfig object
+ *
+ * Since: 1.12
+ **/
+NMSetting *
+nm_setting_tc_config_new (void)
+{
+	return (NMSetting *) g_object_new (NM_TYPE_SETTING_TC_CONFIG, NULL);
+}
+
+static void
+finalize (GObject *object)
+{
+	NMSettingTCConfig *self = NM_SETTING_TC_CONFIG (object);
+
+	g_ptr_array_unref (self->qdiscs);
+	g_ptr_array_unref (self->tfilters);
+
+	G_OBJECT_CLASS (nm_setting_tc_config_parent_class)->finalize (object);
+}
+
 static void
 nm_setting_tc_config_class_init (NMSettingTCConfigClass *klass)
 {
@@ -1597,8 +1604,8 @@ nm_setting_tc_config_class_init (NMSettingTCConfigClass *klass)
 	NMSettingClass *setting_class = NM_SETTING_CLASS (klass);
 	GArray *properties_override = _nm_sett_info_property_override_create_array ();
 
-	object_class->set_property     = set_property;
 	object_class->get_property     = get_property;
+	object_class->set_property     = set_property;
 	object_class->finalize         = finalize;
 
 	setting_class->compare_property = compare_property;

--- a/libnm-core/nm-setting-team-port.c
+++ b/libnm-core/nm-setting-team-port.c
@@ -54,8 +54,7 @@ typedef struct {
 } NMSettingTeamPortPrivate;
 
 /* Keep aligned with _prop_to_keys[] */
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE (NMSettingTeamPort,
 	PROP_CONFIG,
 	PROP_QUEUE_ID,
 	PROP_PRIO,
@@ -63,12 +62,10 @@ enum {
 	PROP_LACP_PRIO,
 	PROP_LACP_KEY,
 	PROP_LINK_WATCHERS,
-	LAST_PROP
-};
+);
 
 /* Keep aligned with team-port properties enum */
-static const _NMUtilsTeamPropertyKeys _prop_to_keys[LAST_PROP] = {
-	[PROP_0] =             { NULL, NULL, NULL, 0 },
+static const _NMUtilsTeamPropertyKeys _prop_to_keys[_PROPERTY_ENUMS_LAST] = {
 	[PROP_CONFIG] =        { NULL, NULL, NULL, 0 },
 	[PROP_QUEUE_ID] =      { "queue_id", NULL, NULL, NM_SETTING_TEAM_PORT_QUEUE_ID_DEFAULT },
 	[PROP_PRIO] =          { "prio", NULL, NULL, 0 },
@@ -251,7 +248,7 @@ nm_setting_team_port_add_link_watcher (NMSettingTeamPort *setting,
 	}
 
 	g_ptr_array_add (priv->link_watchers, nm_team_link_watcher_dup (link_watcher));
-	g_object_notify (G_OBJECT (setting), NM_SETTING_TEAM_PORT_LINK_WATCHERS);
+	_notify (setting, PROP_LINK_WATCHERS);
 	return TRUE;
 }
 
@@ -273,7 +270,7 @@ nm_setting_team_port_remove_link_watcher (NMSettingTeamPort *setting, guint idx)
 	g_return_if_fail (idx < priv->link_watchers->len);
 
 	g_ptr_array_remove_index (priv->link_watchers, idx);
-	g_object_notify (G_OBJECT (setting), NM_SETTING_TEAM_PORT_LINK_WATCHERS);
+	_notify (setting, PROP_LINK_WATCHERS);
 }
 
 /**
@@ -299,7 +296,7 @@ nm_setting_team_port_remove_link_watcher_by_value (NMSettingTeamPort *setting,
 	for (i = 0; i < priv->link_watchers->len; i++) {
 		if (nm_team_link_watcher_equal (priv->link_watchers->pdata[i], link_watcher)) {
 			g_ptr_array_remove_index (priv->link_watchers, i);
-			g_object_notify (G_OBJECT (setting), NM_SETTING_TEAM_PORT_LINK_WATCHERS);
+			_notify (setting, PROP_LINK_WATCHERS);
 			return TRUE;
 		}
 	}
@@ -323,7 +320,7 @@ nm_setting_team_port_clear_link_watchers (NMSettingTeamPort *setting)
 
 	if (priv->link_watchers->len != 0) {
 		g_ptr_array_set_size (priv->link_watchers, 0);
-		g_object_notify (G_OBJECT (setting), NM_SETTING_TEAM_PORT_LINK_WATCHERS);
+		_notify (setting, PROP_LINK_WATCHERS);
 	}
 }
 
@@ -634,13 +631,12 @@ nm_setting_team_port_class_init (NMSettingTeamPortClass *klass)
 	 * description: Team port configuration in JSON. See man teamd.conf for details.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_CONFIG,
-		 g_param_spec_string (NM_SETTING_TEAM_PORT_CONFIG, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_CONFIG] =
+	    g_param_spec_string (NM_SETTING_TEAM_PORT_CONFIG, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTeamPort:queue-id:
@@ -650,12 +646,11 @@ nm_setting_team_port_class_init (NMSettingTeamPortClass *klass)
 	 *
 	 * Since: 1.12
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_QUEUE_ID,
-		 g_param_spec_int (NM_SETTING_TEAM_PORT_QUEUE_ID, "", "",
-		                   G_MININT32, G_MAXINT32, 0,
-		                   G_PARAM_READWRITE |
-		                   G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_QUEUE_ID] =
+	    g_param_spec_int (NM_SETTING_TEAM_PORT_QUEUE_ID, "", "",
+	                      G_MININT32, G_MAXINT32, 0,
+	                      G_PARAM_READWRITE |
+	                      G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTeamPort:prio:
@@ -664,12 +659,11 @@ nm_setting_team_port_class_init (NMSettingTeamPortClass *klass)
 	 *
 	 * Since: 1.12
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_PRIO,
-		 g_param_spec_int (NM_SETTING_TEAM_PORT_PRIO, "", "",
-		                   G_MININT32, G_MAXINT32, 0,
-		                   G_PARAM_READWRITE |
-		                   G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PRIO] =
+	    g_param_spec_int (NM_SETTING_TEAM_PORT_PRIO, "", "",
+	                      G_MININT32, G_MAXINT32, 0,
+	                      G_PARAM_READWRITE |
+	                      G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTeamPort:sticky:
@@ -678,12 +672,11 @@ nm_setting_team_port_class_init (NMSettingTeamPortClass *klass)
 	 *
 	 * Since: 1.12
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_STICKY,
-		 g_param_spec_boolean (NM_SETTING_TEAM_PORT_STICKY, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_STICKY] =
+	    g_param_spec_boolean (NM_SETTING_TEAM_PORT_STICKY, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTeamPort:lacp-prio:
@@ -692,12 +685,11 @@ nm_setting_team_port_class_init (NMSettingTeamPortClass *klass)
 	 *
 	 * Since: 1.12
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_LACP_PRIO,
-		 g_param_spec_int (NM_SETTING_TEAM_PORT_LACP_PRIO, "", "",
-		                   G_MININT32, G_MAXINT32, 0,
-		                   G_PARAM_READWRITE |
-		                   G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_LACP_PRIO] =
+	    g_param_spec_int (NM_SETTING_TEAM_PORT_LACP_PRIO, "", "",
+	                      G_MININT32, G_MAXINT32, 0,
+	                      G_PARAM_READWRITE |
+	                      G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTeamPort:lacp-key:
@@ -706,12 +698,11 @@ nm_setting_team_port_class_init (NMSettingTeamPortClass *klass)
 	 *
 	 * Since: 1.12
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_LACP_KEY,
-		 g_param_spec_int (NM_SETTING_TEAM_PORT_LACP_KEY, "", "",
-		                   G_MININT32, G_MAXINT32, 0,
-		                   G_PARAM_READWRITE |
-		                   G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_LACP_KEY] =
+	    g_param_spec_int (NM_SETTING_TEAM_PORT_LACP_KEY, "", "",
+	                      G_MININT32, G_MAXINT32, 0,
+	                      G_PARAM_READWRITE |
+	                      G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTeamPort:link-watchers: (type GPtrArray(NMTeamLinkWatcher))
@@ -727,19 +718,19 @@ nm_setting_team_port_class_init (NMSettingTeamPortClass *klass)
 	 *
 	 * Since: 1.12
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_LINK_WATCHERS,
-		 g_param_spec_boxed (NM_SETTING_TEAM_PORT_LINK_WATCHERS, "", "",
-		                     G_TYPE_PTR_ARRAY,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_LINK_WATCHERS] =
+	    g_param_spec_boxed (NM_SETTING_TEAM_PORT_LINK_WATCHERS, "", "",
+	                        G_TYPE_PTR_ARRAY,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_transform (properties_override,
-	                                    g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                  NM_SETTING_TEAM_PORT_LINK_WATCHERS),
+	                                    obj_properties[PROP_LINK_WATCHERS],
 	                                    G_VARIANT_TYPE ("aa{sv}"),
 	                                    team_link_watchers_to_dbus,
 	                                    team_link_watchers_from_dbus);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit_full (setting_class, NM_META_SETTING_TYPE_TEAM_PORT,
 	                               NULL, properties_override);

--- a/libnm-core/nm-setting-team.c
+++ b/libnm-core/nm-setting-team.c
@@ -648,8 +648,7 @@ typedef struct {
 } NMSettingTeamPrivate;
 
 /* Keep aligned with _prop_to_keys[] */
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE (NMSettingTeam,
 	PROP_CONFIG,
 	PROP_NOTIFY_PEERS_COUNT,
 	PROP_NOTIFY_PEERS_INTERVAL,
@@ -666,12 +665,10 @@ enum {
 	PROP_RUNNER_MIN_PORTS,
 	PROP_RUNNER_AGG_SELECT_POLICY,
 	PROP_LINK_WATCHERS,
-	LAST_PROP
-};
+);
 
 /* Keep aligned with team properties enum */
-static const _NMUtilsTeamPropertyKeys _prop_to_keys[LAST_PROP] = {
-	[PROP_0] =                           { NULL, NULL, NULL, 0 },
+static const _NMUtilsTeamPropertyKeys _prop_to_keys[_PROPERTY_ENUMS_LAST] = {
 	[PROP_CONFIG] =                      { NULL, NULL, NULL, 0 },
 	[PROP_NOTIFY_PEERS_COUNT] =          { "notify_peers", "count", NULL, 0 },
 	[PROP_NOTIFY_PEERS_INTERVAL] =       { "notify_peers", "interval", NULL, 0 },
@@ -951,7 +948,7 @@ nm_setting_team_remove_runner_tx_hash_by_value (NMSettingTeam *setting,
 	for (i = 0; i < priv->runner_tx_hash->len; i++) {
 		if (nm_streq (txhash, priv->runner_tx_hash->pdata[i])) {
 			g_ptr_array_remove_index (priv->runner_tx_hash, i);
-			g_object_notify (G_OBJECT (setting), NM_SETTING_TEAM_RUNNER_TX_HASH);
+			_notify (setting, PROP_RUNNER_TX_HASH);
 			return TRUE;
 		}
 	}
@@ -1014,7 +1011,7 @@ nm_setting_team_remove_runner_tx_hash (NMSettingTeam *setting, guint idx)
 	g_return_if_fail (idx < priv->runner_tx_hash->len);
 
 	g_ptr_array_remove_index (priv->runner_tx_hash, idx);
-	g_object_notify (G_OBJECT (setting), NM_SETTING_TEAM_RUNNER_TX_HASH);
+	_notify (setting, PROP_RUNNER_TX_HASH);
 }
 
 /**
@@ -1047,7 +1044,7 @@ nm_setting_team_add_runner_tx_hash (NMSettingTeam *setting, const char *txhash)
 	}
 
 	g_ptr_array_add (priv->runner_tx_hash, g_strdup (txhash));
-	g_object_notify (G_OBJECT (setting), NM_SETTING_TEAM_RUNNER_TX_HASH);
+	_notify (setting, PROP_RUNNER_TX_HASH);
 	return TRUE;
 }
 
@@ -1117,7 +1114,7 @@ nm_setting_team_add_link_watcher (NMSettingTeam *setting,
 	}
 
 	g_ptr_array_add (priv->link_watchers, nm_team_link_watcher_dup (link_watcher));
-	g_object_notify (G_OBJECT (setting), NM_SETTING_TEAM_LINK_WATCHERS);
+	_notify (setting, PROP_LINK_WATCHERS);
 	return TRUE;
 }
 
@@ -1139,7 +1136,7 @@ nm_setting_team_remove_link_watcher (NMSettingTeam *setting, guint idx)
 	g_return_if_fail (idx < priv->link_watchers->len);
 
 	g_ptr_array_remove_index (priv->link_watchers, idx);
-	g_object_notify (G_OBJECT (setting), NM_SETTING_TEAM_LINK_WATCHERS);
+	_notify (setting, PROP_LINK_WATCHERS);
 }
 
 /**
@@ -1165,7 +1162,7 @@ nm_setting_team_remove_link_watcher_by_value (NMSettingTeam *setting,
 	for (i = 0; i < priv->link_watchers->len; i++) {
 		if (nm_team_link_watcher_equal (priv->link_watchers->pdata[i], link_watcher)) {
 			g_ptr_array_remove_index (priv->link_watchers, i);
-			g_object_notify (G_OBJECT (setting), NM_SETTING_TEAM_LINK_WATCHERS);
+			_notify (setting, PROP_LINK_WATCHERS);
 			return TRUE;
 		}
 	}
@@ -1188,7 +1185,7 @@ nm_setting_team_clear_link_watchers (NMSettingTeam *setting) {
 
 	if (priv->link_watchers->len != 0) {
 		g_ptr_array_set_size (priv->link_watchers, 0);
-		g_object_notify (G_OBJECT (setting), NM_SETTING_TEAM_LINK_WATCHERS);
+		_notify (setting, PROP_LINK_WATCHERS);
 	}
 }
 
@@ -1671,13 +1668,12 @@ nm_setting_team_class_init (NMSettingTeamClass *klass)
 	 * description: Team configuration in JSON. See man teamd.conf for details.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_CONFIG,
-		 g_param_spec_string (NM_SETTING_TEAM_CONFIG, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_CONFIG] =
+	    g_param_spec_string (NM_SETTING_TEAM_CONFIG, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTeam:notify-peers-count:
@@ -1686,12 +1682,11 @@ nm_setting_team_class_init (NMSettingTeamClass *klass)
 	 *
 	 * Since: 1.12
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_NOTIFY_PEERS_COUNT,
-		 g_param_spec_int (NM_SETTING_TEAM_NOTIFY_PEERS_COUNT, "", "",
-		                   G_MININT32, G_MAXINT32, 0,
-		                   G_PARAM_READWRITE |
-		                   G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_NOTIFY_PEERS_COUNT] =
+	    g_param_spec_int (NM_SETTING_TEAM_NOTIFY_PEERS_COUNT, "", "",
+	                      G_MININT32, G_MAXINT32, 0,
+	                      G_PARAM_READWRITE |
+	                      G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTeam:notify-peers-interval:
@@ -1700,12 +1695,11 @@ nm_setting_team_class_init (NMSettingTeamClass *klass)
 	 *
 	 * Since: 1.12
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_NOTIFY_PEERS_INTERVAL,
-		 g_param_spec_int (NM_SETTING_TEAM_NOTIFY_PEERS_INTERVAL, "", "",
-		                   G_MININT32, G_MAXINT32, 0,
-		                   G_PARAM_READWRITE |
-		                   G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_NOTIFY_PEERS_INTERVAL] =
+	    g_param_spec_int (NM_SETTING_TEAM_NOTIFY_PEERS_INTERVAL, "", "",
+	                      G_MININT32, G_MAXINT32, 0,
+	                      G_PARAM_READWRITE |
+	                      G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTeam:mcast-rejoin-count:
@@ -1714,12 +1708,11 @@ nm_setting_team_class_init (NMSettingTeamClass *klass)
 	 *
 	 * Since: 1.12
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_MCAST_REJOIN_COUNT,
-		 g_param_spec_int (NM_SETTING_TEAM_MCAST_REJOIN_COUNT, "", "",
-		                   G_MININT32, G_MAXINT32, 0,
-		                   G_PARAM_READWRITE |
-		                   G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MCAST_REJOIN_COUNT] =
+	    g_param_spec_int (NM_SETTING_TEAM_MCAST_REJOIN_COUNT, "", "",
+	                      G_MININT32, G_MAXINT32, 0,
+	                      G_PARAM_READWRITE |
+	                      G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTeam:mcast-rejoin-interval:
@@ -1728,12 +1721,11 @@ nm_setting_team_class_init (NMSettingTeamClass *klass)
 	 *
 	 * Since: 1.12
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_MCAST_REJOIN_INTERVAL,
-		 g_param_spec_int (NM_SETTING_TEAM_MCAST_REJOIN_INTERVAL, "", "",
-		                   G_MININT32, G_MAXINT32, 0,
-		                   G_PARAM_READWRITE |
-		                   G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MCAST_REJOIN_INTERVAL] =
+	    g_param_spec_int (NM_SETTING_TEAM_MCAST_REJOIN_INTERVAL, "", "",
+	                      G_MININT32, G_MAXINT32, 0,
+	                      G_PARAM_READWRITE |
+	                      G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTeam:runner:
@@ -1748,12 +1740,11 @@ nm_setting_team_class_init (NMSettingTeamClass *klass)
 	 *
 	 * Since: 1.12
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_RUNNER,
-		 g_param_spec_string (NM_SETTING_TEAM_RUNNER, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_RUNNER] =
+	    g_param_spec_string (NM_SETTING_TEAM_RUNNER, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTeam:runner-hwaddr-policy:
@@ -1762,12 +1753,11 @@ nm_setting_team_class_init (NMSettingTeamClass *klass)
 	 *
 	 * Since: 1.12
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_RUNNER_HWADDR_POLICY,
-		 g_param_spec_string (NM_SETTING_TEAM_RUNNER_HWADDR_POLICY, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_RUNNER_HWADDR_POLICY] =
+	    g_param_spec_string (NM_SETTING_TEAM_RUNNER_HWADDR_POLICY, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTeam:runner-tx-hash:
@@ -1776,13 +1766,12 @@ nm_setting_team_class_init (NMSettingTeamClass *klass)
 	 *
 	 * Since: 1.12
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_RUNNER_TX_HASH,
-		 g_param_spec_boxed (NM_SETTING_TEAM_RUNNER_TX_HASH, "", "",
-		                     G_TYPE_STRV,
+	obj_properties[PROP_RUNNER_TX_HASH] =
+	    g_param_spec_boxed (NM_SETTING_TEAM_RUNNER_TX_HASH, "", "",
+	                        G_TYPE_STRV,
 	                             G_PARAM_READWRITE |
-		                     NM_SETTING_PARAM_INFERRABLE |
-	                             G_PARAM_STATIC_STRINGS));
+	                        NM_SETTING_PARAM_INFERRABLE |
+	                             G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTeam:runner-tx-balancer:
@@ -1791,12 +1780,11 @@ nm_setting_team_class_init (NMSettingTeamClass *klass)
 	 *
 	 * Since: 1.12
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_RUNNER_TX_BALANCER,
-		 g_param_spec_string (NM_SETTING_TEAM_RUNNER_TX_BALANCER, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_RUNNER_TX_BALANCER] =
+	    g_param_spec_string (NM_SETTING_TEAM_RUNNER_TX_BALANCER, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTeam:runner-tx-balancer-interval:
@@ -1805,12 +1793,11 @@ nm_setting_team_class_init (NMSettingTeamClass *klass)
 	 *
 	 * Since: 1.12
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_RUNNER_TX_BALANCER_INTERVAL,
-		 g_param_spec_int (NM_SETTING_TEAM_RUNNER_TX_BALANCER_INTERVAL, "", "",
-		                   G_MININT32, G_MAXINT32, 0,
-		                   G_PARAM_READWRITE |
-		                   G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_RUNNER_TX_BALANCER_INTERVAL] =
+	    g_param_spec_int (NM_SETTING_TEAM_RUNNER_TX_BALANCER_INTERVAL, "", "",
+	                      G_MININT32, G_MAXINT32, 0,
+	                      G_PARAM_READWRITE |
+	                      G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTeam:runner-active:
@@ -1819,12 +1806,11 @@ nm_setting_team_class_init (NMSettingTeamClass *klass)
 	 *
 	 * Since: 1.12
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_RUNNER_ACTIVE,
-		 g_param_spec_boolean (NM_SETTING_TEAM_RUNNER_ACTIVE, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_RUNNER_ACTIVE] =
+	    g_param_spec_boolean (NM_SETTING_TEAM_RUNNER_ACTIVE, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTeam:runner-fast-rate:
@@ -1833,12 +1819,11 @@ nm_setting_team_class_init (NMSettingTeamClass *klass)
 	 *
 	 * Since: 1.12
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_RUNNER_FAST_RATE,
-		 g_param_spec_boolean (NM_SETTING_TEAM_RUNNER_FAST_RATE, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_RUNNER_FAST_RATE] =
+	    g_param_spec_boolean (NM_SETTING_TEAM_RUNNER_FAST_RATE, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTeam:runner-sys-prio:
@@ -1847,12 +1832,11 @@ nm_setting_team_class_init (NMSettingTeamClass *klass)
 	 *
 	 * Since: 1.12
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_RUNNER_SYS_PRIO,
-		 g_param_spec_int (NM_SETTING_TEAM_RUNNER_SYS_PRIO, "", "",
-		                   G_MININT32, G_MAXINT32, 0,
-		                   G_PARAM_READWRITE |
-		                   G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_RUNNER_SYS_PRIO] =
+	    g_param_spec_int (NM_SETTING_TEAM_RUNNER_SYS_PRIO, "", "",
+	                      G_MININT32, G_MAXINT32, 0,
+	                      G_PARAM_READWRITE |
+	                      G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTeam:runner-min-ports:
@@ -1861,12 +1845,11 @@ nm_setting_team_class_init (NMSettingTeamClass *klass)
 	 *
 	 * Since: 1.12
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_RUNNER_MIN_PORTS,
-		 g_param_spec_int (NM_SETTING_TEAM_RUNNER_MIN_PORTS, "", "",
-		                   G_MININT32, G_MAXINT32, 0,
-		                   G_PARAM_READWRITE |
-		                   G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_RUNNER_MIN_PORTS] =
+	    g_param_spec_int (NM_SETTING_TEAM_RUNNER_MIN_PORTS, "", "",
+	                      G_MININT32, G_MAXINT32, 0,
+	                      G_PARAM_READWRITE |
+	                      G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTeam:runner-agg-select-policy:
@@ -1875,12 +1858,11 @@ nm_setting_team_class_init (NMSettingTeamClass *klass)
 	 *
 	 * Since: 1.12
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_RUNNER_AGG_SELECT_POLICY,
-		 g_param_spec_string (NM_SETTING_TEAM_RUNNER_AGG_SELECT_POLICY, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_RUNNER_AGG_SELECT_POLICY] =
+	    g_param_spec_string (NM_SETTING_TEAM_RUNNER_AGG_SELECT_POLICY, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTeam:link-watchers: (type GPtrArray(NMTeamLinkWatcher))
@@ -1896,16 +1878,14 @@ nm_setting_team_class_init (NMSettingTeamClass *klass)
 	 *
 	 * Since: 1.12
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_LINK_WATCHERS,
-		 g_param_spec_boxed (NM_SETTING_TEAM_LINK_WATCHERS, "", "",
-		                     G_TYPE_PTR_ARRAY,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_LINK_WATCHERS] =
+	    g_param_spec_boxed (NM_SETTING_TEAM_LINK_WATCHERS, "", "",
+	                        G_TYPE_PTR_ARRAY,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_transform (properties_override,
-	                                    g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                  NM_SETTING_TEAM_LINK_WATCHERS),
+	                                    obj_properties[PROP_LINK_WATCHERS],
 	                                    G_VARIANT_TYPE ("aa{sv}"),
 	                                    team_link_watchers_to_dbus,
 	                                    team_link_watchers_from_dbus);
@@ -1923,6 +1903,8 @@ nm_setting_team_class_init (NMSettingTeamClass *klass)
 	                                    G_VARIANT_TYPE_STRING,
 	                                    _nm_setting_get_deprecated_virtual_interface_name,
 	                                    NULL);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit_full (setting_class, NM_META_SETTING_TYPE_TEAM,
 	                               NULL, properties_override);

--- a/libnm-core/nm-setting-tun.c
+++ b/libnm-core/nm-setting-tun.c
@@ -51,16 +51,14 @@ typedef struct {
 	gboolean multi_queue;
 } NMSettingTunPrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_MODE,
 	PROP_OWNER,
 	PROP_GROUP,
 	PROP_PI,
 	PROP_VNET_HDR,
 	PROP_MULTI_QUEUE,
-	LAST_PROP
-};
+);
 
 /**
  * nm_setting_tun_new:
@@ -313,14 +311,13 @@ nm_setting_tun_class_init (NMSettingTunClass *klass)
 	 *
 	 * Since: 1.2
 	 */
-	g_object_class_install_property
-		(object_class, PROP_MODE,
-		 g_param_spec_uint (NM_SETTING_TUN_MODE, "", "",
-		                    0, G_MAXUINT, NM_SETTING_TUN_MODE_TUN,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_INFERRABLE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MODE] =
+	    g_param_spec_uint (NM_SETTING_TUN_MODE, "", "",
+	                       0, G_MAXUINT, NM_SETTING_TUN_MODE_TUN,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTun:owner:
@@ -330,13 +327,12 @@ nm_setting_tun_class_init (NMSettingTunClass *klass)
 	 *
 	 * Since: 1.2
 	 */
-	g_object_class_install_property
-		(object_class, PROP_OWNER,
-		 g_param_spec_string (NM_SETTING_TUN_OWNER, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_OWNER] =
+	    g_param_spec_string (NM_SETTING_TUN_OWNER, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTun:group:
@@ -346,13 +342,12 @@ nm_setting_tun_class_init (NMSettingTunClass *klass)
 	 *
 	 * Since: 1.2
 	 */
-	g_object_class_install_property
-		(object_class, PROP_GROUP,
-		 g_param_spec_string (NM_SETTING_TUN_GROUP, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_GROUP] =
+	    g_param_spec_string (NM_SETTING_TUN_GROUP, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTun:pi:
@@ -362,13 +357,12 @@ nm_setting_tun_class_init (NMSettingTunClass *klass)
 	 *
 	 * Since: 1.2
 	 */
-	g_object_class_install_property
-		(object_class, PROP_PI,
-		 g_param_spec_boolean (NM_SETTING_TUN_PI, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       NM_SETTING_PARAM_INFERRABLE |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PI] =
+	    g_param_spec_boolean (NM_SETTING_TUN_PI, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          NM_SETTING_PARAM_INFERRABLE |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTun:vnet-hdr:
@@ -378,13 +372,12 @@ nm_setting_tun_class_init (NMSettingTunClass *klass)
 	 *
 	 * Since: 1.2
 	 */
-	g_object_class_install_property
-		(object_class, PROP_VNET_HDR,
-		 g_param_spec_boolean (NM_SETTING_TUN_VNET_HDR, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       NM_SETTING_PARAM_INFERRABLE |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_VNET_HDR] =
+	    g_param_spec_boolean (NM_SETTING_TUN_VNET_HDR, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          NM_SETTING_PARAM_INFERRABLE |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTun:multi-queue:
@@ -396,13 +389,14 @@ nm_setting_tun_class_init (NMSettingTunClass *klass)
 	 *
 	 * Since: 1.2
 	 */
-	g_object_class_install_property
-		(object_class, PROP_MULTI_QUEUE,
-		 g_param_spec_boolean (NM_SETTING_TUN_MULTI_QUEUE, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       NM_SETTING_PARAM_INFERRABLE |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MULTI_QUEUE] =
+	    g_param_spec_boolean (NM_SETTING_TUN_MULTI_QUEUE, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          NM_SETTING_PARAM_INFERRABLE |
+	                          G_PARAM_STATIC_STRINGS);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit (setting_class, NM_META_SETTING_TYPE_TUN);
 }

--- a/libnm-core/nm-setting-tun.c
+++ b/libnm-core/nm-setting-tun.c
@@ -21,10 +21,11 @@
 
 #include "nm-default.h"
 
+#include "nm-setting-tun.h"
+
 #include <stdlib.h>
 #include <string.h>
 
-#include "nm-setting-tun.h"
 #include "nm-utils.h"
 #include "nm-setting-connection.h"
 #include "nm-setting-private.h"
@@ -38,18 +39,7 @@
  * necessary for connection to TUN/TAP interfaces.
  **/
 
-G_DEFINE_TYPE (NMSettingTun, nm_setting_tun, NM_TYPE_SETTING)
-
-#define NM_SETTING_TUN_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_TUN, NMSettingTunPrivate))
-
-typedef struct {
-	NMSettingTunMode mode;
-	char *owner;
-	char *group;
-	gboolean pi;
-	gboolean vnet_hdr;
-	gboolean multi_queue;
-} NMSettingTunPrivate;
+/*****************************************************************************/
 
 NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_MODE,
@@ -60,20 +50,20 @@ NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_MULTI_QUEUE,
 );
 
-/**
- * nm_setting_tun_new:
- *
- * Creates a new #NMSettingTun object with default values.
- *
- * Returns: (transfer full): the new empty #NMSettingTun object
- *
- * Since: 1.2
- **/
-NMSetting *
-nm_setting_tun_new (void)
-{
-	return (NMSetting *) g_object_new (NM_TYPE_SETTING_TUN, NULL);
-}
+typedef struct {
+	NMSettingTunMode mode;
+	char *owner;
+	char *group;
+	gboolean pi;
+	gboolean vnet_hdr;
+	gboolean multi_queue;
+} NMSettingTunPrivate;
+
+G_DEFINE_TYPE (NMSettingTun, nm_setting_tun, NM_TYPE_SETTING)
+
+#define NM_SETTING_TUN_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_TUN, NMSettingTunPrivate))
+
+/*****************************************************************************/
 
 /**
  * nm_setting_tun_get_mode:
@@ -165,11 +155,6 @@ nm_setting_tun_get_multi_queue (NMSettingTun *setting)
 	return NM_SETTING_TUN_GET_PRIVATE (setting)->multi_queue;
 }
 
-static void
-nm_setting_tun_init (NMSettingTun *setting)
-{
-}
-
 static gboolean
 verify (NMSetting *setting, NMConnection *connection, GError **error)
 {
@@ -210,39 +195,8 @@ verify (NMSetting *setting, NMConnection *connection, GError **error)
 	return TRUE;
 }
 
-static void
-set_property (GObject *object, guint prop_id,
-              const GValue *value, GParamSpec *pspec)
-{
-	NMSettingTun *setting = NM_SETTING_TUN (object);
-	NMSettingTunPrivate *priv = NM_SETTING_TUN_GET_PRIVATE (setting);
+/*****************************************************************************/
 
-	switch (prop_id) {
-	case PROP_MODE:
-		priv->mode = g_value_get_uint (value);
-		break;
-	case PROP_OWNER:
-		g_free (priv->owner);
-		priv->owner = g_value_dup_string (value);
-		break;
-	case PROP_GROUP:
-		g_free (priv->group);
-		priv->group = g_value_dup_string (value);
-		break;
-	case PROP_PI:
-		priv->pi = g_value_get_boolean (value);
-		break;
-	case PROP_VNET_HDR:
-		priv->vnet_hdr = g_value_get_boolean (value);
-		break;
-	case PROP_MULTI_QUEUE:
-		priv->multi_queue = g_value_get_boolean (value);
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
-}
 static void
 get_property (GObject *object, guint prop_id,
               GValue *value, GParamSpec *pspec)
@@ -276,6 +230,61 @@ get_property (GObject *object, guint prop_id,
 }
 
 static void
+set_property (GObject *object, guint prop_id,
+              const GValue *value, GParamSpec *pspec)
+{
+	NMSettingTun *setting = NM_SETTING_TUN (object);
+	NMSettingTunPrivate *priv = NM_SETTING_TUN_GET_PRIVATE (setting);
+
+	switch (prop_id) {
+	case PROP_MODE:
+		priv->mode = g_value_get_uint (value);
+		break;
+	case PROP_OWNER:
+		g_free (priv->owner);
+		priv->owner = g_value_dup_string (value);
+		break;
+	case PROP_GROUP:
+		g_free (priv->group);
+		priv->group = g_value_dup_string (value);
+		break;
+	case PROP_PI:
+		priv->pi = g_value_get_boolean (value);
+		break;
+	case PROP_VNET_HDR:
+		priv->vnet_hdr = g_value_get_boolean (value);
+		break;
+	case PROP_MULTI_QUEUE:
+		priv->multi_queue = g_value_get_boolean (value);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
+}
+/*****************************************************************************/
+
+static void
+nm_setting_tun_init (NMSettingTun *setting)
+{
+}
+
+/**
+ * nm_setting_tun_new:
+ *
+ * Creates a new #NMSettingTun object with default values.
+ *
+ * Returns: (transfer full): the new empty #NMSettingTun object
+ *
+ * Since: 1.2
+ **/
+NMSetting *
+nm_setting_tun_new (void)
+{
+	return (NMSetting *) g_object_new (NM_TYPE_SETTING_TUN, NULL);
+}
+
+static void
 finalize (GObject *object)
 {
 	NMSettingTun *setting = NM_SETTING_TUN (object);
@@ -295,8 +304,8 @@ nm_setting_tun_class_init (NMSettingTunClass *klass)
 
 	g_type_class_add_private (klass, sizeof (NMSettingTunPrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->verify = verify;

--- a/libnm-core/nm-setting-user.c
+++ b/libnm-core/nm-setting-user.c
@@ -550,8 +550,8 @@ nm_setting_user_class_init (NMSettingUserClass *klass)
 	NMSettingClass *setting_class = NM_SETTING_CLASS (klass);
 	GArray *properties_override = _nm_sett_info_property_override_create_array ();
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->compare_property = compare_property;
@@ -584,14 +584,13 @@ nm_setting_user_class_init (NMSettingUserClass *klass)
 	                        G_PARAM_READWRITE |
 	                        G_PARAM_STATIC_STRINGS);
 
-	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
-
 	_properties_override_add_transform (properties_override,
-	                                    g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                  NM_SETTING_USER_DATA),
+	                                    obj_properties[PROP_DATA],
 	                                    G_VARIANT_TYPE ("a{ss}"),
 	                                    _nm_utils_strdict_to_dbus,
 	                                    _nm_utils_strdict_from_dbus);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit_full (setting_class, NM_META_SETTING_TYPE_USER,
 	                               NULL, properties_override);

--- a/libnm-core/nm-setting-vlan.c
+++ b/libnm-core/nm-setting-vlan.c
@@ -53,15 +53,13 @@ typedef struct {
 	GSList *egress_priority_map;
 } NMSettingVlanPrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE (NMSettingVlan,
 	PROP_PARENT,
 	PROP_ID,
 	PROP_FLAGS,
 	PROP_INGRESS_PRIORITY_MAP,
 	PROP_EGRESS_PRIORITY_MAP,
-	LAST_PROP
-};
+);
 
 #define MAX_SKB_PRIO   G_MAXUINT32
 #define MAX_8021P_PRIO 7  /* Max 802.1p priority */
@@ -214,10 +212,10 @@ set_map (NMSettingVlan *self, NMVlanPriorityMap map, GSList *list)
 
 	if (map == NM_VLAN_INGRESS_MAP) {
 		NM_SETTING_VLAN_GET_PRIVATE (self)->ingress_priority_map = list;
-		g_object_notify (G_OBJECT (self), NM_SETTING_VLAN_INGRESS_PRIORITY_MAP);
+		_notify (self, PROP_INGRESS_PRIORITY_MAP);
 	} else if (map == NM_VLAN_EGRESS_MAP) {
 		NM_SETTING_VLAN_GET_PRIVATE (self)->egress_priority_map = list;
-		g_object_notify (G_OBJECT (self), NM_SETTING_VLAN_EGRESS_PRIORITY_MAP);
+		_notify (self, PROP_EGRESS_PRIORITY_MAP);
 	} else
 		g_assert_not_reached ();
 }
@@ -273,9 +271,9 @@ nm_setting_vlan_add_priority_str (NMSettingVlan *setting,
 	if (check_replace_duplicate_priority (list, item->from, item->to)) {
 		g_free (item);
 		if (map == NM_VLAN_INGRESS_MAP)
-			g_object_notify (G_OBJECT (setting), NM_SETTING_VLAN_INGRESS_PRIORITY_MAP);
+			_notify (setting, PROP_INGRESS_PRIORITY_MAP);
 		else
-			g_object_notify (G_OBJECT (setting), NM_SETTING_VLAN_EGRESS_PRIORITY_MAP);
+			_notify (setting, PROP_EGRESS_PRIORITY_MAP);
 		return TRUE;
 	}
 
@@ -377,9 +375,9 @@ nm_setting_vlan_add_priority (NMSettingVlan *setting,
 	list = get_map (setting, map);
 	if (check_replace_duplicate_priority (list, from, to)) {
 		if (map == NM_VLAN_INGRESS_MAP)
-			g_object_notify (G_OBJECT (setting), NM_SETTING_VLAN_INGRESS_PRIORITY_MAP);
+			_notify (setting, PROP_INGRESS_PRIORITY_MAP);
 		else
-			g_object_notify (G_OBJECT (setting), NM_SETTING_VLAN_EGRESS_PRIORITY_MAP);
+			_notify (setting, PROP_EGRESS_PRIORITY_MAP);
 		return TRUE;
 	}
 
@@ -857,14 +855,13 @@ nm_setting_vlan_class_init (NMSettingVlanClass *klass)
 	 * description: Parent interface of the VLAN.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_PARENT,
-		 g_param_spec_string (NM_SETTING_VLAN_PARENT, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_CONSTRUCT |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PARENT] =
+	    g_param_spec_string (NM_SETTING_VLAN_PARENT, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_CONSTRUCT |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingVlan:id:
@@ -878,14 +875,13 @@ nm_setting_vlan_class_init (NMSettingVlanClass *klass)
 	 * description: VLAN identifier.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_ID,
-		 g_param_spec_uint (NM_SETTING_VLAN_ID, "", "",
-		                    0, 4095, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_INFERRABLE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_ID] =
+	    g_param_spec_uint (NM_SETTING_VLAN_ID, "", "",
+	                       0, 4095, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingVlan:flags:
@@ -909,19 +905,17 @@ nm_setting_vlan_class_init (NMSettingVlanClass *klass)
 	 * description: VLAN flags.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_FLAGS,
-		 g_param_spec_flags (NM_SETTING_VLAN_FLAGS, "", "",
-		                     NM_TYPE_VLAN_FLAGS,
-		                     NM_VLAN_FLAG_REORDER_HEADERS,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_CONSTRUCT |
-		                     NM_SETTING_PARAM_INFERRABLE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_FLAGS] =
+	    g_param_spec_flags (NM_SETTING_VLAN_FLAGS, "", "",
+	                        NM_TYPE_VLAN_FLAGS,
+	                        NM_VLAN_FLAG_REORDER_HEADERS,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_CONSTRUCT |
+	                        NM_SETTING_PARAM_INFERRABLE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_override (properties_override,
-	                                   g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                 NM_SETTING_VLAN_FLAGS),
+	                                   obj_properties[PROP_FLAGS],
 	                                   NULL,
 	                                   _override_flags_get,
 	                                   NULL,
@@ -941,13 +935,12 @@ nm_setting_vlan_class_init (NMSettingVlanClass *klass)
 	 * example: VLAN_INGRESS_PRIORITY_MAP=4:2,3:5
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_INGRESS_PRIORITY_MAP,
-		 g_param_spec_boxed (NM_SETTING_VLAN_INGRESS_PRIORITY_MAP, "", "",
-		                     G_TYPE_STRV,
-		                     G_PARAM_READWRITE |
-		                     NM_SETTING_PARAM_INFERRABLE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_INGRESS_PRIORITY_MAP] =
+	    g_param_spec_boxed (NM_SETTING_VLAN_INGRESS_PRIORITY_MAP, "", "",
+	                        G_TYPE_STRV,
+	                        G_PARAM_READWRITE |
+	                        NM_SETTING_PARAM_INFERRABLE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingVlan:egress-priority-map:
@@ -963,13 +956,12 @@ nm_setting_vlan_class_init (NMSettingVlanClass *klass)
 	 * example: VLAN_EGRESS_PRIORITY_MAP=5:4,4:1,3:7
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_EGRESS_PRIORITY_MAP,
-		 g_param_spec_boxed (NM_SETTING_VLAN_EGRESS_PRIORITY_MAP, "", "",
-		                     G_TYPE_STRV,
-		                     G_PARAM_READWRITE |
-		                     NM_SETTING_PARAM_INFERRABLE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_EGRESS_PRIORITY_MAP] =
+	    g_param_spec_boxed (NM_SETTING_VLAN_EGRESS_PRIORITY_MAP, "", "",
+	                        G_TYPE_STRV,
+	                        G_PARAM_READWRITE |
+	                        NM_SETTING_PARAM_INFERRABLE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/* ---ifcfg-rh---
 	 * property: interface-name
@@ -992,6 +984,8 @@ nm_setting_vlan_class_init (NMSettingVlanClass *klass)
 	                                    G_VARIANT_TYPE_STRING,
 	                                    _nm_setting_get_deprecated_virtual_interface_name,
 	                                    NULL);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit_full (setting_class, NM_META_SETTING_TYPE_VLAN,
 	                               NULL, properties_override);

--- a/libnm-core/nm-setting-vpn.c
+++ b/libnm-core/nm-setting-vpn.c
@@ -85,17 +85,14 @@ typedef struct {
 	guint32 timeout;
 } NMSettingVpnPrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE (NMSettingVpn,
 	PROP_SERVICE_TYPE,
 	PROP_USER_NAME,
 	PROP_PERSISTENT,
 	PROP_DATA,
 	PROP_SECRETS,
 	PROP_TIMEOUT,
-
-	LAST_PROP
-};
+);
 
 /**
  * nm_setting_vpn_new:
@@ -194,7 +191,7 @@ nm_setting_vpn_add_data_item (NMSettingVpn *setting,
 
 	g_hash_table_insert (NM_SETTING_VPN_GET_PRIVATE (setting)->data,
 	                     g_strdup (key), g_strdup (item));
-	g_object_notify (G_OBJECT (setting), NM_SETTING_VPN_DATA);
+	_notify (setting, PROP_DATA);
 }
 
 /**
@@ -259,7 +256,7 @@ nm_setting_vpn_remove_data_item (NMSettingVpn *setting, const char *key)
 
 	found = g_hash_table_remove (NM_SETTING_VPN_GET_PRIVATE (setting)->data, key);
 	if (found)
-		g_object_notify (G_OBJECT (setting), NM_SETTING_VPN_DATA);
+		_notify (setting, PROP_DATA);
 	return found;
 }
 
@@ -371,7 +368,7 @@ nm_setting_vpn_add_secret (NMSettingVpn *setting,
 
 	g_hash_table_insert (NM_SETTING_VPN_GET_PRIVATE (setting)->secrets,
 	                     g_strdup (key), g_strdup (secret));
-	g_object_notify (G_OBJECT (setting), NM_SETTING_VPN_SECRETS);
+	_notify (setting, PROP_SECRETS);
 }
 
 /**
@@ -436,7 +433,7 @@ nm_setting_vpn_remove_secret (NMSettingVpn *setting, const char *key)
 
 	found = g_hash_table_remove (NM_SETTING_VPN_GET_PRIVATE (setting)->secrets, key);
 	if (found)
-		g_object_notify (G_OBJECT (setting), NM_SETTING_VPN_SECRETS);
+		_notify (setting, PROP_SECRETS);
 	return found;
 }
 
@@ -694,7 +691,7 @@ update_one_secret (NMSetting *setting, const char *key, GVariant *value, GError 
 	}
 
 	if (success == NM_SETTING_UPDATE_SECRET_SUCCESS_MODIFIED)
-		g_object_notify (G_OBJECT (setting), NM_SETTING_VPN_SECRETS);
+		_notify (NM_SETTING_VPN (setting), PROP_SECRETS);
 
 	return success;
 }
@@ -754,7 +751,7 @@ set_secret_flags (NMSetting *setting,
 	g_hash_table_insert (NM_SETTING_VPN_GET_PRIVATE (setting)->data,
 	                     g_strdup_printf ("%s-flags", secret_name),
 	                     g_strdup_printf ("%u", flags));
-	g_object_notify (G_OBJECT (setting), NM_SETTING_VPN_SECRETS);
+	_notify (NM_SETTING_VPN (setting), PROP_SECRETS);
 	return TRUE;
 }
 
@@ -851,7 +848,7 @@ clear_secrets_with_flags (NMSetting *setting,
 	}
 
 	if (changed)
-		g_object_notify (G_OBJECT (setting), NM_SETTING_VPN_SECRETS);
+		_notify (NM_SETTING_VPN (setting), PROP_SECRETS);
 
 	return changed;
 }
@@ -973,12 +970,11 @@ nm_setting_vpn_class_init (NMSettingVpnClass *klass)
 	 * its network.  i.e. org.freedesktop.NetworkManager.vpnc for the vpnc
 	 * plugin.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_SERVICE_TYPE,
-		 g_param_spec_string (NM_SETTING_VPN_SERVICE_TYPE, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_SERVICE_TYPE] =
+	    g_param_spec_string (NM_SETTING_VPN_SERVICE_TYPE, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingVpn:user-name:
@@ -990,12 +986,11 @@ nm_setting_vpn_class_init (NMSettingVpnClass *klass)
 	 * will automatically supply the username of the user which requested the
 	 * VPN connection.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_USER_NAME,
-		 g_param_spec_string (NM_SETTING_VPN_USER_NAME, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_USER_NAME] =
+	    g_param_spec_string (NM_SETTING_VPN_USER_NAME, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingVpn:persistent:
@@ -1004,12 +999,11 @@ nm_setting_vpn_class_init (NMSettingVpnClass *klass)
 	 * the VPN will attempt to stay connected across link changes and outages,
 	 * until explicitly disconnected.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_PERSISTENT,
-		 g_param_spec_boolean (NM_SETTING_VPN_PERSISTENT, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PERSISTENT] =
+	    g_param_spec_boolean (NM_SETTING_VPN_PERSISTENT, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingVpn:data: (type GHashTable(utf8,utf8)):
@@ -1025,16 +1019,14 @@ nm_setting_vpn_class_init (NMSettingVpnClass *klass)
 	 * example: remote=ovpn.corp.com cipher=AES-256-CBC username=joe
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_DATA,
-		 g_param_spec_boxed (NM_SETTING_VPN_DATA, "", "",
-		                     G_TYPE_HASH_TABLE,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_DATA] =
+	    g_param_spec_boxed (NM_SETTING_VPN_DATA, "", "",
+	                        G_TYPE_HASH_TABLE,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_transform (properties_override,
-	                                    g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                  NM_SETTING_VPN_DATA),
+	                                    obj_properties[PROP_DATA],
 	                                    G_VARIANT_TYPE ("a{ss}"),
 	                                    _nm_utils_strdict_to_dbus,
 	                                    _nm_utils_strdict_from_dbus);
@@ -1053,17 +1045,15 @@ nm_setting_vpn_class_init (NMSettingVpnClass *klass)
 	 * example: password=Popocatepetl
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_SECRETS,
-		 g_param_spec_boxed (NM_SETTING_VPN_SECRETS, "", "",
-		                     G_TYPE_HASH_TABLE,
-		                     G_PARAM_READWRITE |
-		                     NM_SETTING_PARAM_SECRET |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_SECRETS] =
+	    g_param_spec_boxed (NM_SETTING_VPN_SECRETS, "", "",
+	                        G_TYPE_HASH_TABLE,
+	                        G_PARAM_READWRITE |
+	                        NM_SETTING_PARAM_SECRET |
+	                        G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_transform (properties_override,
-	                                    g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                  NM_SETTING_VPN_SECRETS),
+	                                    obj_properties[PROP_SECRETS],
 	                                    G_VARIANT_TYPE ("a{ss}"),
 	                                    _nm_utils_strdict_to_dbus,
 	                                    _nm_utils_strdict_from_dbus);
@@ -1079,12 +1069,13 @@ nm_setting_vpn_class_init (NMSettingVpnClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_TIMEOUT,
-		 g_param_spec_uint (NM_SETTING_VPN_TIMEOUT, "", "",
-		                    0, G_MAXUINT32, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_TIMEOUT] =
+	    g_param_spec_uint (NM_SETTING_VPN_TIMEOUT, "", "",
+	                       0, G_MAXUINT32, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_STATIC_STRINGS);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit_full (setting_class, NM_META_SETTING_TYPE_VPN,
 	                               NULL, properties_override);

--- a/libnm-core/nm-setting-vxlan.c
+++ b/libnm-core/nm-setting-vxlan.c
@@ -59,8 +59,7 @@ typedef struct {
 	gboolean l3_miss;
 } NMSettingVxlanPrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_PARENT,
 	PROP_ID,
 	PROP_LOCAL,
@@ -77,9 +76,7 @@ enum {
 	PROP_RSC,
 	PROP_L2_MISS,
 	PROP_L3_MISS,
-
-	LAST_PROP
-};
+);
 
 #define DST_PORT_DEFAULT   8472
 
@@ -583,14 +580,13 @@ nm_setting_vxlan_class_init (NMSettingVxlanClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_PARENT,
-		 g_param_spec_string (NM_SETTING_VXLAN_PARENT, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_CONSTRUCT |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PARENT] =
+	    g_param_spec_string (NM_SETTING_VXLAN_PARENT, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_CONSTRUCT |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 	/**
 	 * NMSettingVxlan:id:
 	 *
@@ -599,14 +595,13 @@ nm_setting_vxlan_class_init (NMSettingVxlanClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_ID,
-		 g_param_spec_uint (NM_SETTING_VXLAN_ID, "", "",
-		                    0, (1 << 24) - 1, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_INFERRABLE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_ID] =
+	    g_param_spec_uint (NM_SETTING_VXLAN_ID, "", "",
+	                       0, (1 << 24) - 1, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingVxlan:local:
@@ -615,14 +610,13 @@ nm_setting_vxlan_class_init (NMSettingVxlanClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_LOCAL,
-		 g_param_spec_string (NM_SETTING_VXLAN_LOCAL, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_CONSTRUCT |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_LOCAL] =
+	    g_param_spec_string (NM_SETTING_VXLAN_LOCAL, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_CONSTRUCT |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingVxlan:remote:
@@ -633,14 +627,13 @@ nm_setting_vxlan_class_init (NMSettingVxlanClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_REMOTE,
-		 g_param_spec_string (NM_SETTING_VXLAN_REMOTE, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_CONSTRUCT |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_REMOTE] =
+	    g_param_spec_string (NM_SETTING_VXLAN_REMOTE, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_CONSTRUCT |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingVxlan:source-port-min:
@@ -650,14 +643,13 @@ nm_setting_vxlan_class_init (NMSettingVxlanClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_SOURCE_PORT_MIN,
-		 g_param_spec_uint (NM_SETTING_VXLAN_SOURCE_PORT_MIN, "", "",
-		                    0, G_MAXUINT16, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_INFERRABLE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_SOURCE_PORT_MIN] =
+	    g_param_spec_uint (NM_SETTING_VXLAN_SOURCE_PORT_MIN, "", "",
+	                       0, G_MAXUINT16, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingVxlan:source-port-max:
@@ -667,14 +659,13 @@ nm_setting_vxlan_class_init (NMSettingVxlanClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_SOURCE_PORT_MAX,
-		 g_param_spec_uint (NM_SETTING_VXLAN_SOURCE_PORT_MAX, "", "",
-		                    0, G_MAXUINT16, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_INFERRABLE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_SOURCE_PORT_MAX] =
+	    g_param_spec_uint (NM_SETTING_VXLAN_SOURCE_PORT_MAX, "", "",
+	                       0, G_MAXUINT16, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingVxlan:destination-port:
@@ -684,14 +675,13 @@ nm_setting_vxlan_class_init (NMSettingVxlanClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_DESTINATION_PORT,
-		 g_param_spec_uint (NM_SETTING_VXLAN_DESTINATION_PORT, "", "",
-		                    0, G_MAXUINT16, DST_PORT_DEFAULT,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_INFERRABLE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_DESTINATION_PORT] =
+	    g_param_spec_uint (NM_SETTING_VXLAN_DESTINATION_PORT, "", "",
+	                       0, G_MAXUINT16, DST_PORT_DEFAULT,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingVxlan:ageing:
@@ -700,14 +690,13 @@ nm_setting_vxlan_class_init (NMSettingVxlanClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_AGEING,
-		 g_param_spec_uint (NM_SETTING_VXLAN_AGEING, "", "",
-		                    0, G_MAXUINT32, 300,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_INFERRABLE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_AGEING] =
+	    g_param_spec_uint (NM_SETTING_VXLAN_AGEING, "", "",
+	                       0, G_MAXUINT32, 300,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingVxlan:limit:
@@ -717,14 +706,13 @@ nm_setting_vxlan_class_init (NMSettingVxlanClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_LIMIT,
-		 g_param_spec_uint (NM_SETTING_VXLAN_LIMIT, "", "",
-		                    0, G_MAXUINT32, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_INFERRABLE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_LIMIT] =
+	    g_param_spec_uint (NM_SETTING_VXLAN_LIMIT, "", "",
+	                       0, G_MAXUINT32, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingVxlan:tos:
@@ -733,14 +721,13 @@ nm_setting_vxlan_class_init (NMSettingVxlanClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_TOS,
-		 g_param_spec_uint (NM_SETTING_VXLAN_TOS, "", "",
-		                    0, 255, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_INFERRABLE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_TOS] =
+	    g_param_spec_uint (NM_SETTING_VXLAN_TOS, "", "",
+	                       0, 255, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingVxlan:ttl:
@@ -749,14 +736,13 @@ nm_setting_vxlan_class_init (NMSettingVxlanClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_TTL,
-		 g_param_spec_uint (NM_SETTING_VXLAN_TTL, "", "",
-		                    0, 255, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_INFERRABLE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_TTL] =
+	    g_param_spec_uint (NM_SETTING_VXLAN_TTL, "", "",
+	                       0, 255, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_INFERRABLE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingVxlan:proxy:
@@ -765,14 +751,13 @@ nm_setting_vxlan_class_init (NMSettingVxlanClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_PROXY,
-		 g_param_spec_boolean (NM_SETTING_VXLAN_PROXY, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       NM_SETTING_PARAM_INFERRABLE |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PROXY] =
+	    g_param_spec_boolean (NM_SETTING_VXLAN_PROXY, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          NM_SETTING_PARAM_INFERRABLE |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingVxlan:learning:
@@ -782,14 +767,13 @@ nm_setting_vxlan_class_init (NMSettingVxlanClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_LEARNING,
-		 g_param_spec_boolean (NM_SETTING_VXLAN_LEARNING, "", "",
-		                       TRUE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       NM_SETTING_PARAM_INFERRABLE |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_LEARNING] =
+	    g_param_spec_boolean (NM_SETTING_VXLAN_LEARNING, "", "",
+	                          TRUE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          NM_SETTING_PARAM_INFERRABLE |
+	                          G_PARAM_STATIC_STRINGS);
 	/**
 	 * NMSettingVxlan:rsc:
 	 *
@@ -797,14 +781,13 @@ nm_setting_vxlan_class_init (NMSettingVxlanClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_RSC,
-		 g_param_spec_boolean (NM_SETTING_VXLAN_RSC, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       NM_SETTING_PARAM_INFERRABLE |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_RSC] =
+	    g_param_spec_boolean (NM_SETTING_VXLAN_RSC, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          NM_SETTING_PARAM_INFERRABLE |
+	                          G_PARAM_STATIC_STRINGS);
 	/**
 	 * NMSettingVxlan:l2-miss:
 	 *
@@ -812,14 +795,13 @@ nm_setting_vxlan_class_init (NMSettingVxlanClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_L2_MISS,
-		 g_param_spec_boolean (NM_SETTING_VXLAN_L2_MISS, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       NM_SETTING_PARAM_INFERRABLE |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_L2_MISS] =
+	    g_param_spec_boolean (NM_SETTING_VXLAN_L2_MISS, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          NM_SETTING_PARAM_INFERRABLE |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingVxlan:l3-miss:
@@ -828,14 +810,15 @@ nm_setting_vxlan_class_init (NMSettingVxlanClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_L3_MISS,
-		 g_param_spec_boolean (NM_SETTING_VXLAN_L3_MISS, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       NM_SETTING_PARAM_INFERRABLE |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_L3_MISS] =
+	    g_param_spec_boolean (NM_SETTING_VXLAN_L3_MISS, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          NM_SETTING_PARAM_INFERRABLE |
+	                          G_PARAM_STATIC_STRINGS);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit (setting_class, NM_META_SETTING_TYPE_VXLAN);
 }

--- a/libnm-core/nm-setting-vxlan.c
+++ b/libnm-core/nm-setting-vxlan.c
@@ -21,10 +21,11 @@
 
 #include "nm-default.h"
 
+#include "nm-setting-vxlan.h"
+
 #include <stdlib.h>
 #include <string.h>
 
-#include "nm-setting-vxlan.h"
 #include "nm-utils.h"
 #include "nm-setting-private.h"
 
@@ -36,28 +37,9 @@
  * necessary for connection to VXLAN interfaces.
  **/
 
-G_DEFINE_TYPE (NMSettingVxlan, nm_setting_vxlan, NM_TYPE_SETTING)
+#define DST_PORT_DEFAULT   8472
 
-#define NM_SETTING_VXLAN_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_VXLAN, NMSettingVxlanPrivate))
-
-typedef struct {
-	char *parent;
-	guint id;
-	char *local;
-	char *remote;
-	guint source_port_min;
-	guint source_port_max;
-	guint destination_port;
-	guint tos;
-	guint ttl;
-	guint ageing;
-	guint limit;
-	gboolean learning;
-	gboolean proxy;
-	gboolean rsc;
-	gboolean l2_miss;
-	gboolean l3_miss;
-} NMSettingVxlanPrivate;
+/*****************************************************************************/
 
 NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_PARENT,
@@ -78,22 +60,30 @@ NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_L3_MISS,
 );
 
-#define DST_PORT_DEFAULT   8472
+typedef struct {
+	char *parent;
+	guint id;
+	char *local;
+	char *remote;
+	guint source_port_min;
+	guint source_port_max;
+	guint destination_port;
+	guint tos;
+	guint ttl;
+	guint ageing;
+	guint limit;
+	gboolean learning;
+	gboolean proxy;
+	gboolean rsc;
+	gboolean l2_miss;
+	gboolean l3_miss;
+} NMSettingVxlanPrivate;
 
-/**
- * nm_setting_vxlan_new:
- *
- * Creates a new #NMSettingVxlan object with default values.
- *
- * Returns: (transfer full): the new empty #NMSettingVxlan object
- *
- * Since: 1.2
- **/
-NMSetting *
-nm_setting_vxlan_new (void)
-{
-	return (NMSetting *) g_object_new (NM_TYPE_SETTING_VXLAN, NULL);
-}
+G_DEFINE_TYPE (NMSettingVxlan, nm_setting_vxlan, NM_TYPE_SETTING)
+
+#define NM_SETTING_VXLAN_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_VXLAN, NMSettingVxlanPrivate))
+
+/*****************************************************************************/
 
 /**
  * nm_setting_vxlan_get_parent:
@@ -337,11 +327,6 @@ nm_setting_vxlan_get_l3_miss (NMSettingVxlan *setting)
 
 /*****************************************************************************/
 
-static void
-nm_setting_vxlan_init (NMSettingVxlan *setting)
-{
-}
-
 static gboolean
 verify (NMSetting *setting, NMConnection *connection, GError **error)
 {
@@ -419,6 +404,70 @@ verify (NMSetting *setting, NMConnection *connection, GError **error)
 	return TRUE;
 }
 
+/*****************************************************************************/
+
+static void
+get_property (GObject *object, guint prop_id,
+              GValue *value, GParamSpec *pspec)
+{
+	NMSettingVxlan *setting = NM_SETTING_VXLAN (object);
+	NMSettingVxlanPrivate *priv = NM_SETTING_VXLAN_GET_PRIVATE (setting);
+
+	switch (prop_id) {
+	case PROP_PARENT:
+		g_value_set_string (value, priv->parent);
+		break;
+	case PROP_ID:
+		g_value_set_uint (value, priv->id);
+		break;
+	case PROP_LOCAL:
+		g_value_set_string (value, priv->local);
+		break;
+	case PROP_REMOTE:
+		g_value_set_string (value, priv->remote);
+		break;
+	case PROP_SOURCE_PORT_MIN:
+		g_value_set_uint (value, priv->source_port_min);
+		break;
+	case PROP_SOURCE_PORT_MAX:
+		g_value_set_uint (value, priv->source_port_max);
+		break;
+	case PROP_DESTINATION_PORT:
+		g_value_set_uint (value, priv->destination_port);
+		break;
+	case PROP_TOS:
+		g_value_set_uint (value, priv->tos);
+		break;
+	case PROP_AGEING:
+		g_value_set_uint (value, priv->ageing);
+		break;
+	case PROP_LIMIT:
+		g_value_set_uint (value, priv->limit);
+		break;
+	case PROP_PROXY:
+		g_value_set_boolean (value, priv->proxy);
+		break;
+	case PROP_TTL:
+		g_value_set_uint (value, priv->ttl);
+		break;
+	case PROP_LEARNING:
+		g_value_set_boolean (value, priv->learning);
+		break;
+	case PROP_RSC:
+		g_value_set_boolean (value, priv->rsc);
+		break;
+	case PROP_L2_MISS:
+		g_value_set_boolean (value, priv->l2_miss);
+		break;
+	case PROP_L3_MISS:
+		g_value_set_boolean (value, priv->l3_miss);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
+}
+
 static void
 set_property (GObject *object, guint prop_id,
               const GValue *value, GParamSpec *pspec)
@@ -484,66 +533,26 @@ set_property (GObject *object, guint prop_id,
 	}
 }
 
-static void
-get_property (GObject *object, guint prop_id,
-              GValue *value, GParamSpec *pspec)
-{
-	NMSettingVxlan *setting = NM_SETTING_VXLAN (object);
-	NMSettingVxlanPrivate *priv = NM_SETTING_VXLAN_GET_PRIVATE (setting);
+/*****************************************************************************/
 
-	switch (prop_id) {
-	case PROP_PARENT:
-		g_value_set_string (value, priv->parent);
-		break;
-	case PROP_ID:
-		g_value_set_uint (value, priv->id);
-		break;
-	case PROP_LOCAL:
-		g_value_set_string (value, priv->local);
-		break;
-	case PROP_REMOTE:
-		g_value_set_string (value, priv->remote);
-		break;
-	case PROP_SOURCE_PORT_MIN:
-		g_value_set_uint (value, priv->source_port_min);
-		break;
-	case PROP_SOURCE_PORT_MAX:
-		g_value_set_uint (value, priv->source_port_max);
-		break;
-	case PROP_DESTINATION_PORT:
-		g_value_set_uint (value, priv->destination_port);
-		break;
-	case PROP_TOS:
-		g_value_set_uint (value, priv->tos);
-		break;
-	case PROP_AGEING:
-		g_value_set_uint (value, priv->ageing);
-		break;
-	case PROP_LIMIT:
-		g_value_set_uint (value, priv->limit);
-		break;
-	case PROP_PROXY:
-		g_value_set_boolean (value, priv->proxy);
-		break;
-	case PROP_TTL:
-		g_value_set_uint (value, priv->ttl);
-		break;
-	case PROP_LEARNING:
-		g_value_set_boolean (value, priv->learning);
-		break;
-	case PROP_RSC:
-		g_value_set_boolean (value, priv->rsc);
-		break;
-	case PROP_L2_MISS:
-		g_value_set_boolean (value, priv->l2_miss);
-		break;
-	case PROP_L3_MISS:
-		g_value_set_boolean (value, priv->l3_miss);
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
+static void
+nm_setting_vxlan_init (NMSettingVxlan *setting)
+{
+}
+
+/**
+ * nm_setting_vxlan_new:
+ *
+ * Creates a new #NMSettingVxlan object with default values.
+ *
+ * Returns: (transfer full): the new empty #NMSettingVxlan object
+ *
+ * Since: 1.2
+ **/
+NMSetting *
+nm_setting_vxlan_new (void)
+{
+	return (NMSetting *) g_object_new (NM_TYPE_SETTING_VXLAN, NULL);
 }
 
 static void
@@ -567,8 +576,8 @@ nm_setting_vxlan_class_init (NMSettingVxlanClass *klass)
 
 	g_type_class_add_private (klass, sizeof (NMSettingVxlanPrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->verify = verify;

--- a/libnm-core/nm-setting-wimax.c
+++ b/libnm-core/nm-setting-wimax.c
@@ -51,13 +51,10 @@ typedef struct {
 	char *mac_address;
 } NMSettingWimaxPrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_NETWORK_NAME,
 	PROP_MAC_ADDRESS,
-
-	LAST_PROP
-};
+);
 
 /**
  * nm_setting_wimax_new:
@@ -227,12 +224,11 @@ nm_setting_wimax_class_init (NMSettingWimaxClass *klass)
 	 *
 	 * Deprecated: 1.2: WiMAX is no longer supported.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_NETWORK_NAME,
-		 g_param_spec_string (NM_SETTING_WIMAX_NETWORK_NAME, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_NETWORK_NAME] =
+	    g_param_spec_string (NM_SETTING_WIMAX_NETWORK_NAME, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWimax:mac-address:
@@ -243,19 +239,19 @@ nm_setting_wimax_class_init (NMSettingWimaxClass *klass)
 	 *
 	 * Deprecated: 1.2: WiMAX is no longer supported.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_MAC_ADDRESS,
-		 g_param_spec_string (NM_SETTING_WIMAX_MAC_ADDRESS, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MAC_ADDRESS] =
+	    g_param_spec_string (NM_SETTING_WIMAX_MAC_ADDRESS, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_transform (properties_override,
-	                                    g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                  NM_SETTING_WIMAX_MAC_ADDRESS),
+	                                    obj_properties[PROP_MAC_ADDRESS],
 	                                    G_VARIANT_TYPE_BYTESTRING,
 	                                    _nm_utils_hwaddr_to_dbus,
 	                                    _nm_utils_hwaddr_from_dbus);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit_full (setting_class, NM_META_SETTING_TYPE_WIMAX,
 	                               NULL, properties_override);

--- a/libnm-core/nm-setting-wimax.c
+++ b/libnm-core/nm-setting-wimax.c
@@ -22,10 +22,11 @@
 
 #include "nm-default.h"
 
+#include "nm-setting-wimax.h"
+
 #include <string.h>
 #include <net/ethernet.h>
 
-#include "nm-setting-wimax.h"
 #include "nm-setting-private.h"
 #include "nm-utils.h"
 #include "nm-utils-private.h"
@@ -42,34 +43,23 @@
  * connections cannot be activated.
  **/
 
-G_DEFINE_TYPE (NMSettingWimax, nm_setting_wimax, NM_TYPE_SETTING)
-
-#define NM_SETTING_WIMAX_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_WIMAX, NMSettingWimaxPrivate))
-
-typedef struct {
-	char *network_name;
-	char *mac_address;
-} NMSettingWimaxPrivate;
+/*****************************************************************************/
 
 NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_NETWORK_NAME,
 	PROP_MAC_ADDRESS,
 );
 
-/**
- * nm_setting_wimax_new:
- *
- * Creates a new #NMSettingWimax object with default values.
- *
- * Returns: the new empty #NMSettingWimax object
- *
- * Deprecated: 1.2: WiMAX is no longer supported.
- **/
-NMSetting *
-nm_setting_wimax_new (void)
-{
-	return (NMSetting *) g_object_new (NM_TYPE_SETTING_WIMAX, NULL);
-}
+typedef struct {
+	char *network_name;
+	char *mac_address;
+} NMSettingWimaxPrivate;
+
+G_DEFINE_TYPE (NMSettingWimax, nm_setting_wimax, NM_TYPE_SETTING)
+
+#define NM_SETTING_WIMAX_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_WIMAX, NMSettingWimaxPrivate))
+
+/*****************************************************************************/
 
 /**
  * nm_setting_wimax_get_network_name:
@@ -144,20 +134,25 @@ verify (NMSetting *setting, NMConnection *connection, GError **error)
 	return TRUE;
 }
 
-static void
-nm_setting_wimax_init (NMSettingWimax *setting)
-{
-}
+/*****************************************************************************/
 
 static void
-finalize (GObject *object)
+get_property (GObject *object, guint prop_id,
+              GValue *value, GParamSpec *pspec)
 {
-	NMSettingWimaxPrivate *priv = NM_SETTING_WIMAX_GET_PRIVATE (object);
+	NMSettingWimax *setting = NM_SETTING_WIMAX (object);
 
-	g_free (priv->network_name);
-	g_free (priv->mac_address);
-
-	G_OBJECT_CLASS (nm_setting_wimax_parent_class)->finalize (object);
+	switch (prop_id) {
+	case PROP_NETWORK_NAME:
+		g_value_set_string (value, nm_setting_wimax_get_network_name (setting));
+		break;
+	case PROP_MAC_ADDRESS:
+		g_value_set_string (value, nm_setting_wimax_get_mac_address (setting));
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
 }
 
 static void
@@ -182,23 +177,37 @@ set_property (GObject *object, guint prop_id,
 	}
 }
 
-static void
-get_property (GObject *object, guint prop_id,
-              GValue *value, GParamSpec *pspec)
-{
-	NMSettingWimax *setting = NM_SETTING_WIMAX (object);
+/*****************************************************************************/
 
-	switch (prop_id) {
-	case PROP_NETWORK_NAME:
-		g_value_set_string (value, nm_setting_wimax_get_network_name (setting));
-		break;
-	case PROP_MAC_ADDRESS:
-		g_value_set_string (value, nm_setting_wimax_get_mac_address (setting));
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
+static void
+nm_setting_wimax_init (NMSettingWimax *setting)
+{
+}
+
+/**
+ * nm_setting_wimax_new:
+ *
+ * Creates a new #NMSettingWimax object with default values.
+ *
+ * Returns: the new empty #NMSettingWimax object
+ *
+ * Deprecated: 1.2: WiMAX is no longer supported.
+ **/
+NMSetting *
+nm_setting_wimax_new (void)
+{
+	return (NMSetting *) g_object_new (NM_TYPE_SETTING_WIMAX, NULL);
+}
+
+static void
+finalize (GObject *object)
+{
+	NMSettingWimaxPrivate *priv = NM_SETTING_WIMAX_GET_PRIVATE (object);
+
+	g_free (priv->network_name);
+	g_free (priv->mac_address);
+
+	G_OBJECT_CLASS (nm_setting_wimax_parent_class)->finalize (object);
 }
 
 static void
@@ -210,8 +219,8 @@ nm_setting_wimax_class_init (NMSettingWimaxClass *klass)
 
 	g_type_class_add_private (klass, sizeof (NMSettingWimaxPrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->verify = verify;

--- a/libnm-core/nm-setting-wired.c
+++ b/libnm-core/nm-setting-wired.c
@@ -40,26 +40,7 @@
  * necessary for connection to Ethernet networks.
  **/
 
-G_DEFINE_TYPE (NMSettingWired, nm_setting_wired, NM_TYPE_SETTING)
-
-#define NM_SETTING_WIRED_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_WIRED, NMSettingWiredPrivate))
-
-typedef struct {
-	char *port;
-	guint32 speed;
-	char *duplex;
-	gboolean auto_negotiate;
-	char *device_mac_address;
-	char *cloned_mac_address;
-	char *generate_mac_address_mask;
-	GArray *mac_address_blacklist;
-	guint32 mtu;
-	char **s390_subchannels;
-	char *s390_nettype;
-	GHashTable *s390_options;
-	NMSettingWiredWakeOnLan wol;
-	char *wol_password;
-} NMSettingWiredPrivate;
+/*****************************************************************************/
 
 NM_GOBJECT_PROPERTIES_DEFINE (NMSettingWired,
 	PROP_PORT,
@@ -78,6 +59,29 @@ NM_GOBJECT_PROPERTIES_DEFINE (NMSettingWired,
 	PROP_WAKE_ON_LAN_PASSWORD,
 );
 
+typedef struct {
+	char *port;
+	guint32 speed;
+	char *duplex;
+	gboolean auto_negotiate;
+	char *device_mac_address;
+	char *cloned_mac_address;
+	char *generate_mac_address_mask;
+	GArray *mac_address_blacklist;
+	guint32 mtu;
+	char **s390_subchannels;
+	char *s390_nettype;
+	GHashTable *s390_options;
+	NMSettingWiredWakeOnLan wol;
+	char *wol_password;
+} NMSettingWiredPrivate;
+
+G_DEFINE_TYPE (NMSettingWired, nm_setting_wired, NM_TYPE_SETTING)
+
+#define NM_SETTING_WIRED_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_WIRED, NMSettingWiredPrivate))
+
+/*****************************************************************************/
+
 static const char *valid_s390_opts[] = {
 	"portno", "layer2", "portname", "protocol", "priority_queueing",
 	"buffer_count", "isolation", "total", "inter", "inter_jumbo", "route4",
@@ -87,19 +91,6 @@ static const char *valid_s390_opts[] = {
 	"rxip_add4", "rxip_add6", "lancmd_timeout", "ctcprot",
 	NULL
 };
-
-/**
- * nm_setting_wired_new:
- *
- * Creates a new #NMSettingWired object with default values.
- *
- * Returns: (transfer full): the new empty #NMSettingWired object
- **/
-NMSetting *
-nm_setting_wired_new (void)
-{
-	return (NMSetting *) g_object_new (NM_TYPE_SETTING_WIRED, NULL);
-}
 
 /**
  * nm_setting_wired_get_port:
@@ -807,40 +798,62 @@ clear_blacklist_item (char **item_p)
 	g_free (*item_p);
 }
 
+/*****************************************************************************/
+
 static void
-nm_setting_wired_init (NMSettingWired *setting)
+get_property (GObject *object, guint prop_id,
+              GValue *value, GParamSpec *pspec)
 {
+	NMSettingWired *setting = NM_SETTING_WIRED (object);
 	NMSettingWiredPrivate *priv = NM_SETTING_WIRED_GET_PRIVATE (setting);
 
-	priv->s390_options = g_hash_table_new_full (nm_str_hash, g_str_equal, g_free, g_free);
-
-	/* We use GArray rather than GPtrArray so it will automatically be NULL-terminated */
-	priv->mac_address_blacklist = g_array_new (TRUE, FALSE, sizeof (char *));
-	g_array_set_clear_func (priv->mac_address_blacklist, (GDestroyNotify) clear_blacklist_item);
-}
-
-static void
-finalize (GObject *object)
-{
-	NMSettingWiredPrivate *priv = NM_SETTING_WIRED_GET_PRIVATE (object);
-
-	g_free (priv->port);
-	g_free (priv->duplex);
-	g_free (priv->s390_nettype);
-
-	g_hash_table_destroy (priv->s390_options);
-
-	g_free (priv->device_mac_address);
-	g_free (priv->cloned_mac_address);
-	g_free (priv->generate_mac_address_mask);
-	g_array_unref (priv->mac_address_blacklist);
-
-	if (priv->s390_subchannels)
-		g_strfreev (priv->s390_subchannels);
-
-	g_free (priv->wol_password);
-
-	G_OBJECT_CLASS (nm_setting_wired_parent_class)->finalize (object);
+	switch (prop_id) {
+	case PROP_PORT:
+		g_value_set_string (value, nm_setting_wired_get_port (setting));
+		break;
+	case PROP_SPEED:
+		g_value_set_uint (value, nm_setting_wired_get_speed (setting));
+		break;
+	case PROP_DUPLEX:
+		g_value_set_string (value, nm_setting_wired_get_duplex (setting));
+		break;
+	case PROP_AUTO_NEGOTIATE:
+		g_value_set_boolean (value, nm_setting_wired_get_auto_negotiate (setting));
+		break;
+	case PROP_MAC_ADDRESS:
+		g_value_set_string (value, nm_setting_wired_get_mac_address (setting));
+		break;
+	case PROP_CLONED_MAC_ADDRESS:
+		g_value_set_string (value, nm_setting_wired_get_cloned_mac_address (setting));
+		break;
+	case PROP_GENERATE_MAC_ADDRESS_MASK:
+		g_value_set_string (value, nm_setting_wired_get_generate_mac_address_mask (setting));
+		break;
+	case PROP_MAC_ADDRESS_BLACKLIST:
+		g_value_set_boxed (value, (char **) priv->mac_address_blacklist->data);
+		break;
+	case PROP_MTU:
+		g_value_set_uint (value, nm_setting_wired_get_mtu (setting));
+		break;
+	case PROP_S390_SUBCHANNELS:
+		g_value_set_boxed (value, priv->s390_subchannels);
+		break;
+	case PROP_S390_NETTYPE:
+		g_value_set_string (value, nm_setting_wired_get_s390_nettype (setting));
+		break;
+	case PROP_S390_OPTIONS:
+		g_value_take_boxed (value, _nm_utils_copy_strdict (priv->s390_options));
+		break;
+	case PROP_WAKE_ON_LAN:
+		g_value_set_uint (value, priv->wol);
+		break;
+	case PROP_WAKE_ON_LAN_PASSWORD:
+		g_value_set_string (value, priv->wol_password);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
 }
 
 static void
@@ -920,60 +933,55 @@ set_property (GObject *object, guint prop_id,
 	}
 }
 
+/*****************************************************************************/
+
 static void
-get_property (GObject *object, guint prop_id,
-              GValue *value, GParamSpec *pspec)
+nm_setting_wired_init (NMSettingWired *setting)
 {
-	NMSettingWired *setting = NM_SETTING_WIRED (object);
 	NMSettingWiredPrivate *priv = NM_SETTING_WIRED_GET_PRIVATE (setting);
 
-	switch (prop_id) {
-	case PROP_PORT:
-		g_value_set_string (value, nm_setting_wired_get_port (setting));
-		break;
-	case PROP_SPEED:
-		g_value_set_uint (value, nm_setting_wired_get_speed (setting));
-		break;
-	case PROP_DUPLEX:
-		g_value_set_string (value, nm_setting_wired_get_duplex (setting));
-		break;
-	case PROP_AUTO_NEGOTIATE:
-		g_value_set_boolean (value, nm_setting_wired_get_auto_negotiate (setting));
-		break;
-	case PROP_MAC_ADDRESS:
-		g_value_set_string (value, nm_setting_wired_get_mac_address (setting));
-		break;
-	case PROP_CLONED_MAC_ADDRESS:
-		g_value_set_string (value, nm_setting_wired_get_cloned_mac_address (setting));
-		break;
-	case PROP_GENERATE_MAC_ADDRESS_MASK:
-		g_value_set_string (value, nm_setting_wired_get_generate_mac_address_mask (setting));
-		break;
-	case PROP_MAC_ADDRESS_BLACKLIST:
-		g_value_set_boxed (value, (char **) priv->mac_address_blacklist->data);
-		break;
-	case PROP_MTU:
-		g_value_set_uint (value, nm_setting_wired_get_mtu (setting));
-		break;
-	case PROP_S390_SUBCHANNELS:
-		g_value_set_boxed (value, priv->s390_subchannels);
-		break;
-	case PROP_S390_NETTYPE:
-		g_value_set_string (value, nm_setting_wired_get_s390_nettype (setting));
-		break;
-	case PROP_S390_OPTIONS:
-		g_value_take_boxed (value, _nm_utils_copy_strdict (priv->s390_options));
-		break;
-	case PROP_WAKE_ON_LAN:
-		g_value_set_uint (value, priv->wol);
-		break;
-	case PROP_WAKE_ON_LAN_PASSWORD:
-		g_value_set_string (value, priv->wol_password);
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
+	priv->s390_options = g_hash_table_new_full (nm_str_hash, g_str_equal, g_free, g_free);
+
+	/* We use GArray rather than GPtrArray so it will automatically be NULL-terminated */
+	priv->mac_address_blacklist = g_array_new (TRUE, FALSE, sizeof (char *));
+	g_array_set_clear_func (priv->mac_address_blacklist, (GDestroyNotify) clear_blacklist_item);
+}
+
+/**
+ * nm_setting_wired_new:
+ *
+ * Creates a new #NMSettingWired object with default values.
+ *
+ * Returns: (transfer full): the new empty #NMSettingWired object
+ **/
+NMSetting *
+nm_setting_wired_new (void)
+{
+	return (NMSetting *) g_object_new (NM_TYPE_SETTING_WIRED, NULL);
+}
+
+static void
+finalize (GObject *object)
+{
+	NMSettingWiredPrivate *priv = NM_SETTING_WIRED_GET_PRIVATE (object);
+
+	g_free (priv->port);
+	g_free (priv->duplex);
+	g_free (priv->s390_nettype);
+
+	g_hash_table_destroy (priv->s390_options);
+
+	g_free (priv->device_mac_address);
+	g_free (priv->cloned_mac_address);
+	g_free (priv->generate_mac_address_mask);
+	g_array_unref (priv->mac_address_blacklist);
+
+	if (priv->s390_subchannels)
+		g_strfreev (priv->s390_subchannels);
+
+	g_free (priv->wol_password);
+
+	G_OBJECT_CLASS (nm_setting_wired_parent_class)->finalize (object);
 }
 
 static void
@@ -985,8 +993,8 @@ nm_setting_wired_class_init (NMSettingWiredClass *klass)
 
 	g_type_class_add_private (klass, sizeof (NMSettingWiredPrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->verify           = verify;

--- a/libnm-core/nm-setting-wired.c
+++ b/libnm-core/nm-setting-wired.c
@@ -61,8 +61,7 @@ typedef struct {
 	char *wol_password;
 } NMSettingWiredPrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE (NMSettingWired,
 	PROP_PORT,
 	PROP_SPEED,
 	PROP_DUPLEX,
@@ -77,9 +76,7 @@ enum {
 	PROP_S390_OPTIONS,
 	PROP_WAKE_ON_LAN,
 	PROP_WAKE_ON_LAN_PASSWORD,
-
-	LAST_PROP
-};
+);
 
 static const char *valid_s390_opts[] = {
 	"portno", "layer2", "portname", "protocol", "priority_queueing",
@@ -288,7 +285,7 @@ nm_setting_wired_add_mac_blacklist_item (NMSettingWired *setting, const char *ma
 
 	mac = nm_utils_hwaddr_canonical (mac, ETH_ALEN);
 	g_array_append_val (priv->mac_address_blacklist, mac);
-	g_object_notify (G_OBJECT (setting), NM_SETTING_WIRED_MAC_ADDRESS_BLACKLIST);
+	_notify (setting, PROP_MAC_ADDRESS_BLACKLIST);
 	return TRUE;
 }
 
@@ -310,7 +307,7 @@ nm_setting_wired_remove_mac_blacklist_item (NMSettingWired *setting, guint32 idx
 	g_return_if_fail (idx < priv->mac_address_blacklist->len);
 
 	g_array_remove_index (priv->mac_address_blacklist, idx);
-	g_object_notify (G_OBJECT (setting), NM_SETTING_WIRED_MAC_ADDRESS_BLACKLIST);
+	_notify (setting, PROP_MAC_ADDRESS_BLACKLIST);
 }
 
 /**
@@ -338,7 +335,7 @@ nm_setting_wired_remove_mac_blacklist_item_by_value (NMSettingWired *setting, co
 		candidate = g_array_index (priv->mac_address_blacklist, char *, i);
 		if (!nm_utils_hwaddr_matches (mac, -1, candidate, -1)) {
 			g_array_remove_index (priv->mac_address_blacklist, i);
-			g_object_notify (G_OBJECT (setting), NM_SETTING_WIRED_MAC_ADDRESS_BLACKLIST);
+			_notify (setting, PROP_MAC_ADDRESS_BLACKLIST);
 			return TRUE;
 		}
 	}
@@ -357,7 +354,7 @@ nm_setting_wired_clear_mac_blacklist_items (NMSettingWired *setting)
 	g_return_if_fail (NM_IS_SETTING_WIRED (setting));
 
 	g_array_set_size (NM_SETTING_WIRED_GET_PRIVATE (setting)->mac_address_blacklist, 0);
-	g_object_notify (G_OBJECT (setting), NM_SETTING_WIRED_MAC_ADDRESS_BLACKLIST);
+	_notify (setting, PROP_MAC_ADDRESS_BLACKLIST);
 }
 
 /**
@@ -530,7 +527,7 @@ nm_setting_wired_add_s390_option (NMSettingWired *setting,
 	g_hash_table_insert (NM_SETTING_WIRED_GET_PRIVATE (setting)->s390_options,
 	                     g_strdup (key),
 	                     g_strdup (value));
-	g_object_notify (G_OBJECT (setting), NM_SETTING_WIRED_S390_OPTIONS);
+	_notify (setting, PROP_S390_OPTIONS);
 	return TRUE;
 }
 
@@ -557,7 +554,7 @@ nm_setting_wired_remove_s390_option (NMSettingWired *setting,
 
 	found = g_hash_table_remove (NM_SETTING_WIRED_GET_PRIVATE (setting)->s390_options, key);
 	if (found)
-		g_object_notify (G_OBJECT (setting), NM_SETTING_WIRED_S390_OPTIONS);
+		_notify (setting, PROP_S390_OPTIONS);
 	return found;
 }
 
@@ -1009,12 +1006,11 @@ nm_setting_wired_class_init (NMSettingWiredClass *klass)
 	 * description: The property is not saved by the plugin.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_PORT,
-		 g_param_spec_string (NM_SETTING_WIRED_PORT, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PORT] =
+	    g_param_spec_string (NM_SETTING_WIRED_PORT, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWired:speed:
@@ -1040,13 +1036,12 @@ nm_setting_wired_class_init (NMSettingWiredClass *klass)
 	 *    parameter in the ETHTOOL_OPTS variable.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_SPEED,
-		 g_param_spec_uint (NM_SETTING_WIRED_SPEED, "", "",
-		                    0, G_MAXUINT32, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_SPEED] =
+	    g_param_spec_uint (NM_SETTING_WIRED_SPEED, "", "",
+	                       0, G_MAXUINT32, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWired:duplex:
@@ -1071,12 +1066,11 @@ nm_setting_wired_class_init (NMSettingWiredClass *klass)
 	 *    "duplex" parameter in the ETHOOL_OPTS variable.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_DUPLEX,
-		 g_param_spec_string (NM_SETTING_WIRED_DUPLEX, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_DUPLEX] =
+	    g_param_spec_string (NM_SETTING_WIRED_DUPLEX, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWired:auto-negotiate:
@@ -1098,17 +1092,15 @@ nm_setting_wired_class_init (NMSettingWiredClass *klass)
 	 *    "speed" and "duplex" parameters (skips link configuration).
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_AUTO_NEGOTIATE,
-		 g_param_spec_boolean (NM_SETTING_WIRED_AUTO_NEGOTIATE, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_CONSTRUCT |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_AUTO_NEGOTIATE] =
+	    g_param_spec_boolean (NM_SETTING_WIRED_AUTO_NEGOTIATE, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_CONSTRUCT |
+	                          G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_override (properties_override,
-	                                   g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                 NM_SETTING_WIRED_AUTO_NEGOTIATE),
+	                                   obj_properties[PROP_AUTO_NEGOTIATE],
 	                                   G_VARIANT_TYPE_BOOLEAN,
 	                                   _override_autoneg_get,
 	                                   NULL,
@@ -1138,17 +1130,15 @@ nm_setting_wired_class_init (NMSettingWiredClass *klass)
 	 *    permanent MAC address exists, the MAC address initially configured on the device.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_MAC_ADDRESS,
-		 g_param_spec_string (NM_SETTING_WIRED_MAC_ADDRESS, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MAC_ADDRESS] =
+	    g_param_spec_string (NM_SETTING_WIRED_MAC_ADDRESS, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_transform (properties_override,
-	                                    g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                  NM_SETTING_WIRED_MAC_ADDRESS),
+	                                    obj_properties[PROP_MAC_ADDRESS],
 	                                    G_VARIANT_TYPE_BYTESTRING,
 	                                    _nm_utils_hwaddr_to_dbus,
 	                                    _nm_utils_hwaddr_from_dbus);
@@ -1196,17 +1186,15 @@ nm_setting_wired_class_init (NMSettingWiredClass *klass)
 	 *    For libnm and nmcli, this field is called "cloned-mac-address".
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_CLONED_MAC_ADDRESS,
-		 g_param_spec_string (NM_SETTING_WIRED_CLONED_MAC_ADDRESS, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_CLONED_MAC_ADDRESS] =
+	    g_param_spec_string (NM_SETTING_WIRED_CLONED_MAC_ADDRESS, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_override (properties_override,
-	                                     g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                   NM_SETTING_WIRED_CLONED_MAC_ADDRESS),
+	                                     obj_properties[PROP_CLONED_MAC_ADDRESS],
 	                                     G_VARIANT_TYPE_BYTESTRING,
 	                                     _nm_utils_hwaddr_cloned_get,
 	                                     _nm_utils_hwaddr_cloned_set,
@@ -1269,13 +1257,12 @@ nm_setting_wired_class_init (NMSettingWiredClass *klass)
 	 *   cloned-mac-address.
 	 * ---end---
 	 */
-	g_object_class_install_property
-	    (object_class, PROP_GENERATE_MAC_ADDRESS_MASK,
+	obj_properties[PROP_GENERATE_MAC_ADDRESS_MASK] =
 	     g_param_spec_string (NM_SETTING_WIRED_GENERATE_MAC_ADDRESS_MASK, "", "",
 	                          NULL,
 	                          G_PARAM_READWRITE |
 	                          NM_SETTING_PARAM_FUZZY_IGNORE |
-	                          G_PARAM_STATIC_STRINGS));
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWired:mac-address-blacklist:
@@ -1299,13 +1286,12 @@ nm_setting_wired_class_init (NMSettingWiredClass *klass)
 	 * example: HWADDR_BLACKLIST="00:22:68:11:69:08 00:11:22:11:44:55"
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_MAC_ADDRESS_BLACKLIST,
-		 g_param_spec_boxed (NM_SETTING_WIRED_MAC_ADDRESS_BLACKLIST, "", "",
-		                     G_TYPE_STRV,
-		                     G_PARAM_READWRITE |
-		                     NM_SETTING_PARAM_FUZZY_IGNORE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MAC_ADDRESS_BLACKLIST] =
+	    g_param_spec_boxed (NM_SETTING_WIRED_MAC_ADDRESS_BLACKLIST, "", "",
+	                        G_TYPE_STRV,
+	                        G_PARAM_READWRITE |
+	                        NM_SETTING_PARAM_FUZZY_IGNORE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWired:mtu:
@@ -1319,14 +1305,13 @@ nm_setting_wired_class_init (NMSettingWiredClass *klass)
 	 * description: MTU of the interface.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_MTU,
-		 g_param_spec_uint (NM_SETTING_WIRED_MTU, "", "",
-		                    0, G_MAXUINT32, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_FUZZY_IGNORE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MTU] =
+	    g_param_spec_uint (NM_SETTING_WIRED_MTU, "", "",
+	                       0, G_MAXUINT32, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_FUZZY_IGNORE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWired:s390-subchannels:
@@ -1346,13 +1331,12 @@ nm_setting_wired_class_init (NMSettingWiredClass *klass)
 	 * example: SUBCHANNELS=0.0.b00a,0.0.b00b,0.0.b00c
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_S390_SUBCHANNELS,
-		 g_param_spec_boxed (NM_SETTING_WIRED_S390_SUBCHANNELS, "", "",
-		                     G_TYPE_STRV,
-		                     G_PARAM_READWRITE |
-		                     NM_SETTING_PARAM_INFERRABLE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_S390_SUBCHANNELS] =
+	    g_param_spec_boxed (NM_SETTING_WIRED_S390_SUBCHANNELS, "", "",
+	                        G_TYPE_STRV,
+	                        G_PARAM_READWRITE |
+	                        NM_SETTING_PARAM_INFERRABLE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWired:s390-nettype:
@@ -1368,13 +1352,12 @@ nm_setting_wired_class_init (NMSettingWiredClass *klass)
 	 * example: NETTYPE=qeth
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_S390_NETTYPE,
-		 g_param_spec_string (NM_SETTING_WIRED_S390_NETTYPE, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_S390_NETTYPE] =
+	    g_param_spec_string (NM_SETTING_WIRED_S390_NETTYPE, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWired:s390-options: (type GHashTable(utf8,utf8)):
@@ -1391,17 +1374,15 @@ nm_setting_wired_class_init (NMSettingWiredClass *klass)
 	 *   "portname" and "ctcprot" that have their own variables.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_S390_OPTIONS,
-		 g_param_spec_boxed (NM_SETTING_WIRED_S390_OPTIONS, "", "",
-		                     G_TYPE_HASH_TABLE,
-		                     G_PARAM_READWRITE |
-		                     NM_SETTING_PARAM_INFERRABLE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_S390_OPTIONS] =
+	    g_param_spec_boxed (NM_SETTING_WIRED_S390_OPTIONS, "", "",
+	                        G_TYPE_HASH_TABLE,
+	                        G_PARAM_READWRITE |
+	                        NM_SETTING_PARAM_INFERRABLE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_transform (properties_override,
-	                                    g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                  NM_SETTING_WIRED_S390_OPTIONS),
+	                                    obj_properties[PROP_S390_OPTIONS],
 	                                    G_VARIANT_TYPE ("a{ss}"),
 	                                    _nm_utils_strdict_to_dbus,
 	                                    _nm_utils_strdict_from_dbus);
@@ -1420,13 +1401,12 @@ nm_setting_wired_class_init (NMSettingWiredClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_WAKE_ON_LAN,
-		 g_param_spec_uint (NM_SETTING_WIRED_WAKE_ON_LAN, "", "",
-		                    0, G_MAXUINT32, NM_SETTING_WIRED_WAKE_ON_LAN_DEFAULT,
-		                    G_PARAM_CONSTRUCT |
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_WAKE_ON_LAN] =
+	    g_param_spec_uint (NM_SETTING_WIRED_WAKE_ON_LAN, "", "",
+	                       0, G_MAXUINT32, NM_SETTING_WIRED_WAKE_ON_LAN_DEFAULT,
+	                       G_PARAM_CONSTRUCT |
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWired:wake-on-lan-password:
@@ -1437,12 +1417,13 @@ nm_setting_wired_class_init (NMSettingWiredClass *klass)
 	 *
 	 * Since: 1.2
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_WAKE_ON_LAN_PASSWORD,
-		 g_param_spec_string (NM_SETTING_WIRED_WAKE_ON_LAN_PASSWORD, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_WAKE_ON_LAN_PASSWORD] =
+	    g_param_spec_string (NM_SETTING_WIRED_WAKE_ON_LAN_PASSWORD, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit_full (setting_class, NM_META_SETTING_TYPE_WIRED,
 	                               NULL, properties_override);

--- a/libnm-core/nm-setting-wireless-security.c
+++ b/libnm-core/nm-setting-wireless-security.c
@@ -90,8 +90,7 @@ typedef struct {
 	NMSettingWirelessSecurityFils fils;
 } NMSettingWirelessSecurityPrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE (NMSettingWirelessSecurity,
 	PROP_KEY_MGMT,
 	PROP_WEP_TX_KEYIDX,
 	PROP_AUTH_ALG,
@@ -112,9 +111,7 @@ enum {
 	PROP_LEAP_PASSWORD_FLAGS,
 	PROP_WPS_METHOD,
 	PROP_FILS,
-
-	LAST_PROP
-};
+);
 
 /**
  * nm_setting_wireless_security_new:
@@ -209,7 +206,7 @@ nm_setting_wireless_security_add_proto (NMSettingWirelessSecurity *setting, cons
 	}
 
 	priv->proto = g_slist_append (priv->proto, g_ascii_strdown (proto, -1));
-	g_object_notify (G_OBJECT (setting), NM_SETTING_WIRELESS_SECURITY_PROTO);
+	_notify (setting, PROP_PROTO);
 	return TRUE;
 }
 
@@ -234,7 +231,7 @@ nm_setting_wireless_security_remove_proto (NMSettingWirelessSecurity *setting, g
 
 	g_free (elt->data);
 	priv->proto = g_slist_delete_link (priv->proto, elt);
-	g_object_notify (G_OBJECT (setting), NM_SETTING_WIRELESS_SECURITY_PROTO);
+	_notify (setting, PROP_PROTO);
 }
 
 /**
@@ -260,7 +257,7 @@ nm_setting_wireless_security_remove_proto_by_value (NMSettingWirelessSecurity *s
 	for (iter = priv->proto; iter; iter = g_slist_next (iter)) {
 		if (strcasecmp (proto, (char *) iter->data) == 0) {
 			priv->proto = g_slist_delete_link (priv->proto, iter);
-			g_object_notify (G_OBJECT (setting), NM_SETTING_WIRELESS_SECURITY_PROTO);
+			_notify (setting, PROP_PROTO);
 			return TRUE;
 		}
 	}
@@ -284,7 +281,7 @@ nm_setting_wireless_security_clear_protos (NMSettingWirelessSecurity *setting)
 	priv = NM_SETTING_WIRELESS_SECURITY_GET_PRIVATE (setting);
 	g_slist_free_full (priv->proto, g_free);
 	priv->proto = NULL;
-	g_object_notify (G_OBJECT (setting), NM_SETTING_WIRELESS_SECURITY_PROTO);
+	_notify (setting, PROP_PROTO);
 }
 
 /**
@@ -353,7 +350,7 @@ nm_setting_wireless_security_add_pairwise (NMSettingWirelessSecurity *setting, c
 	}
 
 	priv->pairwise = g_slist_append (priv->pairwise, g_ascii_strdown (pairwise, -1));
-	g_object_notify (G_OBJECT (setting), NM_SETTING_WIRELESS_SECURITY_PAIRWISE);
+	_notify (setting, PROP_PAIRWISE);
 	return TRUE;
 }
 
@@ -379,7 +376,7 @@ nm_setting_wireless_security_remove_pairwise (NMSettingWirelessSecurity *setting
 
 	g_free (elt->data);
 	priv->pairwise = g_slist_delete_link (priv->pairwise, elt);
-	g_object_notify (G_OBJECT (setting), NM_SETTING_WIRELESS_SECURITY_PAIRWISE);
+	_notify (setting, PROP_PAIRWISE);
 }
 
 /**
@@ -406,7 +403,7 @@ nm_setting_wireless_security_remove_pairwise_by_value (NMSettingWirelessSecurity
 	for (iter = priv->pairwise; iter; iter = g_slist_next (iter)) {
 		if (strcasecmp (pairwise, (char *) iter->data) == 0) {
 			priv->pairwise = g_slist_delete_link (priv->pairwise, iter);
-			g_object_notify (G_OBJECT (setting), NM_SETTING_WIRELESS_SECURITY_PAIRWISE);
+			_notify (setting, PROP_PAIRWISE);
 			return TRUE;
 		}
 	}
@@ -430,7 +427,7 @@ nm_setting_wireless_security_clear_pairwise (NMSettingWirelessSecurity *setting)
 	priv = NM_SETTING_WIRELESS_SECURITY_GET_PRIVATE (setting);
 	g_slist_free_full (priv->pairwise, g_free);
 	priv->pairwise = NULL;
-	g_object_notify (G_OBJECT (setting), NM_SETTING_WIRELESS_SECURITY_PAIRWISE);
+	_notify (setting, PROP_PAIRWISE);
 }
 
 /**
@@ -500,7 +497,7 @@ nm_setting_wireless_security_add_group (NMSettingWirelessSecurity *setting, cons
 	}
 
 	priv->group = g_slist_append (priv->group, g_ascii_strdown (group, -1));
-	g_object_notify (G_OBJECT (setting), NM_SETTING_WIRELESS_SECURITY_GROUP);
+	_notify (setting, PROP_GROUP);
 	return TRUE;
 }
 
@@ -526,7 +523,7 @@ nm_setting_wireless_security_remove_group (NMSettingWirelessSecurity *setting, g
 
 	g_free (elt->data);
 	priv->group = g_slist_delete_link (priv->group, elt);
-	g_object_notify (G_OBJECT (setting), NM_SETTING_WIRELESS_SECURITY_GROUP);
+	_notify (setting, PROP_GROUP);
 }
 
 /**
@@ -554,7 +551,7 @@ nm_setting_wireless_security_remove_group_by_value (NMSettingWirelessSecurity *s
 	for (iter = priv->group; iter; iter = g_slist_next (iter)) {
 		if (strcasecmp (group, (char *) iter->data) == 0) {
 			priv->group = g_slist_delete_link (priv->group, iter);
-			g_object_notify (G_OBJECT (setting), NM_SETTING_WIRELESS_SECURITY_GROUP);
+			_notify (setting, PROP_GROUP);
 			return TRUE;
 		}
 	}
@@ -578,7 +575,7 @@ nm_setting_wireless_security_clear_groups (NMSettingWirelessSecurity *setting)
 	priv = NM_SETTING_WIRELESS_SECURITY_GET_PRIVATE (setting);
 	g_slist_free_full (priv->group, g_free);
 	priv->group = NULL;
-	g_object_notify (G_OBJECT (setting), NM_SETTING_WIRELESS_SECURITY_GROUP);
+	_notify (setting, PROP_GROUP);
 }
 
 /*
@@ -721,22 +718,22 @@ nm_setting_wireless_security_set_wep_key (NMSettingWirelessSecurity *setting, gu
 	case 0:
 		g_free (priv->wep_key0);
 		priv->wep_key0 = g_strdup (key);
-		g_object_notify (G_OBJECT (setting), NM_SETTING_WIRELESS_SECURITY_WEP_KEY0);
+		_notify (setting, PROP_WEP_KEY0);
 		break;
 	case 1:
 		g_free (priv->wep_key1);
 		priv->wep_key1 = g_strdup (key);
-		g_object_notify (G_OBJECT (setting), NM_SETTING_WIRELESS_SECURITY_WEP_KEY1);
+		_notify (setting, PROP_WEP_KEY1);
 		break;
 	case 2:
 		g_free (priv->wep_key2);
 		priv->wep_key2 = g_strdup (key);
-		g_object_notify (G_OBJECT (setting), NM_SETTING_WIRELESS_SECURITY_WEP_KEY2);
+		_notify (setting, PROP_WEP_KEY2);
 		break;
 	case 3:
 		g_free (priv->wep_key3);
 		priv->wep_key3 = g_strdup (key);
-		g_object_notify (G_OBJECT (setting), NM_SETTING_WIRELESS_SECURITY_WEP_KEY3);
+		_notify (setting, PROP_WEP_KEY3);
 		break;
 	default:
 		g_assert_not_reached ();
@@ -1465,13 +1462,12 @@ nm_setting_wireless_security_class_init (NMSettingWirelessSecurityClass *klass)
 	 * description: Key management menthod.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_KEY_MGMT,
-		 g_param_spec_string (NM_SETTING_WIRELESS_SECURITY_KEY_MGMT, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_REQUIRED |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_KEY_MGMT] =
+	    g_param_spec_string (NM_SETTING_WIRELESS_SECURITY_KEY_MGMT, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_REQUIRED |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWirelessSecurity:wep-tx-keyidx:
@@ -1489,13 +1485,12 @@ nm_setting_wireless_security_class_init (NMSettingWirelessSecurityClass *klass)
 	 * description: Index of active WEP key.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_WEP_TX_KEYIDX,
-		 g_param_spec_uint (NM_SETTING_WIRELESS_SECURITY_WEP_TX_KEYIDX, "", "",
-		                    0, 3, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_WEP_TX_KEYIDX] =
+	    g_param_spec_uint (NM_SETTING_WIRELESS_SECURITY_WEP_TX_KEYIDX, "", "",
+	                       0, 3, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWirelessSecurity:auth-alg:
@@ -1513,12 +1508,11 @@ nm_setting_wireless_security_class_init (NMSettingWirelessSecurityClass *klass)
 	 * description: Authentication algorithm for WEP.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_AUTH_ALG,
-		 g_param_spec_string (NM_SETTING_WIRELESS_SECURITY_AUTH_ALG, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_AUTH_ALG] =
+	    g_param_spec_string (NM_SETTING_WIRELESS_SECURITY_AUTH_ALG, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWirelessSecurity:proto:
@@ -1535,12 +1529,11 @@ nm_setting_wireless_security_class_init (NMSettingWirelessSecurityClass *klass)
 	 * description: Allowed WPA protocols, WPA and WPA2 (RSN).
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_PROTO,
-		 g_param_spec_boxed (NM_SETTING_WIRELESS_SECURITY_PROTO, "", "",
-		                     G_TYPE_STRV,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PROTO] =
+	    g_param_spec_boxed (NM_SETTING_WIRELESS_SECURITY_PROTO, "", "",
+	                        G_TYPE_STRV,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWirelessSecurity:pairwise:
@@ -1558,12 +1551,11 @@ nm_setting_wireless_security_class_init (NMSettingWirelessSecurityClass *klass)
 	 *   separated list.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_PAIRWISE,
-		 g_param_spec_boxed (NM_SETTING_WIRELESS_SECURITY_PAIRWISE, "", "",
-		                     G_TYPE_STRV,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PAIRWISE] =
+	    g_param_spec_boxed (NM_SETTING_WIRELESS_SECURITY_PAIRWISE, "", "",
+	                        G_TYPE_STRV,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWirelessSecurity:group:
@@ -1581,12 +1573,11 @@ nm_setting_wireless_security_class_init (NMSettingWirelessSecurityClass *klass)
 	 *   separated list.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_GROUP,
-		 g_param_spec_boxed (NM_SETTING_WIRELESS_SECURITY_GROUP, "", "",
-		                     G_TYPE_STRV,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_GROUP] =
+	    g_param_spec_boxed (NM_SETTING_WIRELESS_SECURITY_GROUP, "", "",
+	                        G_TYPE_STRV,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWirelessSecurity:pmf:
@@ -1610,14 +1601,13 @@ nm_setting_wireless_security_class_init (NMSettingWirelessSecurityClass *klass)
 	 * example: PMF=required
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_PMF,
-		 g_param_spec_int (NM_SETTING_WIRELESS_SECURITY_PMF, "", "",
-		                   G_MININT32, G_MAXINT32, 0,
-		                   G_PARAM_READWRITE |
-		                   G_PARAM_CONSTRUCT |
-		                   NM_SETTING_PARAM_FUZZY_IGNORE |
-		                   G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PMF] =
+	    g_param_spec_int (NM_SETTING_WIRELESS_SECURITY_PMF, "", "",
+	                      G_MININT32, G_MAXINT32, 0,
+	                      G_PARAM_READWRITE |
+	                      G_PARAM_CONSTRUCT |
+	                      NM_SETTING_PARAM_FUZZY_IGNORE |
+	                      G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWirelessSecurity:leap-username:
@@ -1631,12 +1621,11 @@ nm_setting_wireless_security_class_init (NMSettingWirelessSecurityClass *klass)
 	 * description: Login name for LEAP.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_LEAP_USERNAME,
-		 g_param_spec_string (NM_SETTING_WIRELESS_SECURITY_LEAP_USERNAME, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_LEAP_USERNAME] =
+	    g_param_spec_string (NM_SETTING_WIRELESS_SECURITY_LEAP_USERNAME, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWirelessSecurity:wep-key0:
@@ -1650,13 +1639,12 @@ nm_setting_wireless_security_class_init (NMSettingWirelessSecurityClass *klass)
 	 * description: The first WEP key (used in most networks). See also DEFAULTKEY for key index.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_WEP_KEY0,
-		 g_param_spec_string (NM_SETTING_WIRELESS_SECURITY_WEP_KEY0, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_SECRET |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_WEP_KEY0] =
+	    g_param_spec_string (NM_SETTING_WIRELESS_SECURITY_WEP_KEY0, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_SECRET |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWirelessSecurity:wep-key1:
@@ -1670,13 +1658,12 @@ nm_setting_wireless_security_class_init (NMSettingWirelessSecurityClass *klass)
 	 * description: WEP key with index 1. See also DEFAULTKEY for key index.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_WEP_KEY1,
-		 g_param_spec_string (NM_SETTING_WIRELESS_SECURITY_WEP_KEY1, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_SECRET |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_WEP_KEY1] =
+	    g_param_spec_string (NM_SETTING_WIRELESS_SECURITY_WEP_KEY1, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_SECRET |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWirelessSecurity:wep-key2:
@@ -1690,13 +1677,12 @@ nm_setting_wireless_security_class_init (NMSettingWirelessSecurityClass *klass)
 	 * description: WEP key with index 2. See also DEFAULTKEY for key index.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_WEP_KEY2,
-		 g_param_spec_string (NM_SETTING_WIRELESS_SECURITY_WEP_KEY2, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_SECRET |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_WEP_KEY2] =
+	    g_param_spec_string (NM_SETTING_WIRELESS_SECURITY_WEP_KEY2, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_SECRET |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWirelessSecurity:wep-key3:
@@ -1710,13 +1696,12 @@ nm_setting_wireless_security_class_init (NMSettingWirelessSecurityClass *klass)
 	 * description: WEP key with index 3. See also DEFAULTKEY for key index.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_WEP_KEY3,
-		 g_param_spec_string (NM_SETTING_WIRELESS_SECURITY_WEP_KEY3, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_SECRET |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_WEP_KEY3] =
+	    g_param_spec_string (NM_SETTING_WIRELESS_SECURITY_WEP_KEY3, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_SECRET |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWirelessSecurity:wep-key-flags:
@@ -1732,13 +1717,12 @@ nm_setting_wireless_security_class_init (NMSettingWirelessSecurityClass *klass)
 	 * description: Password flags for KEY<i>, KEY_PASSPHRASE<i> password.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_WEP_KEY_FLAGS,
-		 g_param_spec_flags (NM_SETTING_WIRELESS_SECURITY_WEP_KEY_FLAGS, "", "",
-		                     NM_TYPE_SETTING_SECRET_FLAGS,
-		                     NM_SETTING_SECRET_FLAG_NONE,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_WEP_KEY_FLAGS] =
+	    g_param_spec_flags (NM_SETTING_WIRELESS_SECURITY_WEP_KEY_FLAGS, "", "",
+	                        NM_TYPE_SETTING_SECRET_FLAGS,
+	                        NM_SETTING_SECRET_FLAG_NONE,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWirelessSecurity:psk:
@@ -1756,13 +1740,12 @@ nm_setting_wireless_security_class_init (NMSettingWirelessSecurityClass *klass)
 	 * description: Pre-Shared-Key for WPA networks.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_PSK,
-		 g_param_spec_string (NM_SETTING_WIRELESS_SECURITY_PSK, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_SECRET |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PSK] =
+	    g_param_spec_string (NM_SETTING_WIRELESS_SECURITY_PSK, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_SECRET |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWirelessSecurity:psk-flags:
@@ -1778,13 +1761,12 @@ nm_setting_wireless_security_class_init (NMSettingWirelessSecurityClass *klass)
 	 * example: WPA_PSK_FLAGS=user
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_PSK_FLAGS,
-		 g_param_spec_flags (NM_SETTING_WIRELESS_SECURITY_PSK_FLAGS, "", "",
-		                     NM_TYPE_SETTING_SECRET_FLAGS,
-		                     NM_SETTING_SECRET_FLAG_NONE,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PSK_FLAGS] =
+	    g_param_spec_flags (NM_SETTING_WIRELESS_SECURITY_PSK_FLAGS, "", "",
+	                        NM_TYPE_SETTING_SECRET_FLAGS,
+	                        NM_SETTING_SECRET_FLAG_NONE,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWirelessSecurity:leap-password:
@@ -1799,13 +1781,12 @@ nm_setting_wireless_security_class_init (NMSettingWirelessSecurityClass *klass)
 	 *  lookaside file, or it can be owned by a secret agent.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_LEAP_PASSWORD,
-		 g_param_spec_string (NM_SETTING_WIRELESS_SECURITY_LEAP_PASSWORD, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_SECRET |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_LEAP_PASSWORD] =
+	    g_param_spec_string (NM_SETTING_WIRELESS_SECURITY_LEAP_PASSWORD, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_SECRET |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWirelessSecurity:leap-password-flags:
@@ -1820,13 +1801,12 @@ nm_setting_wireless_security_class_init (NMSettingWirelessSecurityClass *klass)
 	 * description: Password flags for IEEE_8021X_PASSWORD_FLAGS.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_LEAP_PASSWORD_FLAGS,
-		 g_param_spec_flags (NM_SETTING_WIRELESS_SECURITY_LEAP_PASSWORD_FLAGS, "", "",
-		                     NM_TYPE_SETTING_SECRET_FLAGS,
-		                     NM_SETTING_SECRET_FLAG_NONE,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_LEAP_PASSWORD_FLAGS] =
+	    g_param_spec_flags (NM_SETTING_WIRELESS_SECURITY_LEAP_PASSWORD_FLAGS, "", "",
+	                        NM_TYPE_SETTING_SECRET_FLAGS,
+	                        NM_SETTING_SECRET_FLAG_NONE,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWirelessSecurity:wep-key-type:
@@ -1848,18 +1828,16 @@ nm_setting_wireless_security_class_init (NMSettingWirelessSecurityClass *klass)
 	 * example: KEY1=s:ahoj, KEY1=0a1c45bc02, KEY_PASSPHRASE1=mysupersecretkey
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_WEP_KEY_TYPE,
-		 g_param_spec_enum (NM_SETTING_WIRELESS_SECURITY_WEP_KEY_TYPE, "", "",
-		                    NM_TYPE_WEP_KEY_TYPE,
-		                    NM_WEP_KEY_TYPE_UNKNOWN,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_WEP_KEY_TYPE] =
+	    g_param_spec_enum (NM_SETTING_WIRELESS_SECURITY_WEP_KEY_TYPE, "", "",
+	                       NM_TYPE_WEP_KEY_TYPE,
+	                       NM_WEP_KEY_TYPE_UNKNOWN,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_transform (properties_override,
-	                                    g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                  NM_SETTING_WIRELESS_SECURITY_WEP_KEY_TYPE),
+	                                    obj_properties[PROP_WEP_KEY_TYPE],
 	                                    G_VARIANT_TYPE_UINT32,
 	                                    wep_key_type_to_dbus,
 	                                    NULL);
@@ -1885,14 +1863,13 @@ nm_setting_wireless_security_class_init (NMSettingWirelessSecurityClass *klass)
 	 * example: WPS_METHOD=disabled, WPS_METHOD="pin pbc"
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_WPS_METHOD,
-		 g_param_spec_uint (NM_SETTING_WIRELESS_SECURITY_WPS_METHOD, "", "",
-		                    0, G_MAXUINT32, NM_SETTING_WIRELESS_SECURITY_WPS_METHOD_DEFAULT,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_FUZZY_IGNORE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_WPS_METHOD] =
+	    g_param_spec_uint (NM_SETTING_WIRELESS_SECURITY_WPS_METHOD, "", "",
+	                       0, G_MAXUINT32, NM_SETTING_WIRELESS_SECURITY_WPS_METHOD_DEFAULT,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_FUZZY_IGNORE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWirelessSecurity:fils:
@@ -1916,14 +1893,15 @@ nm_setting_wireless_security_class_init (NMSettingWirelessSecurityClass *klass)
 	 * example: FILS=required
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_FILS,
-		 g_param_spec_int (NM_SETTING_WIRELESS_SECURITY_FILS, "", "",
-		                   G_MININT32, G_MAXINT32, 0,
-		                   G_PARAM_READWRITE |
-		                   G_PARAM_CONSTRUCT |
-		                   NM_SETTING_PARAM_FUZZY_IGNORE |
-		                   G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_FILS] =
+	    g_param_spec_int (NM_SETTING_WIRELESS_SECURITY_FILS, "", "",
+	                      G_MININT32, G_MAXINT32, 0,
+	                      G_PARAM_READWRITE |
+	                      G_PARAM_CONSTRUCT |
+	                      NM_SETTING_PARAM_FUZZY_IGNORE |
+	                      G_PARAM_STATIC_STRINGS);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit_full (setting_class, NM_META_SETTING_TYPE_WIRELESS_SECURITY,
 	                               NULL, properties_override);

--- a/libnm-core/nm-setting-wireless-security.c
+++ b/libnm-core/nm-setting-wireless-security.c
@@ -22,9 +22,10 @@
 
 #include "nm-default.h"
 
+#include "nm-setting-wireless-security.h"
+
 #include <string.h>
 
-#include "nm-setting-wireless-security.h"
 #include "nm-setting-8021x.h"
 #include "nm-utils.h"
 #include "nm-utils-private.h"
@@ -53,9 +54,30 @@
  *       ISBN: 978-1587051548
  **/
 
-G_DEFINE_TYPE (NMSettingWirelessSecurity, nm_setting_wireless_security, NM_TYPE_SETTING)
+/*****************************************************************************/
 
-#define NM_SETTING_WIRELESS_SECURITY_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_WIRELESS_SECURITY, NMSettingWirelessSecurityPrivate))
+NM_GOBJECT_PROPERTIES_DEFINE (NMSettingWirelessSecurity,
+	PROP_KEY_MGMT,
+	PROP_WEP_TX_KEYIDX,
+	PROP_AUTH_ALG,
+	PROP_PROTO,
+	PROP_PAIRWISE,
+	PROP_GROUP,
+	PROP_PMF,
+	PROP_LEAP_USERNAME,
+	PROP_WEP_KEY0,
+	PROP_WEP_KEY1,
+	PROP_WEP_KEY2,
+	PROP_WEP_KEY3,
+	PROP_WEP_KEY_FLAGS,
+	PROP_WEP_KEY_TYPE,
+	PROP_PSK,
+	PROP_PSK_FLAGS,
+	PROP_LEAP_PASSWORD,
+	PROP_LEAP_PASSWORD_FLAGS,
+	PROP_WPS_METHOD,
+	PROP_FILS,
+);
 
 typedef struct {
 	char *key_mgmt;
@@ -90,41 +112,11 @@ typedef struct {
 	NMSettingWirelessSecurityFils fils;
 } NMSettingWirelessSecurityPrivate;
 
-NM_GOBJECT_PROPERTIES_DEFINE (NMSettingWirelessSecurity,
-	PROP_KEY_MGMT,
-	PROP_WEP_TX_KEYIDX,
-	PROP_AUTH_ALG,
-	PROP_PROTO,
-	PROP_PAIRWISE,
-	PROP_GROUP,
-	PROP_PMF,
-	PROP_LEAP_USERNAME,
-	PROP_WEP_KEY0,
-	PROP_WEP_KEY1,
-	PROP_WEP_KEY2,
-	PROP_WEP_KEY3,
-	PROP_WEP_KEY_FLAGS,
-	PROP_WEP_KEY_TYPE,
-	PROP_PSK,
-	PROP_PSK_FLAGS,
-	PROP_LEAP_PASSWORD,
-	PROP_LEAP_PASSWORD_FLAGS,
-	PROP_WPS_METHOD,
-	PROP_FILS,
-);
+G_DEFINE_TYPE (NMSettingWirelessSecurity, nm_setting_wireless_security, NM_TYPE_SETTING)
 
-/**
- * nm_setting_wireless_security_new:
- *
- * Creates a new #NMSettingWirelessSecurity object with default values.
- *
- * Returns: (transfer full): the new empty #NMSettingWirelessSecurity object
- **/
-NMSetting *
-nm_setting_wireless_security_new (void)
-{
-	return (NMSetting *) g_object_new (NM_TYPE_SETTING_WIRELESS_SECURITY, NULL);
-}
+#define NM_SETTING_WIRELESS_SECURITY_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_WIRELESS_SECURITY, NMSettingWirelessSecurityPrivate))
+
+/*****************************************************************************/
 
 /**
  * nm_setting_wireless_security_get_key_mgmt:
@@ -1226,36 +1218,6 @@ set_secret_flags (NMSetting *setting,
 	return NM_SETTING_CLASS (nm_setting_wireless_security_parent_class)->set_secret_flags (setting, secret_name, flags, error);
 }
 
-static void
-nm_setting_wireless_security_init (NMSettingWirelessSecurity *setting)
-{
-}
-
-static void
-finalize (GObject *object)
-{
-	NMSettingWirelessSecurity *self = NM_SETTING_WIRELESS_SECURITY (object);
-	NMSettingWirelessSecurityPrivate *priv = NM_SETTING_WIRELESS_SECURITY_GET_PRIVATE (self);
-
-	/* Strings first. g_free() already checks for NULLs so we don't have to */
-
-	g_free (priv->key_mgmt);
-	g_free (priv->auth_alg);
-	g_free (priv->leap_username);
-	g_free (priv->wep_key0);
-	g_free (priv->wep_key1);
-	g_free (priv->wep_key2);
-	g_free (priv->wep_key3);
-	g_free (priv->psk);
-	g_free (priv->leap_password);
-
-	g_slist_free_full (priv->proto, g_free);
-	g_slist_free_full (priv->pairwise, g_free);
-	g_slist_free_full (priv->group, g_free);
-
-	G_OBJECT_CLASS (nm_setting_wireless_security_parent_class)->finalize (object);
-}
-
 /* NMSettingWirelessSecurity:wep-key-type is an enum, but needs to be marshalled
  * as 'u', not 'i', for backward-compatibility.
  */
@@ -1263,6 +1225,82 @@ static GVariant *
 wep_key_type_to_dbus (const GValue *from)
 {
 	return g_variant_new_uint32 (g_value_get_enum (from));
+}
+
+/*****************************************************************************/
+
+static void
+get_property (GObject *object, guint prop_id,
+              GValue *value, GParamSpec *pspec)
+{
+	NMSettingWirelessSecurity *setting = NM_SETTING_WIRELESS_SECURITY (object);
+	NMSettingWirelessSecurityPrivate *priv = NM_SETTING_WIRELESS_SECURITY_GET_PRIVATE (setting);
+
+	switch (prop_id) {
+	case PROP_KEY_MGMT:
+		g_value_set_string (value, priv->key_mgmt);
+		break;
+	case PROP_WEP_TX_KEYIDX:
+		g_value_set_uint (value, priv->wep_tx_keyidx);
+		break;
+	case PROP_AUTH_ALG:
+		g_value_set_string (value, priv->auth_alg);
+		break;
+	case PROP_PROTO:
+		g_value_take_boxed (value, _nm_utils_slist_to_strv (priv->proto, TRUE));
+		break;
+	case PROP_PAIRWISE:
+		g_value_take_boxed (value, _nm_utils_slist_to_strv (priv->pairwise, TRUE));
+		break;
+	case PROP_GROUP:
+		g_value_take_boxed (value, _nm_utils_slist_to_strv (priv->group, TRUE));
+		break;
+	case PROP_PMF:
+		g_value_set_int (value, nm_setting_wireless_security_get_pmf (setting));
+		break;
+	case PROP_LEAP_USERNAME:
+		g_value_set_string (value, priv->leap_username);
+		break;
+	case PROP_WEP_KEY0:
+		g_value_set_string (value, priv->wep_key0);
+		break;
+	case PROP_WEP_KEY1:
+		g_value_set_string (value, priv->wep_key1);
+		break;
+	case PROP_WEP_KEY2:
+		g_value_set_string (value, priv->wep_key2);
+		break;
+	case PROP_WEP_KEY3:
+		g_value_set_string (value, priv->wep_key3);
+		break;
+	case PROP_WEP_KEY_FLAGS:
+		g_value_set_flags (value, priv->wep_key_flags);
+		break;
+	case PROP_PSK:
+		g_value_set_string (value, priv->psk);
+		break;
+	case PROP_PSK_FLAGS:
+		g_value_set_flags (value, priv->psk_flags);
+		break;
+	case PROP_LEAP_PASSWORD:
+		g_value_set_string (value, priv->leap_password);
+		break;
+	case PROP_LEAP_PASSWORD_FLAGS:
+		g_value_set_flags (value, priv->leap_password_flags);
+		break;
+	case PROP_WEP_KEY_TYPE:
+		g_value_set_enum (value, priv->wep_key_type);
+		break;
+	case PROP_WPS_METHOD:
+		g_value_set_uint (value, priv->wps_method);
+		break;
+	case PROP_FILS:
+		g_value_set_int (value, nm_setting_wireless_security_get_fils (setting));
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
 }
 
 static void
@@ -1354,78 +1392,47 @@ set_property (GObject *object, guint prop_id,
 	}
 }
 
-static void
-get_property (GObject *object, guint prop_id,
-              GValue *value, GParamSpec *pspec)
-{
-	NMSettingWirelessSecurity *setting = NM_SETTING_WIRELESS_SECURITY (object);
-	NMSettingWirelessSecurityPrivate *priv = NM_SETTING_WIRELESS_SECURITY_GET_PRIVATE (setting);
+/*****************************************************************************/
 
-	switch (prop_id) {
-	case PROP_KEY_MGMT:
-		g_value_set_string (value, priv->key_mgmt);
-		break;
-	case PROP_WEP_TX_KEYIDX:
-		g_value_set_uint (value, priv->wep_tx_keyidx);
-		break;
-	case PROP_AUTH_ALG:
-		g_value_set_string (value, priv->auth_alg);
-		break;
-	case PROP_PROTO:
-		g_value_take_boxed (value, _nm_utils_slist_to_strv (priv->proto, TRUE));
-		break;
-	case PROP_PAIRWISE:
-		g_value_take_boxed (value, _nm_utils_slist_to_strv (priv->pairwise, TRUE));
-		break;
-	case PROP_GROUP:
-		g_value_take_boxed (value, _nm_utils_slist_to_strv (priv->group, TRUE));
-		break;
-	case PROP_PMF:
-		g_value_set_int (value, nm_setting_wireless_security_get_pmf (setting));
-		break;
-	case PROP_LEAP_USERNAME:
-		g_value_set_string (value, priv->leap_username);
-		break;
-	case PROP_WEP_KEY0:
-		g_value_set_string (value, priv->wep_key0);
-		break;
-	case PROP_WEP_KEY1:
-		g_value_set_string (value, priv->wep_key1);
-		break;
-	case PROP_WEP_KEY2:
-		g_value_set_string (value, priv->wep_key2);
-		break;
-	case PROP_WEP_KEY3:
-		g_value_set_string (value, priv->wep_key3);
-		break;
-	case PROP_WEP_KEY_FLAGS:
-		g_value_set_flags (value, priv->wep_key_flags);
-		break;
-	case PROP_PSK:
-		g_value_set_string (value, priv->psk);
-		break;
-	case PROP_PSK_FLAGS:
-		g_value_set_flags (value, priv->psk_flags);
-		break;
-	case PROP_LEAP_PASSWORD:
-		g_value_set_string (value, priv->leap_password);
-		break;
-	case PROP_LEAP_PASSWORD_FLAGS:
-		g_value_set_flags (value, priv->leap_password_flags);
-		break;
-	case PROP_WEP_KEY_TYPE:
-		g_value_set_enum (value, priv->wep_key_type);
-		break;
-	case PROP_WPS_METHOD:
-		g_value_set_uint (value, priv->wps_method);
-		break;
-	case PROP_FILS:
-		g_value_set_int (value, nm_setting_wireless_security_get_fils (setting));
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
+static void
+nm_setting_wireless_security_init (NMSettingWirelessSecurity *setting)
+{
+}
+
+/**
+ * nm_setting_wireless_security_new:
+ *
+ * Creates a new #NMSettingWirelessSecurity object with default values.
+ *
+ * Returns: (transfer full): the new empty #NMSettingWirelessSecurity object
+ **/
+NMSetting *
+nm_setting_wireless_security_new (void)
+{
+	return (NMSetting *) g_object_new (NM_TYPE_SETTING_WIRELESS_SECURITY, NULL);
+}
+
+static void
+finalize (GObject *object)
+{
+	NMSettingWirelessSecurity *self = NM_SETTING_WIRELESS_SECURITY (object);
+	NMSettingWirelessSecurityPrivate *priv = NM_SETTING_WIRELESS_SECURITY_GET_PRIVATE (self);
+
+	g_free (priv->key_mgmt);
+	g_free (priv->auth_alg);
+	g_free (priv->leap_username);
+	g_free (priv->wep_key0);
+	g_free (priv->wep_key1);
+	g_free (priv->wep_key2);
+	g_free (priv->wep_key3);
+	g_free (priv->psk);
+	g_free (priv->leap_password);
+
+	g_slist_free_full (priv->proto, g_free);
+	g_slist_free_full (priv->pairwise, g_free);
+	g_slist_free_full (priv->group, g_free);
+
+	G_OBJECT_CLASS (nm_setting_wireless_security_parent_class)->finalize (object);
 }
 
 static void
@@ -1437,8 +1444,8 @@ nm_setting_wireless_security_class_init (NMSettingWirelessSecurityClass *klass)
 
 	g_type_class_add_private (klass, sizeof (NMSettingWirelessSecurityPrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->verify           = verify;

--- a/libnm-core/nm-setting-wireless.c
+++ b/libnm-core/nm-setting-wireless.c
@@ -1076,7 +1076,7 @@ set_property (GObject *object, guint prop_id,
 			 * In this case, we also clear mac-address-randomization flag */
 			if (priv->mac_address_randomization != NM_SETTING_MAC_RANDOMIZATION_DEFAULT) {
 				priv->mac_address_randomization = NM_SETTING_MAC_RANDOMIZATION_DEFAULT;
-				g_object_notify (object, NM_SETTING_WIRELESS_MAC_ADDRESS);
+				g_object_notify (object, NM_SETTING_WIRELESS_MAC_ADDRESS_RANDOMIZATION);
 			}
 		}
 		break;

--- a/libnm-core/nm-setting-wireless.c
+++ b/libnm-core/nm-setting-wireless.c
@@ -64,8 +64,7 @@ typedef struct {
 	guint32 wowl;
 } NMSettingWirelessPrivate;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE (NMSettingWireless,
 	PROP_SSID,
 	PROP_MODE,
 	PROP_BAND,
@@ -83,9 +82,7 @@ enum {
 	PROP_POWERSAVE,
 	PROP_MAC_ADDRESS_RANDOMIZATION,
 	PROP_WAKE_ON_WLAN,
-
-	LAST_PROP
-};
+);
 
 static gboolean
 match_cipher (const char *cipher,
@@ -523,7 +520,7 @@ nm_setting_wireless_add_mac_blacklist_item (NMSettingWireless *setting, const ch
 
 	mac = nm_utils_hwaddr_canonical (mac, ETH_ALEN);
 	g_array_append_val (priv->mac_address_blacklist, mac);
-	g_object_notify (G_OBJECT (setting), NM_SETTING_WIRELESS_MAC_ADDRESS_BLACKLIST);
+	_notify (setting, PROP_MAC_ADDRESS_BLACKLIST);
 	return TRUE;
 }
 
@@ -545,7 +542,7 @@ nm_setting_wireless_remove_mac_blacklist_item (NMSettingWireless *setting, guint
 	g_return_if_fail (idx < priv->mac_address_blacklist->len);
 
 	g_array_remove_index (priv->mac_address_blacklist, idx);
-	g_object_notify (G_OBJECT (setting), NM_SETTING_WIRELESS_MAC_ADDRESS_BLACKLIST);
+	_notify (setting, PROP_MAC_ADDRESS_BLACKLIST);
 }
 
 /**
@@ -573,7 +570,7 @@ nm_setting_wireless_remove_mac_blacklist_item_by_value (NMSettingWireless *setti
 		candidate = g_array_index (priv->mac_address_blacklist, char *, i);
 		if (!nm_utils_hwaddr_matches (mac, -1, candidate, -1)) {
 			g_array_remove_index (priv->mac_address_blacklist, i);
-			g_object_notify (G_OBJECT (setting), NM_SETTING_WIRELESS_MAC_ADDRESS_BLACKLIST);
+			_notify (setting, PROP_MAC_ADDRESS_BLACKLIST);
 			return TRUE;
 		}
 	}
@@ -592,7 +589,7 @@ nm_setting_wireless_clear_mac_blacklist_items (NMSettingWireless *setting)
 	g_return_if_fail (NM_IS_SETTING_WIRELESS (setting));
 
 	g_array_set_size (NM_SETTING_WIRELESS_GET_PRIVATE (setting)->mac_address_blacklist, 0);
-	g_object_notify (G_OBJECT (setting), NM_SETTING_WIRELESS_MAC_ADDRESS_BLACKLIST);
+	_notify (setting, PROP_MAC_ADDRESS_BLACKLIST);
 }
 
 /**
@@ -695,7 +692,7 @@ nm_setting_wireless_add_seen_bssid (NMSettingWireless *setting,
 
 	if (!found) {
 		priv->seen_bssids = g_slist_prepend (priv->seen_bssids, lower_bssid);
-		g_object_notify (G_OBJECT (setting), NM_SETTING_WIRELESS_SEEN_BSSIDS);
+		_notify (setting, PROP_SEEN_BSSIDS);
 	} else
 		g_free (lower_bssid);
 
@@ -1076,7 +1073,7 @@ set_property (GObject *object, guint prop_id,
 			 * In this case, we also clear mac-address-randomization flag */
 			if (priv->mac_address_randomization != NM_SETTING_MAC_RANDOMIZATION_DEFAULT) {
 				priv->mac_address_randomization = NM_SETTING_MAC_RANDOMIZATION_DEFAULT;
-				g_object_notify (object, NM_SETTING_WIRELESS_MAC_ADDRESS_RANDOMIZATION);
+				_notify (NM_SETTING_WIRELESS (object), PROP_MAC_ADDRESS_RANDOMIZATION);
 			}
 		}
 		break;
@@ -1218,12 +1215,11 @@ nm_setting_wireless_class_init (NMSettingWirelessClass *klass)
 	 * example: ESSID="Quick Net"
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_SSID,
-		 g_param_spec_boxed (NM_SETTING_WIRELESS_SSID, "", "",
-		                     G_TYPE_BYTES,
-		                     G_PARAM_READWRITE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_SSID] =
+	    g_param_spec_boxed (NM_SETTING_WIRELESS_SSID, "", "",
+	                        G_TYPE_BYTES,
+	                        G_PARAM_READWRITE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWireless:mode:
@@ -1238,12 +1234,11 @@ nm_setting_wireless_class_init (NMSettingWirelessClass *klass)
 	 * description: Wi-Fi network mode.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_MODE,
-		 g_param_spec_string (NM_SETTING_WIRELESS_MODE, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MODE] =
+	    g_param_spec_string (NM_SETTING_WIRELESS_MODE, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWireless:band:
@@ -1264,12 +1259,11 @@ nm_setting_wireless_class_init (NMSettingWirelessClass *klass)
 	 * example: BAND=bg
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_BAND,
-		 g_param_spec_string (NM_SETTING_WIRELESS_BAND, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_BAND] =
+	    g_param_spec_string (NM_SETTING_WIRELESS_BAND, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWireless:channel:
@@ -1288,13 +1282,12 @@ nm_setting_wireless_class_init (NMSettingWirelessClass *klass)
 	 * example: CHANNEL=6
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_CHANNEL,
-		 g_param_spec_uint (NM_SETTING_WIRELESS_CHANNEL, "", "",
-		                    0, G_MAXUINT32, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_CHANNEL] =
+	    g_param_spec_uint (NM_SETTING_WIRELESS_CHANNEL, "", "",
+	                       0, G_MAXUINT32, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWireless:bssid:
@@ -1311,16 +1304,14 @@ nm_setting_wireless_class_init (NMSettingWirelessClass *klass)
 	 * example: BSSID=00:1E:BD:64:83:21
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_BSSID,
-		 g_param_spec_string (NM_SETTING_WIRELESS_BSSID, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_BSSID] =
+	    g_param_spec_string (NM_SETTING_WIRELESS_BSSID, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_transform (properties_override,
-	                                    g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                  NM_SETTING_WIRELESS_BSSID),
+	                                    obj_properties[PROP_BSSID],
 	                                    G_VARIANT_TYPE_BYTESTRING,
 	                                    _nm_utils_hwaddr_to_dbus,
 	                                    _nm_utils_hwaddr_from_dbus);
@@ -1339,14 +1330,13 @@ nm_setting_wireless_class_init (NMSettingWirelessClass *klass)
 	 * description: This property is not handled by ifcfg-rh plugin.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_RATE,
-		 g_param_spec_uint (NM_SETTING_WIRELESS_RATE, "", "",
-		                    0, G_MAXUINT32, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_FUZZY_IGNORE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_RATE] =
+	    g_param_spec_uint (NM_SETTING_WIRELESS_RATE, "", "",
+	                       0, G_MAXUINT32, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_FUZZY_IGNORE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWireless:tx-power:
@@ -1361,14 +1351,13 @@ nm_setting_wireless_class_init (NMSettingWirelessClass *klass)
 	 * description: This property is not handled by ifcfg-rh plugin.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_TX_POWER,
-		 g_param_spec_uint (NM_SETTING_WIRELESS_TX_POWER, "", "",
-		                    0, G_MAXUINT32, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_FUZZY_IGNORE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_TX_POWER] =
+	    g_param_spec_uint (NM_SETTING_WIRELESS_TX_POWER, "", "",
+	                       0, G_MAXUINT32, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_FUZZY_IGNORE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWireless:mac-address:
@@ -1394,16 +1383,14 @@ nm_setting_wireless_class_init (NMSettingWirelessClass *klass)
 	 *    permanent MAC address exists, the MAC address initially configured on the device.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_MAC_ADDRESS,
-		 g_param_spec_string (NM_SETTING_WIRELESS_MAC_ADDRESS, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MAC_ADDRESS] =
+	    g_param_spec_string (NM_SETTING_WIRELESS_MAC_ADDRESS, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_transform (properties_override,
-	                                    g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                  NM_SETTING_WIRELESS_MAC_ADDRESS),
+	                                    obj_properties[PROP_MAC_ADDRESS],
 	                                    G_VARIANT_TYPE_BYTESTRING,
 	                                    _nm_utils_hwaddr_to_dbus,
 	                                    _nm_utils_hwaddr_from_dbus);
@@ -1450,17 +1437,15 @@ nm_setting_wireless_class_init (NMSettingWirelessClass *klass)
 	 *    For libnm and nmcli, this field is called "cloned-mac-address".
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_CLONED_MAC_ADDRESS,
-		 g_param_spec_string (NM_SETTING_WIRELESS_CLONED_MAC_ADDRESS, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      NM_SETTING_PARAM_INFERRABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_CLONED_MAC_ADDRESS] =
+	    g_param_spec_string (NM_SETTING_WIRELESS_CLONED_MAC_ADDRESS, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         NM_SETTING_PARAM_INFERRABLE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	_properties_override_add_override (properties_override,
-	                                   g_object_class_find_property (G_OBJECT_CLASS (setting_class),
-	                                                                 NM_SETTING_WIRELESS_CLONED_MAC_ADDRESS),
+	                                   obj_properties[PROP_CLONED_MAC_ADDRESS],
 	                                   G_VARIANT_TYPE_BYTESTRING,
 	                                   _nm_utils_hwaddr_cloned_get,
 	                                   _nm_utils_hwaddr_cloned_set,
@@ -1523,13 +1508,12 @@ nm_setting_wireless_class_init (NMSettingWirelessClass *klass)
 	 *   cloned-mac-address.
 	 * ---end---
 	 */
-	g_object_class_install_property
-	    (object_class, PROP_GENERATE_MAC_ADDRESS_MASK,
+	obj_properties[PROP_GENERATE_MAC_ADDRESS_MASK] =
 	     g_param_spec_string (NM_SETTING_WIRELESS_GENERATE_MAC_ADDRESS_MASK, "", "",
 	                          NULL,
 	                          G_PARAM_READWRITE |
 	                          NM_SETTING_PARAM_FUZZY_IGNORE |
-	                          G_PARAM_STATIC_STRINGS));
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWireless:mac-address-blacklist:
@@ -1551,13 +1535,12 @@ nm_setting_wireless_class_init (NMSettingWirelessClass *klass)
 	 *   is listed.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_MAC_ADDRESS_BLACKLIST,
-		 g_param_spec_boxed (NM_SETTING_WIRELESS_MAC_ADDRESS_BLACKLIST, "", "",
-		                     G_TYPE_STRV,
-		                     G_PARAM_READWRITE |
-		                     NM_SETTING_PARAM_FUZZY_IGNORE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MAC_ADDRESS_BLACKLIST] =
+	    g_param_spec_boxed (NM_SETTING_WIRELESS_MAC_ADDRESS_BLACKLIST, "", "",
+	                        G_TYPE_STRV,
+	                        G_PARAM_READWRITE |
+	                        NM_SETTING_PARAM_FUZZY_IGNORE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWireless:seen-bssids:
@@ -1575,13 +1558,12 @@ nm_setting_wireless_class_init (NMSettingWirelessClass *klass)
 	 * description: This property is not handled by ifcfg-rh plugin.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_SEEN_BSSIDS,
-		 g_param_spec_boxed (NM_SETTING_WIRELESS_SEEN_BSSIDS, "", "",
-		                     G_TYPE_STRV,
-		                     G_PARAM_READWRITE |
-		                     NM_SETTING_PARAM_FUZZY_IGNORE |
-		                     G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_SEEN_BSSIDS] =
+	    g_param_spec_boxed (NM_SETTING_WIRELESS_SEEN_BSSIDS, "", "",
+	                        G_TYPE_STRV,
+	                        G_PARAM_READWRITE |
+	                        NM_SETTING_PARAM_FUZZY_IGNORE |
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWireless:mtu:
@@ -1595,14 +1577,13 @@ nm_setting_wireless_class_init (NMSettingWirelessClass *klass)
 	 * description: MTU of the wireless interface.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_MTU,
-		 g_param_spec_uint (NM_SETTING_WIRELESS_MTU, "", "",
-		                    0, G_MAXUINT32, 0,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_CONSTRUCT |
-		                    NM_SETTING_PARAM_FUZZY_IGNORE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MTU] =
+	    g_param_spec_uint (NM_SETTING_WIRELESS_MTU, "", "",
+	                       0, G_MAXUINT32, 0,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_CONSTRUCT |
+	                       NM_SETTING_PARAM_FUZZY_IGNORE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWireless:hidden:
@@ -1628,12 +1609,11 @@ nm_setting_wireless_class_init (NMSettingWirelessClass *klass)
 	 * description: Whether the network hides the SSID.
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_HIDDEN,
-		 g_param_spec_boolean (NM_SETTING_WIRELESS_HIDDEN, "", "",
-		                       FALSE,
-		                       G_PARAM_READWRITE |
-		                       G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_HIDDEN] =
+	    g_param_spec_boolean (NM_SETTING_WIRELESS_HIDDEN, "", "",
+	                          FALSE,
+	                          G_PARAM_READWRITE |
+	                          G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWireless:powersave:
@@ -1654,12 +1634,11 @@ nm_setting_wireless_class_init (NMSettingWirelessClass *klass)
 	 * example: POWERSAVE=enable
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_POWERSAVE,
-		 g_param_spec_uint (NM_SETTING_WIRELESS_POWERSAVE, "", "",
-		                    0, G_MAXUINT32, NM_SETTING_WIRELESS_POWERSAVE_DEFAULT,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_POWERSAVE] =
+	    g_param_spec_uint (NM_SETTING_WIRELESS_POWERSAVE, "", "",
+	                       0, G_MAXUINT32, NM_SETTING_WIRELESS_POWERSAVE_DEFAULT,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWireless:mac-address-randomization:
@@ -1682,12 +1661,11 @@ nm_setting_wireless_class_init (NMSettingWirelessClass *klass)
 	 * example: MAC_ADDRESS_RANDOMIZATION=always
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_MAC_ADDRESS_RANDOMIZATION,
-		 g_param_spec_uint (NM_SETTING_WIRELESS_MAC_ADDRESS_RANDOMIZATION, "", "",
-		                    0, G_MAXUINT32, NM_SETTING_MAC_RANDOMIZATION_DEFAULT,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MAC_ADDRESS_RANDOMIZATION] =
+	    g_param_spec_uint (NM_SETTING_WIRELESS_MAC_ADDRESS_RANDOMIZATION, "", "",
+	                       0, G_MAXUINT32, NM_SETTING_MAC_RANDOMIZATION_DEFAULT,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/* Compatibility for deprecated property */
 	/* ---ifcfg-rh---
@@ -1727,13 +1705,14 @@ nm_setting_wireless_class_init (NMSettingWirelessClass *klass)
 	 *
 	 * Since: 1.12
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_WAKE_ON_WLAN,
-		 g_param_spec_uint (NM_SETTING_WIRELESS_WAKE_ON_WLAN, "", "",
-		                    0, G_MAXUINT32, NM_SETTING_WIRELESS_WAKE_ON_WLAN_DEFAULT,
-		                    G_PARAM_CONSTRUCT |
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_WAKE_ON_WLAN] =
+	    g_param_spec_uint (NM_SETTING_WIRELESS_WAKE_ON_WLAN, "", "",
+	                       0, G_MAXUINT32, NM_SETTING_WIRELESS_WAKE_ON_WLAN_DEFAULT,
+	                       G_PARAM_CONSTRUCT |
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_STATIC_STRINGS);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit_full (setting_class, NM_META_SETTING_TYPE_WIRELESS,
 	                               NULL, properties_override);

--- a/libnm-core/nm-setting-wpan.c
+++ b/libnm-core/nm-setting-wpan.c
@@ -26,6 +26,14 @@
 #include "nm-setting-private.h"
 #include "nm-utils-private.h"
 
+/**
+ * SECTION:nm-setting-wpan
+ * @short_description: Describes connection properties for IEEE 802.15.4 (WPAN) MAC
+ *
+ * The #NMSettingWpan object is a #NMSetting subclass that describes properties
+ * necessary for configuring IEEE 802.15.4 (WPAN) MAC layer devices.
+ **/
+
 /* Ideally we'll be able to get these from a public header. */
 #ifndef IEEE802154_ADDR_LEN
 #define IEEE802154_ADDR_LEN 8
@@ -38,6 +46,8 @@
 #ifndef IEEE802154_MAX_CHANNEL
 #define IEEE802154_MAX_CHANNEL 26
 #endif
+
+/*****************************************************************************/
 
 NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_MAC_ADDRESS,
@@ -68,17 +78,11 @@ struct _NMSettingWpanClass {
         NMSettingClass parent;
 };
 
-/**
- * SECTION:nm-setting-wpan
- * @short_description: Describes connection properties for IEEE 802.15.4 (WPAN) MAC
- *
- * The #NMSettingWpan object is a #NMSetting subclass that describes properties
- * necessary for configuring IEEE 802.15.4 (WPAN) MAC layer devices.
- **/
-
 G_DEFINE_TYPE (NMSettingWpan, nm_setting_wpan, NM_TYPE_SETTING)
 
 #define NM_SETTING_WPAN_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NM_TYPE_SETTING_WPAN, NMSettingWpanPrivate))
+
+/*****************************************************************************/
 
 /**
  * nm_setting_wpan_get_mac_address:
@@ -208,6 +212,8 @@ verify (NMSetting *setting, NMConnection *connection, GError **error)
 	return TRUE;
 }
 
+/*****************************************************************************/
+
 static void
 get_property (GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
 {
@@ -264,6 +270,8 @@ set_property (GObject *object, guint prop_id, const GValue *value, GParamSpec *p
 	}
 }
 
+/*****************************************************************************/
+
 static void
 nm_setting_wpan_init (NMSettingWpan *setting)
 {
@@ -308,8 +316,8 @@ nm_setting_wpan_class_init (NMSettingWpanClass *klass)
 
 	g_type_class_add_private (setting_class, sizeof (NMSettingWpanPrivate));
 
-	object_class->set_property = set_property;
 	object_class->get_property = get_property;
+	object_class->set_property = set_property;
 	object_class->finalize     = finalize;
 
 	setting_class->verify = verify;

--- a/libnm-core/nm-setting-wpan.c
+++ b/libnm-core/nm-setting-wpan.c
@@ -39,14 +39,13 @@
 #define IEEE802154_MAX_CHANNEL 26
 #endif
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_MAC_ADDRESS,
 	PROP_PAN_ID,
 	PROP_SHORT_ADDRESS,
 	PROP_PAGE,
 	PROP_CHANNEL,
-};
+);
 
 typedef struct {
 	char *mac_address;
@@ -328,36 +327,33 @@ nm_setting_wpan_class_init (NMSettingWpanClass *klass)
 	 *   (e.g. 76:d8:9b:87:66:60:84:ee).
 	 * ---end---
 	 */
-	g_object_class_install_property
-		(object_class, PROP_MAC_ADDRESS,
-		 g_param_spec_string (NM_SETTING_WPAN_MAC_ADDRESS, "", "",
-		                      NULL,
-		                      G_PARAM_READWRITE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_MAC_ADDRESS] =
+	    g_param_spec_string (NM_SETTING_WPAN_MAC_ADDRESS, "", "",
+	                         NULL,
+	                         G_PARAM_READWRITE |
+	                         G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWpan:pan-id:
 	 *
 	 * IEEE 802.15.4 Personal Area Network (PAN) identifier.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_PAN_ID,
-		 g_param_spec_uint (NM_SETTING_WPAN_PAN_ID, "", "",
-		                    0, G_MAXUINT16, G_MAXUINT16,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PAN_ID] =
+	    g_param_spec_uint (NM_SETTING_WPAN_PAN_ID, "", "",
+	                       0, G_MAXUINT16, G_MAXUINT16,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWpan:short-address:
 	 *
 	 * Short IEEE 802.15.4 address to be used within a restricted environment.
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_SHORT_ADDRESS,
-		 g_param_spec_uint (NM_SETTING_WPAN_SHORT_ADDRESS, "", "",
-		                    0, G_MAXUINT16, G_MAXUINT16,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_SHORT_ADDRESS] =
+	    g_param_spec_uint (NM_SETTING_WPAN_SHORT_ADDRESS, "", "",
+	                       0, G_MAXUINT16, G_MAXUINT16,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWpan:page:
@@ -367,14 +363,13 @@ nm_setting_wpan_class_init (NMSettingWpanClass *klass)
 	 *
 	 * Since: 1.16
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_PAGE,
-		 g_param_spec_int (NM_SETTING_WPAN_PAGE, "", "",
-		                    G_MININT16,
-		                    G_MAXINT16,
-		                    NM_SETTING_WPAN_PAGE_DEFAULT,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_PAGE] =
+	    g_param_spec_int (NM_SETTING_WPAN_PAGE, "", "",
+	                       G_MININT16,
+	                       G_MAXINT16,
+	                       NM_SETTING_WPAN_PAGE_DEFAULT,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingWpan:channel:
@@ -384,14 +379,15 @@ nm_setting_wpan_class_init (NMSettingWpanClass *klass)
 	 *
 	 * Since: 1.16
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_CHANNEL,
-		 g_param_spec_int (NM_SETTING_WPAN_CHANNEL, "", "",
-		                    G_MININT16,
-		                    G_MAXINT16,
-		                    NM_SETTING_WPAN_CHANNEL_DEFAULT,
-		                    G_PARAM_READWRITE |
-		                    G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_CHANNEL] =
+	    g_param_spec_int (NM_SETTING_WPAN_CHANNEL, "", "",
+	                       G_MININT16,
+	                       G_MAXINT16,
+	                       NM_SETTING_WPAN_CHANNEL_DEFAULT,
+	                       G_PARAM_READWRITE |
+	                       G_PARAM_STATIC_STRINGS);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 
 	_nm_setting_class_commit (setting_class, NM_META_SETTING_TYPE_WPAN);
 }

--- a/libnm-core/nm-setting.c
+++ b/libnm-core/nm-setting.c
@@ -2517,11 +2517,6 @@ _nm_setting_gendata_reset_from_hash (NMSetting *setting,
 /*****************************************************************************/
 
 static void
-nm_setting_init (NMSetting *setting)
-{
-}
-
-static void
 get_property (GObject *object, guint prop_id,
               GValue *value, GParamSpec *pspec)
 {
@@ -2535,6 +2530,13 @@ get_property (GObject *object, guint prop_id,
 		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
 		break;
 	}
+}
+
+/*****************************************************************************/
+
+static void
+nm_setting_init (NMSetting *setting)
+{
 }
 
 static void

--- a/libnm-core/nm-setting.c
+++ b/libnm-core/nm-setting.c
@@ -67,12 +67,9 @@ typedef struct {
 	NMSettingPriority priority;
 } SettingInfo;
 
-enum {
-	PROP_0,
+NM_GOBJECT_PROPERTIES_DEFINE_BASE (
 	PROP_NAME,
-
-	PROP_LAST
-};
+);
 
 typedef struct {
 	GenData *gendata;
@@ -2593,10 +2590,11 @@ nm_setting_class_init (NMSettingClass *setting_class)
 	 * connection.  Each setting type has a name unique to that type, for
 	 * example "ppp" or "802-11-wireless" or "802-3-ethernet".
 	 **/
-	g_object_class_install_property
-		(object_class, PROP_NAME,
-		 g_param_spec_string (NM_SETTING_NAME, "", "",
-		                      NULL,
-		                      G_PARAM_READABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	obj_properties[PROP_NAME] =
+	    g_param_spec_string (NM_SETTING_NAME, "", "",
+	                         NULL,
+	                         G_PARAM_READABLE |
+	                         G_PARAM_STATIC_STRINGS);
+
+	g_object_class_install_properties (object_class, _PROPERTY_ENUMS_LAST, obj_properties);
 }

--- a/libnm-core/nm-simple-connection.c
+++ b/libnm-core/nm-simple-connection.c
@@ -22,6 +22,7 @@
 #include "nm-default.h"
 
 #include "nm-simple-connection.h"
+
 #include "nm-setting-private.h"
 
 /**
@@ -32,11 +33,15 @@
  * but might be used in the process of creating a new one.
  **/
 
+/*****************************************************************************/
+
 static void nm_simple_connection_interface_init (NMConnectionInterface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (NMSimpleConnection, nm_simple_connection, G_TYPE_OBJECT,
                          G_IMPLEMENT_INTERFACE (NM_TYPE_CONNECTION, nm_simple_connection_interface_init);
                          )
+
+/*****************************************************************************/
 
 static void
 nm_simple_connection_init (NMSimpleConnection *self)

--- a/libnm-core/nm-vpn-editor-plugin.c
+++ b/libnm-core/nm-vpn-editor-plugin.c
@@ -29,6 +29,8 @@
 
 #include "nm-core-internal.h"
 
+/*****************************************************************************/
+
 static void nm_vpn_editor_plugin_default_init (NMVpnEditorPluginInterface *iface);
 
 G_DEFINE_INTERFACE (NMVpnEditorPlugin, nm_vpn_editor_plugin, G_TYPE_OBJECT)
@@ -36,18 +38,16 @@ G_DEFINE_INTERFACE (NMVpnEditorPlugin, nm_vpn_editor_plugin, G_TYPE_OBJECT)
 static void
 nm_vpn_editor_plugin_default_init (NMVpnEditorPluginInterface *iface)
 {
-	/* Properties */
-
 	/**
 	 * NMVpnEditorPlugin:name:
 	 *
 	 * Short display name of the VPN plugin.
 	 */
 	g_object_interface_install_property (iface,
-		 g_param_spec_string (NM_VPN_EDITOR_PLUGIN_NAME, "", "",
-		                      NULL,
-		                      G_PARAM_READABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	    g_param_spec_string (NM_VPN_EDITOR_PLUGIN_NAME, "", "",
+	                         NULL,
+	                         G_PARAM_READABLE |
+	                         G_PARAM_STATIC_STRINGS));
 
 	/**
 	 * NMVpnEditorPlugin:description:
@@ -55,10 +55,10 @@ nm_vpn_editor_plugin_default_init (NMVpnEditorPluginInterface *iface)
 	 * Longer description of the VPN plugin.
 	 */
 	g_object_interface_install_property (iface,
-		 g_param_spec_string (NM_VPN_EDITOR_PLUGIN_DESCRIPTION, "", "",
-		                      NULL,
-		                      G_PARAM_READABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	    g_param_spec_string (NM_VPN_EDITOR_PLUGIN_DESCRIPTION, "", "",
+	                         NULL,
+	                         G_PARAM_READABLE |
+	                         G_PARAM_STATIC_STRINGS));
 
 	/**
 	 * NMVpnEditorPlugin:service:
@@ -66,10 +66,10 @@ nm_vpn_editor_plugin_default_init (NMVpnEditorPluginInterface *iface)
 	 * D-Bus service name of the plugin's VPN service.
 	 */
 	g_object_interface_install_property (iface,
-		 g_param_spec_string (NM_VPN_EDITOR_PLUGIN_SERVICE, "", "",
-		                      NULL,
-		                      G_PARAM_READABLE |
-		                      G_PARAM_STATIC_STRINGS));
+	    g_param_spec_string (NM_VPN_EDITOR_PLUGIN_SERVICE, "", "",
+	                         NULL,
+	                         G_PARAM_READABLE |
+	                         G_PARAM_STATIC_STRINGS));
 }
 
 /*****************************************************************************/

--- a/libnm-core/nm-vpn-plugin-info.c
+++ b/libnm-core/nm-vpn-plugin-info.c
@@ -1095,60 +1095,42 @@ nm_vpn_plugin_info_load_editor_plugin (NMVpnPluginInfo *self, GError **error)
 
 /*****************************************************************************/
 
-/**
- * nm_vpn_plugin_info_new_from_file:
- * @filename: filename to read.
- * @error: on failure, the error reason.
- *
- * Read the plugin info from file @filename. Does not do
- * any further verification on the file. You might want to check
- * file permissions and ownership of the file.
- *
- * Returns: %NULL if there is any error or a newly created
- * #NMVpnPluginInfo instance.
- *
- * Since: 1.2
- */
-NMVpnPluginInfo *
-nm_vpn_plugin_info_new_from_file (const char *filename,
-                                  GError **error)
+static void
+get_property (GObject *object, guint prop_id,
+              GValue *value, GParamSpec *pspec)
 {
-	g_return_val_if_fail (filename, NULL);
+	NMVpnPluginInfoPrivate *priv = NM_VPN_PLUGIN_INFO_GET_PRIVATE (object);
 
-	return NM_VPN_PLUGIN_INFO (g_initable_new (NM_TYPE_VPN_PLUGIN_INFO,
-	                                           NULL,
-	                                           error,
-	                                           NM_VPN_PLUGIN_INFO_FILENAME, filename,
-	                                           NULL));
+	switch (prop_id) {
+	case PROP_NAME:
+		g_value_set_string (value, priv->name);
+		break;
+	case PROP_FILENAME:
+		g_value_set_string (value, priv->filename);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
 }
 
-/**
- * nm_vpn_plugin_info_new_with_data:
- * @filename: optional filename.
- * @keyfile: inject data for the plugin info instance.
- * @error: construction may fail if the keyfile lacks mandatory fields.
- *   In this case, return the error reason.
- *
- * This constructor does not read any data from file but
- * takes instead a @keyfile argument.
- *
- * Returns: new plugin info instance.
- *
- * Since: 1.2
- */
-NMVpnPluginInfo *
-nm_vpn_plugin_info_new_with_data (const char *filename,
-                                  GKeyFile *keyfile,
-                                  GError **error)
+static void
+set_property (GObject *object, guint prop_id,
+              const GValue *value, GParamSpec *pspec)
 {
-	g_return_val_if_fail (keyfile, NULL);
+	NMVpnPluginInfoPrivate *priv = NM_VPN_PLUGIN_INFO_GET_PRIVATE (object);
 
-	return NM_VPN_PLUGIN_INFO (g_initable_new (NM_TYPE_VPN_PLUGIN_INFO,
-	                                           NULL,
-	                                           error,
-	                                           NM_VPN_PLUGIN_INFO_FILENAME, filename,
-	                                           NM_VPN_PLUGIN_INFO_KEYFILE, keyfile,
-	                                           NULL));
+	switch (prop_id) {
+	case PROP_FILENAME:
+		priv->filename = g_value_dup_string (value);
+		break;
+	case PROP_KEYFILE:
+		priv->keyfile = g_value_dup_boxed (value);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
 }
 
 /*****************************************************************************/
@@ -1224,42 +1206,60 @@ init_sync (GInitable *initable, GCancellable *cancellable, GError **error)
 	return TRUE;
 }
 
-static void
-set_property (GObject *object, guint prop_id,
-              const GValue *value, GParamSpec *pspec)
+/**
+ * nm_vpn_plugin_info_new_from_file:
+ * @filename: filename to read.
+ * @error: on failure, the error reason.
+ *
+ * Read the plugin info from file @filename. Does not do
+ * any further verification on the file. You might want to check
+ * file permissions and ownership of the file.
+ *
+ * Returns: %NULL if there is any error or a newly created
+ * #NMVpnPluginInfo instance.
+ *
+ * Since: 1.2
+ */
+NMVpnPluginInfo *
+nm_vpn_plugin_info_new_from_file (const char *filename,
+                                  GError **error)
 {
-	NMVpnPluginInfoPrivate *priv = NM_VPN_PLUGIN_INFO_GET_PRIVATE (object);
+	g_return_val_if_fail (filename, NULL);
 
-	switch (prop_id) {
-	case PROP_FILENAME:
-		priv->filename = g_value_dup_string (value);
-		break;
-	case PROP_KEYFILE:
-		priv->keyfile = g_value_dup_boxed (value);
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
+	return NM_VPN_PLUGIN_INFO (g_initable_new (NM_TYPE_VPN_PLUGIN_INFO,
+	                                           NULL,
+	                                           error,
+	                                           NM_VPN_PLUGIN_INFO_FILENAME, filename,
+	                                           NULL));
 }
 
-static void
-get_property (GObject *object, guint prop_id,
-              GValue *value, GParamSpec *pspec)
+/**
+ * nm_vpn_plugin_info_new_with_data:
+ * @filename: optional filename.
+ * @keyfile: inject data for the plugin info instance.
+ * @error: construction may fail if the keyfile lacks mandatory fields.
+ *   In this case, return the error reason.
+ *
+ * This constructor does not read any data from file but
+ * takes instead a @keyfile argument.
+ *
+ * Returns: new plugin info instance.
+ *
+ * Since: 1.2
+ */
+NMVpnPluginInfo *
+nm_vpn_plugin_info_new_with_data (const char *filename,
+                                  GKeyFile *keyfile,
+                                  GError **error)
 {
-	NMVpnPluginInfoPrivate *priv = NM_VPN_PLUGIN_INFO_GET_PRIVATE (object);
+	g_return_val_if_fail (keyfile, NULL);
 
-	switch (prop_id) {
-	case PROP_NAME:
-		g_value_set_string (value, priv->name);
-		break;
-	case PROP_FILENAME:
-		g_value_set_string (value, priv->filename);
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
-	}
+	return NM_VPN_PLUGIN_INFO (g_initable_new (NM_TYPE_VPN_PLUGIN_INFO,
+	                                           NULL,
+	                                           error,
+	                                           NM_VPN_PLUGIN_INFO_FILENAME, filename,
+	                                           NM_VPN_PLUGIN_INFO_KEYFILE, keyfile,
+	                                           NULL));
 }
 
 static void
@@ -1298,13 +1298,10 @@ nm_vpn_plugin_info_class_init (NMVpnPluginInfoClass *plugin_class)
 
 	g_type_class_add_private (object_class, sizeof (NMVpnPluginInfoPrivate));
 
-	/* virtual methods */
 	object_class->set_property = set_property;
 	object_class->get_property = get_property;
 	object_class->dispose      = dispose;
 	object_class->finalize     = finalize;
-
-	/* properties */
 
 	/**
 	 * NMVpnPluginInfo:name:
@@ -1361,4 +1358,3 @@ nm_vpn_plugin_info_initable_iface_init (GInitableIface *iface)
 {
 	iface->init = init_sync;
 }
-


### PR DESCRIPTION
Some refactoring to let also `libnm-core/` follow the patterns from `src/`, with respect to their GObject implementations.

The main reason I did this, is because whenever we create a new setting class, we start by copying an existing one. So, the existing ones should be good examples for how to do it.