### PR TITLE
[th/various-for-wireguard-2]

### DIFF
--- a/libnm-core/nm-connection.c
+++ b/libnm-core/nm-connection.c
@@ -1873,6 +1873,147 @@ nm_connection_clear_secrets_with_flags (NMConnection *connection,
 	g_signal_emit (connection, signals[SECRETS_CLEARED], 0);
 }
 
+/*****************************************************************************/
+
+/* Returns always a non-NULL, non-floating variant that must
+ * be unrefed by the caller. */
+GVariant *
+_nm_connection_for_each_secret (NMConnection *self,
+                                GVariant *secrets,
+                                gboolean remove_non_secrets,
+                                NMConnectionForEachSecretFunc callback,
+                                gpointer callback_data)
+{
+	GVariantBuilder secrets_builder, setting_builder;
+	GVariantIter secrets_iter, *setting_iter;
+	const char *setting_name;
+
+	/* This function, given a dict of dicts representing new secrets of
+	 * an NMConnection, walks through each toplevel dict (which represents a
+	 * NMSetting), and for each setting, walks through that setting dict's
+	 * properties.  For each property that's a secret, it will check that
+	 * secret's flags in the backing NMConnection object, and call a supplied
+	 * callback.
+	 *
+	 * The one complexity is that the VPN setting's 'secrets' property is
+	 * *also* a dict (since the key/value pairs are arbitrary and known
+	 * only to the VPN plugin itself).  That means we have three levels of
+	 * dicts that we potentially have to traverse here.  When we hit the
+	 * VPN setting's 'secrets' property, we special-case that and iterate over
+	 * each item in that 'secrets' dict, calling the supplied callback
+	 * each time.
+	 */
+
+	g_return_val_if_fail (callback, NULL);
+
+	g_variant_iter_init (&secrets_iter, secrets);
+	g_variant_builder_init (&secrets_builder, NM_VARIANT_TYPE_CONNECTION);
+	while (g_variant_iter_next (&secrets_iter, "{&sa{sv}}", &setting_name, &setting_iter)) {
+		NMSetting *setting;
+		const char *secret_name;
+		GVariant *val;
+
+		setting = nm_connection_get_setting_by_name (self, setting_name);
+		if (setting == NULL) {
+			g_variant_iter_free (setting_iter);
+			continue;
+		}
+
+		g_variant_builder_init (&setting_builder, NM_VARIANT_TYPE_SETTING);
+		while (g_variant_iter_next (setting_iter, "{&sv}", &secret_name, &val)) {
+			NMSettingSecretFlags secret_flags = NM_SETTING_SECRET_FLAG_NONE;
+
+			/* VPN secrets need slightly different treatment here since the
+			 * "secrets" property is actually a hash table of secrets.
+			 */
+			if (NM_IS_SETTING_VPN (setting) && !g_strcmp0 (secret_name, NM_SETTING_VPN_SECRETS)) {
+				GVariantBuilder vpn_secrets_builder;
+				GVariantIter vpn_secrets_iter;
+				const char *vpn_secret_name, *secret;
+
+				if (!g_variant_is_of_type (val, G_VARIANT_TYPE ("a{ss}"))) {
+					/* invalid type. Silently ignore the secrets as we cannot find out the
+					 * secret-flags. */
+					g_variant_unref (val);
+					continue;
+				}
+
+				/* Iterate through each secret from the VPN dict in the overall secrets dict */
+				g_variant_builder_init (&vpn_secrets_builder, G_VARIANT_TYPE ("a{ss}"));
+				g_variant_iter_init (&vpn_secrets_iter, val);
+				while (g_variant_iter_next (&vpn_secrets_iter, "{&s&s}", &vpn_secret_name, &secret)) {
+
+					/* we ignore the return value of get_secret_flags. The function may determine
+					 * that this is not a secret, based on having not secret-flags and no secrets.
+					 * But we have the secret at hand. We know it would be a valid secret, if we
+					 * only would add it to the VPN settings. */
+					nm_setting_get_secret_flags (setting, vpn_secret_name, &secret_flags, NULL);
+
+					if (callback (secret_flags, callback_data))
+						g_variant_builder_add (&vpn_secrets_builder, "{ss}", vpn_secret_name, secret);
+				}
+
+				g_variant_builder_add (&setting_builder, "{sv}",
+				                       secret_name, g_variant_builder_end (&vpn_secrets_builder));
+			} else {
+				if (!nm_setting_get_secret_flags (setting, secret_name, &secret_flags, NULL)) {
+					if (!remove_non_secrets)
+						g_variant_builder_add (&setting_builder, "{sv}", secret_name, val);
+					g_variant_unref (val);
+					continue;
+				}
+				if (callback (secret_flags, callback_data))
+					g_variant_builder_add (&setting_builder, "{sv}", secret_name, val);
+			}
+			g_variant_unref (val);
+		}
+
+		g_variant_iter_free (setting_iter);
+		g_variant_builder_add (&secrets_builder, "{sa{sv}}", setting_name, &setting_builder);
+	}
+
+	return g_variant_ref_sink (g_variant_builder_end (&secrets_builder));
+}
+
+/*****************************************************************************/
+
+typedef struct {
+	NMConnectionFindSecretFunc find_func;
+	gpointer find_func_data;
+	gboolean found;
+} FindSecretData;
+
+static gboolean
+find_secret_for_each_func (NMSettingSecretFlags flags,
+                           gpointer user_data)
+{
+	FindSecretData *data = user_data;
+
+	if (!data->found)
+		data->found = data->find_func (flags, data->find_func_data);
+	return FALSE;
+}
+
+gboolean
+_nm_connection_find_secret (NMConnection *self,
+                            GVariant *secrets,
+                            NMConnectionFindSecretFunc callback,
+                            gpointer callback_data)
+{
+	FindSecretData data;
+	GVariant *dummy;
+
+	data.find_func = callback;
+	data.find_func_data = callback_data;
+	data.found = FALSE;
+
+	dummy = _nm_connection_for_each_secret (self, secrets, FALSE, find_secret_for_each_func, &data);
+	g_variant_unref (dummy);
+	return data.found;
+}
+
+/*****************************************************************************/
+
 /**
  * nm_connection_to_dbus:
  * @connection: the #NMConnection

--- a/libnm-core/nm-core-internal.h
+++ b/libnm-core/nm-core-internal.h
@@ -733,14 +733,10 @@ GBytes *_nm_setting_802_1x_cert_value_to_bytes (NMSetting8021xCKScheme scheme,
 
 /*****************************************************************************/
 
-/* Return TRUE to keep (copy to the result), FALSE to drop. */
-typedef gboolean (*NMConnectionForEachSecretFunc) (NMSettingSecretFlags flags,
-                                                   gpointer user_data);
-
 GVariant *_nm_connection_for_each_secret (NMConnection *self,
                                           GVariant *secrets,
                                           gboolean remove_non_secrets,
-                                          NMConnectionForEachSecretFunc callback,
+                                          _NMConnectionForEachSecretFunc callback,
                                           gpointer callback_data);
 
 typedef gboolean (*NMConnectionFindSecretFunc) (NMSettingSecretFlags flags,

--- a/libnm-core/nm-core-internal.h
+++ b/libnm-core/nm-core-internal.h
@@ -733,4 +733,24 @@ GBytes *_nm_setting_802_1x_cert_value_to_bytes (NMSetting8021xCKScheme scheme,
 
 /*****************************************************************************/
 
+/* Return TRUE to keep (copy to the result), FALSE to drop. */
+typedef gboolean (*NMConnectionForEachSecretFunc) (NMSettingSecretFlags flags,
+                                                   gpointer user_data);
+
+GVariant *_nm_connection_for_each_secret (NMConnection *self,
+                                          GVariant *secrets,
+                                          gboolean remove_non_secrets,
+                                          NMConnectionForEachSecretFunc callback,
+                                          gpointer callback_data);
+
+typedef gboolean (*NMConnectionFindSecretFunc) (NMSettingSecretFlags flags,
+                                                gpointer user_data);
+
+gboolean _nm_connection_find_secret (NMConnection *self,
+                                     GVariant *secrets,
+                                     NMConnectionFindSecretFunc callback,
+                                     gpointer callback_data);
+
+/*****************************************************************************/
+
 #endif

--- a/libnm-core/nm-core-internal.h
+++ b/libnm-core/nm-core-internal.h
@@ -614,7 +614,8 @@ gboolean _nm_setting_sriov_sort_vfs (NMSettingSriov *setting);
 
 /*****************************************************************************/
 
-typedef struct _NMSettInfoSetting NMSettInfoSetting;
+typedef struct _NMSettInfoSetting  NMSettInfoSetting;
+typedef struct _NMSettInfoProperty NMSettInfoProperty;
 
 typedef GVariant *(*NMSettingPropertyGetFunc)           (NMSetting     *setting,
                                                          const char    *property);
@@ -638,7 +639,7 @@ typedef GVariant *(*NMSettingPropertyTransformToFunc)   (const GValue *from);
 typedef void      (*NMSettingPropertyTransformFromFunc) (GVariant *from,
                                                           GValue *to);
 
-typedef struct {
+struct _NMSettInfoProperty {
 	const char *name;
 	GParamSpec *param_spec;
 	const GVariantType *dbus_type;
@@ -650,7 +651,7 @@ typedef struct {
 
 	NMSettingPropertyTransformToFunc   to_dbus;
 	NMSettingPropertyTransformFromFunc from_dbus;
-} NMSettInfoProperty;
+};
 
 typedef struct {
 	const GVariantType *(*get_variant_type) (const struct _NMSettInfoSetting *sett_info,

--- a/libnm-core/nm-setting-private.h
+++ b/libnm-core/nm-setting-private.h
@@ -39,6 +39,8 @@ int _nm_setting_compare_priority (gconstpointer a, gconstpointer b);
 
 /*****************************************************************************/
 
+void _nm_setting_emit_property_changed (NMSetting *setting);
+
 typedef enum NMSettingUpdateSecretResult {
 	NM_SETTING_UPDATE_SECRET_ERROR              = FALSE,
 	NM_SETTING_UPDATE_SECRET_SUCCESS_MODIFIED   = TRUE,

--- a/libnm-core/nm-setting-private.h
+++ b/libnm-core/nm-setting-private.h
@@ -101,9 +101,6 @@ gboolean _nm_setting_verify_secret_string (const char *str,
 gboolean _nm_setting_aggregate (NMSetting *setting,
                                 NMConnectionAggregateType type,
                                 gpointer arg);
-gboolean _nm_setting_vpn_aggregate (NMSettingVpn *setting,
-                                    NMConnectionAggregateType type,
-                                    gpointer arg);
 
 gboolean _nm_setting_slave_type_is_valid (const char *slave_type, const char **out_port_type);
 

--- a/libnm-core/nm-setting-vpn.c
+++ b/libnm-core/nm-setting-vpn.c
@@ -684,6 +684,57 @@ update_one_secret (NMSetting *setting, const char *key, GVariant *value, GError 
 	return success;
 }
 
+static void
+for_each_secret (NMSetting *setting,
+                 const char *secret_name,
+                 GVariant *val,
+                 gboolean remove_non_secrets,
+                 _NMConnectionForEachSecretFunc callback,
+                 gpointer callback_data,
+                 GVariantBuilder *setting_builder)
+{
+	GVariantBuilder vpn_secrets_builder;
+	GVariantIter vpn_secrets_iter;
+	const char *vpn_secret_name;
+	const char *secret;
+
+	if (!nm_streq (secret_name, NM_SETTING_VPN_SECRETS)) {
+		NM_SETTING_CLASS (nm_setting_vpn_parent_class)->for_each_secret (setting,
+		                                                                 secret_name,
+		                                                                 val,
+		                                                                 remove_non_secrets,
+		                                                                 callback,
+		                                                                 callback_data,
+		                                                                 setting_builder);
+		return;
+	}
+
+	if (!g_variant_is_of_type (val, G_VARIANT_TYPE ("a{ss}"))) {
+		/* invalid type. Silently ignore the secrets as we cannot find out the
+		 * secret-flags. */
+		return;
+	}
+
+	/* Iterate through each secret from the VPN dict in the overall secrets dict */
+	g_variant_builder_init (&vpn_secrets_builder, G_VARIANT_TYPE ("a{ss}"));
+	g_variant_iter_init (&vpn_secrets_iter, val);
+	while (g_variant_iter_next (&vpn_secrets_iter, "{&s&s}", &vpn_secret_name, &secret)) {
+		NMSettingSecretFlags secret_flags = NM_SETTING_SECRET_FLAG_NONE;
+
+		/* we ignore the return value of get_secret_flags. The function may determine
+		 * that this is not a secret, based on having not secret-flags and no secrets.
+		 * But we have the secret at hand. We know it would be a valid secret, if we
+		 * only add it to the VPN settings. */
+		nm_setting_get_secret_flags (setting, vpn_secret_name, &secret_flags, NULL);
+
+		if (callback (secret_flags, callback_data))
+			g_variant_builder_add (&vpn_secrets_builder, "{ss}", vpn_secret_name, secret);
+	}
+
+	g_variant_builder_add (setting_builder, "{sv}",
+	                       secret_name, g_variant_builder_end (&vpn_secrets_builder));
+}
+
 static gboolean
 get_secret_flags (NMSetting *setting,
                   const char *secret_name,
@@ -976,6 +1027,7 @@ nm_setting_vpn_class_init (NMSettingVpnClass *klass)
 
 	setting_class->verify            = verify;
 	setting_class->update_one_secret = update_one_secret;
+	setting_class->for_each_secret   = for_each_secret;
 	setting_class->get_secret_flags  = get_secret_flags;
 	setting_class->set_secret_flags  = set_secret_flags;
 	setting_class->need_secrets      = need_secrets;

--- a/libnm-core/nm-setting-vpn.c
+++ b/libnm-core/nm-setting-vpn.c
@@ -449,19 +449,16 @@ nm_setting_vpn_foreach_secret (NMSettingVpn *setting,
 	foreach_item_helper (setting, TRUE, func, user_data);
 }
 
-gboolean
-_nm_setting_vpn_aggregate (NMSettingVpn *setting,
-                           NMConnectionAggregateType type,
-                           gpointer arg)
+static gboolean
+aggregate (NMSetting *setting,
+           int type_i,
+           gpointer arg)
 {
-	NMSettingVpnPrivate *priv;
+	NMSettingVpnPrivate *priv = NM_SETTING_VPN_GET_PRIVATE (setting);
+	NMConnectionAggregateType type = type_i;
 	NMSettingSecretFlags secret_flags;
 	const char *key_name;
 	GHashTableIter iter;
-
-	g_return_val_if_fail (NM_IS_SETTING_VPN (setting), FALSE);
-
-	priv = NM_SETTING_VPN_GET_PRIVATE (setting);
 
 	switch (type) {
 
@@ -984,6 +981,7 @@ nm_setting_vpn_class_init (NMSettingVpnClass *klass)
 	setting_class->need_secrets      = need_secrets;
 	setting_class->compare_property  = compare_property;
 	setting_class->clear_secrets     = clear_secrets;
+	setting_class->aggregate         = aggregate;
 
 	/**
 	 * NMSettingVpn:service-type:

--- a/libnm-core/nm-setting.c
+++ b/libnm-core/nm-setting.c
@@ -32,15 +32,6 @@
 #include "nm-utils-private.h"
 #include "nm-property-compare.h"
 
-#include "nm-setting-connection.h"
-#include "nm-setting-bond.h"
-#include "nm-setting-bridge.h"
-#include "nm-setting-bridge-port.h"
-#include "nm-setting-pppoe.h"
-#include "nm-setting-team.h"
-#include "nm-setting-team-port.h"
-#include "nm-setting-vpn.h"
-
 /**
  * SECTION:nm-setting
  * @short_description: Describes related configuration information

--- a/libnm-core/nm-setting.c
+++ b/libnm-core/nm-setting.c
@@ -1111,6 +1111,8 @@ duplicate_copy_properties (const NMSettInfoSetting *sett_info,
 	if (sett_info->detail.gendata_info) {
 		GenData *gendata = _gendata_hash (src, FALSE);
 
+		nm_assert (!_gendata_hash (dst, FALSE));
+
 		if (   gendata
 		    && g_hash_table_size (gendata->hash) > 0) {
 			GHashTableIter iter;
@@ -2322,7 +2324,7 @@ _nm_setting_gendata_notify (NMSetting *setting,
 
 	gendata = _gendata_hash (setting, FALSE);
 	if (!gendata)
-		return;
+		goto out;
 
 	nm_clear_g_free (&gendata->values);
 
@@ -2332,7 +2334,7 @@ _nm_setting_gendata_notify (NMSetting *setting,
 		nm_clear_g_free (&gendata->names);
 	}
 
-	/* Note, that currently there is now way to notify the subclass when gendata changed.
+	/* Note, currently there is no way to notify the subclass when gendata changed.
 	 * gendata is only changed in two situations:
 	 *   1) from within NMSetting itself, for example when creating a NMSetting instance
 	 *      from keyfile or a D-Bus GVariant.
@@ -2345,6 +2347,9 @@ _nm_setting_gendata_notify (NMSetting *setting,
 	 *
 	 * If we ever need it, then we would need to call a virtual function to notify the subclass
 	 * that gendata changed. */
+
+out:
+	_nm_setting_emit_property_changed (setting);
 }
 
 GVariant *
@@ -2467,7 +2472,7 @@ nm_setting_gendata_get_all_values (NMSetting *setting)
 
 void
 _nm_setting_gendata_to_gvalue (NMSetting *setting,
-                                GValue *value)
+                               GValue *value)
 {
 	GenData *gendata;
 	GHashTable *new;

--- a/libnm-core/nm-setting.h
+++ b/libnm-core/nm-setting.h
@@ -187,6 +187,10 @@ typedef void (*NMSettingValueIterFn) (NMSetting *setting,
                                       GParamFlags flags,
                                       gpointer user_data);
 
+/*< private >*/
+typedef gboolean (*_NMConnectionForEachSecretFunc) (NMSettingSecretFlags flags,
+                                                    gpointer user_data);
+
 typedef struct {
 	GObjectClass parent;
 
@@ -253,10 +257,19 @@ typedef struct {
 	                       gpointer arg);
 
 	/*< private >*/
-	const struct _NMMetaSettingInfo *setting_info;
+	void (*for_each_secret) (NMSetting *setting,
+	                         const char *secret_name,
+	                         GVariant *val,
+	                         gboolean remove_non_secrets,
+	                         _NMConnectionForEachSecretFunc callback,
+	                         gpointer callback_data,
+	                         GVariantBuilder *setting_builder);
 
 	/*< private >*/
-	gpointer padding[3];
+	gpointer padding[2];
+
+	/*< private >*/
+	const struct _NMMetaSettingInfo *setting_info;
 } NMSettingClass;
 
 GType nm_setting_get_type (void);

--- a/libnm-core/nm-setting.h
+++ b/libnm-core/nm-setting.h
@@ -248,10 +248,15 @@ typedef struct {
 	                          gpointer user_data);
 
 	/*< private >*/
+	gboolean (*aggregate) (NMSetting *setting,
+	                       int type_i,
+	                       gpointer arg);
+
+	/*< private >*/
 	const struct _NMMetaSettingInfo *setting_info;
 
 	/*< private >*/
-	gpointer padding[4];
+	gpointer padding[3];
 } NMSettingClass;
 
 GType nm_setting_get_type (void);

--- a/libnm-core/nm-setting.h
+++ b/libnm-core/nm-setting.h
@@ -170,6 +170,22 @@ typedef gboolean (*NMSettingClearSecretsWithFlagsFn) (NMSetting *setting,
 
 struct _NMMetaSettingInfo;
 struct _NMSettInfoSetting;
+struct _NMSettInfoProperty;
+
+/**
+ * NMSettingValueIterFn:
+ * @setting: The setting for which properties are being iterated, given to
+ * nm_setting_enumerate_values()
+ * @key: The value/property name
+ * @value: The property's value
+ * @flags: The property's flags, like %NM_SETTING_PARAM_SECRET
+ * @user_data: User data passed to nm_setting_enumerate_values()
+ */
+typedef void (*NMSettingValueIterFn) (NMSetting *setting,
+                                      const char *key,
+                                      const GValue *value,
+                                      GParamFlags flags,
+                                      gpointer user_data);
 
 typedef struct {
 	GObjectClass parent;
@@ -226,26 +242,17 @@ typedef struct {
 	                                   NMSetting *dst);
 
 	/*< private >*/
+	void (*enumerate_values) (const struct _NMSettInfoProperty *property_info,
+	                          NMSetting *setting,
+	                          NMSettingValueIterFn func,
+	                          gpointer user_data);
+
+	/*< private >*/
 	const struct _NMMetaSettingInfo *setting_info;
 
 	/*< private >*/
-	gpointer padding[5];
+	gpointer padding[4];
 } NMSettingClass;
-
-/**
- * NMSettingValueIterFn:
- * @setting: The setting for which properties are being iterated, given to
- * nm_setting_enumerate_values()
- * @key: The value/property name
- * @value: The property's value
- * @flags: The property's flags, like %NM_SETTING_PARAM_SECRET
- * @user_data: User data passed to nm_setting_enumerate_values()
- */
-typedef void (*NMSettingValueIterFn) (NMSetting *setting,
-                                      const char *key,
-                                      const GValue *value,
-                                      GParamFlags flags,
-                                      gpointer user_data);
 
 GType nm_setting_get_type (void);
 

--- a/src/settings/nm-settings-connection.c
+++ b/src/settings/nm-settings-connection.c
@@ -279,11 +279,12 @@ for_each_secret (NMConnection *self,
 				g_variant_builder_init (&vpn_secrets_builder, G_VARIANT_TYPE ("a{ss}"));
 				g_variant_iter_init (&vpn_secrets_iter, val);
 				while (g_variant_iter_next (&vpn_secrets_iter, "{&s&s}", &vpn_secret_name, &secret)) {
-					if (!nm_setting_get_secret_flags (setting, vpn_secret_name, &secret_flags, NULL)) {
-						if (!remove_non_secrets)
-							g_variant_builder_add (&vpn_secrets_builder, "{ss}", vpn_secret_name, secret);
-						continue;
-					}
+
+					/* we ignore the return value of get_secret_flags. The function may determine
+					 * that this is not a secret, based on having not secret-flags and no secrets.
+					 * But we have the secret at hand. We know it would be a valid secret, if we
+					 * only would add it to the VPN settings. */
+					nm_setting_get_secret_flags (setting, vpn_secret_name, &secret_flags, NULL);
 
 					if (callback (secret_flags, callback_data))
 						g_variant_builder_add (&vpn_secrets_builder, "{ss}", vpn_secret_name, secret);

--- a/src/settings/nm-settings-connection.c
+++ b/src/settings/nm-settings-connection.c
@@ -268,6 +268,13 @@ for_each_secret (NMConnection *self,
 				GVariantIter vpn_secrets_iter;
 				const char *vpn_secret_name, *secret;
 
+				if (!g_variant_is_of_type (val, G_VARIANT_TYPE ("a{ss}"))) {
+					/* invalid type. Silently ignore the secrets as we cannot find out the
+					 * secret-flags. */
+					g_variant_unref (val);
+					continue;
+				}
+
 				/* Iterate through each secret from the VPN dict in the overall secrets dict */
 				g_variant_builder_init (&vpn_secrets_builder, G_VARIANT_TYPE ("a{ss}"));
 				g_variant_iter_init (&vpn_secrets_iter, val);

--- a/src/settings/nm-settings-connection.c
+++ b/src/settings/nm-settings-connection.c
@@ -288,6 +288,7 @@ for_each_secret (NMConnection *self,
 				if (!nm_setting_get_secret_flags (setting, secret_name, &secret_flags, NULL)) {
 					if (!remove_non_secrets)
 						g_variant_builder_add (&setting_builder, "{sv}", secret_name, val);
+					g_variant_unref (val);
 					continue;
 				}
 				if (callback (secret_flags, callback_data))


### PR DESCRIPTION
Few patches to make libnm-core's settings extentable, so that sub-classes can override and better handle non-GObject-based properties.