### PR TITLE
[th/wifi-p2p-various]

### DIFF
--- a/libnm-core/nm-errors.h
+++ b/libnm-core/nm-errors.h
@@ -145,6 +145,7 @@ GQuark nm_crypto_error_quark (void);
  * @NM_DEVICE_ERROR_VERSION_ID_MISMATCH: the version id did not match.
  * @NM_DEVICE_ERROR_MISSING_DEPENDENCIES: the requested operation could not
  *   be completed due to missing dependencies.
+ * @NM_DEVICE_ERROR_INVALID_ARGUMENT: invalid argument. Since: 1.16
  *
  * Device-related errors.
  *
@@ -163,6 +164,7 @@ typedef enum {
 	NM_DEVICE_ERROR_SPECIFIC_OBJECT_NOT_FOUND, /*< nick=SpecificObjectNotFound >*/
 	NM_DEVICE_ERROR_VERSION_ID_MISMATCH,       /*< nick=VersionIdMismatch >*/
 	NM_DEVICE_ERROR_MISSING_DEPENDENCIES,      /*< nick=MissingDependencies >*/
+	NM_DEVICE_ERROR_INVALID_ARGUMENT,          /*< nick=InvalidArgument >*/
 } NMDeviceError;
 
 #define NM_DEVICE_ERROR nm_device_error_quark ()

--- a/libnm/libnm.ver
+++ b/libnm/libnm.ver
@@ -1454,6 +1454,10 @@ global:
 	nm_device_wifi_p2p_get_hw_address;
 	nm_device_wifi_p2p_get_peers;
 	nm_device_wifi_p2p_get_type;
+	nm_device_wifi_p2p_start_find;
+	nm_device_wifi_p2p_start_find_finish;
+	nm_device_wifi_p2p_stop_find;
+	nm_device_wifi_p2p_stop_find_finish;
 	nm_setting_wifi_p2p_get_peer;
 	nm_setting_wifi_p2p_get_type;
 	nm_setting_wifi_p2p_get_wps_method;

--- a/libnm/nm-device-wifi-p2p.c
+++ b/libnm/nm-device-wifi-p2p.c
@@ -203,6 +203,7 @@ start_find_finished_cb (GObject      *obj,
 /**
  * nm_device_wifi_p2p_start_find:
  * @device: a #NMDeviceWifiP2P
+ * @options: (allow-none): optional options passed to StartFind.
  * @cancellable: a #GCancellable, or %NULL
  * @callback: a #GAsyncReadyCallback, or %NULL
  * @user_data: user_data for @callback
@@ -218,19 +219,20 @@ start_find_finished_cb (GObject      *obj,
  **/
 void
 nm_device_wifi_p2p_start_find (NMDeviceWifiP2P     *device,
+                               GVariant            *options,
                                GCancellable        *cancellable,
                                GAsyncReadyCallback  callback,
                                gpointer             user_data)
 {
 	NMDeviceWifiP2PPrivate *priv = NM_DEVICE_WIFI_P2P_GET_PRIVATE (device);
-	GVariant *options;
 	GTask *task;
 
 	g_return_if_fail (NM_IS_DEVICE_WIFI_P2P (device));
 
 	task = g_task_new (device, cancellable, callback, user_data);
 
-	options = g_variant_new_array (G_VARIANT_TYPE ("{sv}"), NULL, 0);
+	if (!options)
+		options = g_variant_new_array (G_VARIANT_TYPE ("{sv}"), NULL, 0);
 	nmdbus_device_wifi_p2p_call_start_find (priv->proxy,
 	                                        options,
 	                                        cancellable,

--- a/libnm/nm-device-wifi-p2p.c
+++ b/libnm/nm-device-wifi-p2p.c
@@ -189,7 +189,7 @@ start_find_finished_cb (GObject      *obj,
                         gpointer user_data)
 {
 	NMDBusDeviceWifiP2P *proxy = (NMDBusDeviceWifiP2P*) obj;
-	GTask *task = G_TASK (user_data);
+	gs_unref_object GTask *task = G_TASK (user_data);
 	GError *error = NULL;
 	gboolean success;
 
@@ -198,8 +198,6 @@ start_find_finished_cb (GObject      *obj,
 		g_task_return_error (task, error);
 	else
 		g_task_return_boolean (task, TRUE);
-
-	g_object_unref (task);
 }
 
 /**
@@ -225,13 +223,14 @@ nm_device_wifi_p2p_start_find (NMDeviceWifiP2P     *device,
                                gpointer             user_data)
 {
 	NMDeviceWifiP2PPrivate *priv = NM_DEVICE_WIFI_P2P_GET_PRIVATE (device);
-	GVariant *options = g_variant_new_array (G_VARIANT_TYPE ("{sv}"), NULL, 0);
+	GVariant *options;
 	GTask *task;
 
 	g_return_if_fail (NM_IS_DEVICE_WIFI_P2P (device));
 
 	task = g_task_new (device, cancellable, callback, user_data);
 
+	options = g_variant_new_array (G_VARIANT_TYPE ("{sv}"), NULL, 0);
 	nmdbus_device_wifi_p2p_call_start_find (priv->proxy,
 	                                        options,
 	                                        cancellable,
@@ -265,7 +264,7 @@ stop_find_finished_cb (GObject      *obj,
                        gpointer user_data)
 {
 	NMDBusDeviceWifiP2P *proxy = (NMDBusDeviceWifiP2P*) obj;
-	GTask *task = G_TASK (user_data);
+	gs_unref_object GTask *task = G_TASK (user_data);
 	GError *error = NULL;
 	gboolean success;
 
@@ -274,8 +273,6 @@ stop_find_finished_cb (GObject      *obj,
 		g_task_return_error (task, error);
 	else
 		g_task_return_boolean (task, TRUE);
-
-	g_object_unref (task);
 }
 
 /**

--- a/libnm/nm-device-wifi-p2p.c
+++ b/libnm/nm-device-wifi-p2p.c
@@ -184,6 +184,151 @@ nm_device_wifi_p2p_get_peer_by_path (NMDeviceWifiP2P *device,
 }
 
 static void
+start_find_finished_cb (GObject      *obj,
+                        GAsyncResult *res,
+                        gpointer user_data)
+{
+	NMDBusDeviceWifiP2P *proxy = (NMDBusDeviceWifiP2P*) obj;
+	GTask *task = G_TASK (user_data);
+	GError *error = NULL;
+	gboolean success;
+
+	success = nmdbus_device_wifi_p2p_call_start_find_finish (proxy, res, &error);
+	if (!success)
+		g_task_return_error (task, error);
+	else
+		g_task_return_boolean (task, TRUE);
+
+	g_object_unref (task);
+}
+
+/**
+ * nm_device_wifi_p2p_start_find:
+ * @device: a #NMDeviceWifiP2P
+ * @cancellable: a #GCancellable, or %NULL
+ * @callback: a #GAsyncReadyCallback, or %NULL
+ * @user_data: user_data for @callback
+ *
+ * Request NM to search for Wi-Fi P2P peers on @device. Note that the call
+ * returns immediately after requesting the find, and it may take some time
+ * after that for peers to be found.
+ *
+ * The find operation will run for 30s by default. You can stop it earlier
+ * using nm_device_p2p_wifi_stop_find().
+ *
+ * Since: 1.16
+ **/
+void
+nm_device_wifi_p2p_start_find (NMDeviceWifiP2P     *device,
+                               GCancellable        *cancellable,
+                               GAsyncReadyCallback  callback,
+                               gpointer             user_data)
+{
+	NMDeviceWifiP2PPrivate *priv = NM_DEVICE_WIFI_P2P_GET_PRIVATE (device);
+	GVariant *options = g_variant_new_array (G_VARIANT_TYPE ("{sv}"), NULL, 0);
+	GTask *task;
+
+	g_return_if_fail (NM_IS_DEVICE_WIFI_P2P (device));
+
+	task = g_task_new (device, cancellable, callback, user_data);
+
+	nmdbus_device_wifi_p2p_call_start_find (priv->proxy,
+	                                        options,
+	                                        cancellable,
+	                                        start_find_finished_cb,
+	                                        task);
+}
+
+/**
+ * nm_device_wifi_p2p_start_find_finish:
+ * @device: a #NMDeviceWifiP2P
+ * @result: the #GAsyncResult
+ * @error: #GError return address
+ *
+ * Finish an operation started by nm_device_wifi_p2p_start_find().
+ *
+ * Returns: %TRUE if the call was successful
+ *
+ * Since: 1.16
+ **/
+gboolean
+nm_device_wifi_p2p_start_find_finish (NMDeviceWifiP2P  *device,
+                                      GAsyncResult     *result,
+                                      GError          **error)
+{
+	return g_task_propagate_boolean (G_TASK (result), error);
+}
+
+static void
+stop_find_finished_cb (GObject      *obj,
+                       GAsyncResult *res,
+                       gpointer user_data)
+{
+	NMDBusDeviceWifiP2P *proxy = (NMDBusDeviceWifiP2P*) obj;
+	GTask *task = G_TASK (user_data);
+	GError *error = NULL;
+	gboolean success;
+
+	success = nmdbus_device_wifi_p2p_call_stop_find_finish (proxy, res, &error);
+	if (!success)
+		g_task_return_error (task, error);
+	else
+		g_task_return_boolean (task, TRUE);
+
+	g_object_unref (task);
+}
+
+/**
+ * nm_device_wifi_p2p_stop_find:
+ * @device: a #NMDeviceWifiP2P
+ * @cancellable: a #GCancellable, or %NULL
+ * @callback: a #GAsyncReadyCallback, or %NULL
+ * @user_data: user_data for @callback
+ *
+ * Request NM to stop any ongoing find operation for Wi-Fi P2P peers on @device.
+ *
+ * Since: 1.16
+ **/
+void
+nm_device_wifi_p2p_stop_find (NMDeviceWifiP2P     *device,
+                              GCancellable        *cancellable,
+                              GAsyncReadyCallback  callback,
+                              gpointer             user_data)
+{
+	NMDeviceWifiP2PPrivate *priv = NM_DEVICE_WIFI_P2P_GET_PRIVATE (device);
+	GTask *task;
+
+	g_return_if_fail (NM_IS_DEVICE_WIFI_P2P (device));
+
+	task = g_task_new (device, cancellable, callback, user_data);
+
+	nmdbus_device_wifi_p2p_call_stop_find (priv->proxy,
+	                                       cancellable,
+	                                       stop_find_finished_cb,
+	                                       task);
+}
+
+/**
+ * nm_device_wifi_p2p_stop_find_finish:
+ * @device: a #NMDeviceWifiP2P
+ * @result: the #GAsyncResult
+ * @error: #GError return address
+ *
+ * Finish an operation started by nm_device_wifi_p2p_stop_find().
+ *
+ * Returns: %TRUE if the call was successful
+ *
+ * Since: 1.16
+ **/
+gboolean
+nm_device_wifi_p2p_stop_find_finish (NMDeviceWifiP2P  *device,
+                                      GAsyncResult     *result,
+                                      GError          **error)
+{
+	return g_task_propagate_boolean (G_TASK (result), error);
+}
+
+static void
 clean_up_peers (NMDeviceWifiP2P *self)
 {
 	NMDeviceWifiP2PPrivate *priv = NM_DEVICE_WIFI_P2P_GET_PRIVATE (self);

--- a/libnm/nm-device-wifi-p2p.h
+++ b/libnm/nm-device-wifi-p2p.h
@@ -60,6 +60,7 @@ const GPtrArray *        nm_device_wifi_p2p_get_peers        (NMDeviceWifiP2P *d
 
 NM_AVAILABLE_IN_1_16
 void                     nm_device_wifi_p2p_start_find        (NMDeviceWifiP2P     *device,
+                                                               GVariant            *options,
                                                                GCancellable        *cancellable,
                                                                GAsyncReadyCallback  callback,
                                                                gpointer             user_data);

--- a/libnm/nm-device-wifi-p2p.h
+++ b/libnm/nm-device-wifi-p2p.h
@@ -58,6 +58,26 @@ NMWifiP2PPeer *          nm_device_wifi_p2p_get_peer_by_path (NMDeviceWifiP2P *d
 NM_AVAILABLE_IN_1_16
 const GPtrArray *        nm_device_wifi_p2p_get_peers        (NMDeviceWifiP2P *device);
 
+NM_AVAILABLE_IN_1_16
+void                     nm_device_wifi_p2p_start_find        (NMDeviceWifiP2P     *device,
+                                                               GCancellable        *cancellable,
+                                                               GAsyncReadyCallback  callback,
+                                                               gpointer             user_data);
+NM_AVAILABLE_IN_1_16
+gboolean                 nm_device_wifi_p2p_start_find_finish (NMDeviceWifiP2P     *device,
+                                                               GAsyncResult        *result,
+                                                               GError             **error);
+
+NM_AVAILABLE_IN_1_16
+void                     nm_device_wifi_p2p_stop_find         (NMDeviceWifiP2P     *device,
+                                                               GCancellable        *cancellable,
+                                                               GAsyncReadyCallback  callback,
+                                                               gpointer             user_data);
+NM_AVAILABLE_IN_1_16
+gboolean                 nm_device_wifi_p2p_stop_find_finish  (NMDeviceWifiP2P     *device,
+                                                               GAsyncResult        *result,
+                                                               GError             **error);
+
 G_END_DECLS
 
 #endif /* __NM_DEVICE_WIFI_P2P_H__ */

--- a/src/devices/wifi/nm-device-wifi-p2p.c
+++ b/src/devices/wifi/nm-device-wifi-p2p.c
@@ -1006,11 +1006,11 @@ impl_device_wifi_p2p_start_find (NMDBusObject *obj,
 	NMDeviceWifiP2P *self = NM_DEVICE_WIFI_P2P (obj);
 	NMDeviceWifiP2PPrivate *priv = NM_DEVICE_WIFI_P2P_GET_PRIVATE (self);
 	gs_unref_variant GVariant *options = NULL;
-	int timeout;
+	gint32 timeout;
 
 	g_variant_get (parameters, "(@a{sv})", &options);
 
-	if (!g_variant_lookup (options, "Timeout", "^ai", &timeout)) {
+	if (!g_variant_lookup (options, "Timeout", "i", &timeout)) {
 		/* Default to running a find for 30s. */
 		timeout = 30;
 	}

--- a/src/devices/wifi/nm-device-wifi-p2p.c
+++ b/src/devices/wifi/nm-device-wifi-p2p.c
@@ -1010,7 +1010,7 @@ impl_device_wifi_p2p_start_find (NMDBusObject *obj,
 
 	g_variant_get (parameters, "(@a{sv})", &options);
 
-	if (!g_variant_lookup (options, "Timeout", "i", &timeout)) {
+	if (!g_variant_lookup (options, "timeout", "i", &timeout)) {
 		/* Default to running a find for 30s. */
 		timeout = 30;
 	}

--- a/src/supplicant/nm-supplicant-interface.c
+++ b/src/supplicant/nm-supplicant-interface.c
@@ -2482,7 +2482,6 @@ nm_supplicant_interface_p2p_start_find (NMSupplicantInterface *self,
 
 	priv = NM_SUPPLICANT_INTERFACE_GET_PRIVATE (self);
 
-	/* Find parameters */
 	g_variant_builder_init (&builder, G_VARIANT_TYPE_VARDICT);
 	g_variant_builder_add (&builder, "{sv}", "Timeout", g_variant_new_int32 (timeout));
 


### PR DESCRIPTION
Follow-up after merging ce3f7bf812c21773251748693cd39d2fb54b9055. Most notable:

- rename stuff, to consistently name it "Wi-Fi P2P".

- drop `nm_device_p2p_wifi_start_find()` and `nm_device_p2p_wifi_stop_find()` for the moment.