### PR TITLE
build: replace intltool with gettext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,6 +192,7 @@ test-*.trs
 /libnm/tests/test-secret-agent
 
 /m4/codeset.m4
+/m4/fcntl-o.m4
 /m4/gettext.m4
 /m4/glibc2.m4
 /m4/glibc21.m4
@@ -219,6 +220,7 @@ test-*.trs
 /m4/progtest.m4
 /m4/size_max.m4
 /m4/stdint_h.m4
+/m4/threadlib.m4
 /m4/uintmax_t.m4
 /m4/visibility.m4
 /m4/wchar_t.m4
@@ -241,6 +243,7 @@ test-*.trs
 /po/en@quot.header
 /po/insert-header.sin
 /po/quot.sed
+/po/remove-potcdate.sed
 /po/remove-potcdate.sin
 
 /src/NetworkManager

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-dist: trusty
+dist: xenial
 sudo: required
 compiler:
   - gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ addons:
     - autoconf
     - libtool
     - pkg-config
-    - intltool
     - libdbus-glib-1-dev
     - libdbus-1-dev
     - libiw-dev

--- a/Makefile.am
+++ b/Makefile.am
@@ -183,8 +183,6 @@ endif
 
 dist: $(dist_configure_check) $(dist_dependencies)
 
-DISTCLEANFILES += intltool-extract intltool-merge intltool-update
-
 ###############################################################################
 
 if WITH_LEGACY_LIBRARIES
@@ -200,7 +198,8 @@ dist_polkit_policy_in_in_files = \
 
 polkit_policy_DATA = $(dist_polkit_policy_in_in_files:.policy.in.in=.policy)
 
-@INTLTOOL_POLICY_RULE@
+data/org.freedesktop.NetworkManager.policy: data/org.freedesktop.NetworkManager.policy.in
+	$(AM_V_GEN)$(MSGFMT) --xml --template $< -d $(top_srcdir)/po -o $@
 
 DISTCLEANFILES += $(polkit_policy_DATA)
 
@@ -5220,9 +5219,6 @@ TESTS += $(check_programs)
 EXTRA_DIST += \
 	CONTRIBUTING \
 	NetworkManager.pc.in \
-	intltool-extract.in \
-	intltool-merge.in \
-	intltool-update.in \
 	linker-script-binary.ver \
 	linker-script-devices.ver \
 	linker-script-settings.ver \

--- a/autogen.sh
+++ b/autogen.sh
@@ -23,8 +23,7 @@ PKG_NAME=NetworkManager
 cd $srcdir
 
 gtkdocize
-autopoint --force
-AUTOPOINT='intltoolize --automake --copy' autoreconf --force --install --verbose
+autoreconf --force --install --verbose
 
 cd $olddir
 if test -z "$NOCONFIGURE"; then

--- a/configure.ac
+++ b/configure.ac
@@ -106,10 +106,8 @@ AC_CHECK_DECLS([getrandom],
 dnl
 dnl translation support
 dnl
-IT_PROG_INTLTOOL([0.40.0])
-
 AM_GNU_GETTEXT([external])
-AM_GNU_GETTEXT_VERSION([0.17])
+AM_GNU_GETTEXT_VERSION([0.18])
 
 GETTEXT_PACKAGE=NetworkManager
 AC_SUBST(GETTEXT_PACKAGE)

--- a/contrib/fedora/REQUIRED_PACKAGES
+++ b/contrib/fedora/REQUIRED_PACKAGES
@@ -38,7 +38,6 @@ install \
     gnutls-devel \
     gobject-introspection-devel \
     gtk-doc \
-    intltool \
     iptables \
     jansson-devel \
     libcurl-devel \

--- a/contrib/fedora/rpm/NetworkManager.spec
+++ b/contrib/fedora/rpm/NetworkManager.spec
@@ -152,8 +152,7 @@ BuildRequires: meson
 BuildRequires: automake
 BuildRequires: autoconf
 %endif
-BuildRequires: intltool
-BuildRequires: gettext-devel
+BuildRequires: gettext-devel >= 0.18
 
 BuildRequires: dbus-devel >= %{dbus_version}
 BuildRequires: dbus-glib-devel >= %{dbus_glib_version}
@@ -581,7 +580,6 @@ by nm-connection-editor and nm-applet in a non-graphical environment.
 gtkdocize
 %endif
 autoreconf --install --force
-intltoolize --automake --copy --force
 %configure \
 	--disable-silent-rules \
 	--disable-static \

--- a/data/meson.build
+++ b/data/meson.build
@@ -72,7 +72,7 @@ if enable_polkit
     policy,
     input: policy_in,
     output: policy,
-    command: intltool_xml_cmd,
+    command: msgfmt_xml_cmd,
     install: true,
     install_dir: polkit_dir,
   )

--- a/data/org.freedesktop.NetworkManager.policy.in.in
+++ b/data/org.freedesktop.NetworkManager.policy.in.in
@@ -10,8 +10,8 @@
   <icon_name>nm-icon</icon_name>
 
   <action id="org.freedesktop.NetworkManager.enable-disable-network">
-    <_description>Enable or disable system networking</_description>
-    <_message>System policy prevents enabling or disabling system networking</_message>
+    <description>Enable or disable system networking</description>
+    <message>System policy prevents enabling or disabling system networking</message>
     <defaults>
       <allow_inactive>no</allow_inactive>
       <allow_active>yes</allow_active>
@@ -19,8 +19,8 @@
   </action>
 
   <action id="org.freedesktop.NetworkManager.reload">
-    <_description>Reload NetworkManager configuration</_description>
-    <_message>System policy prevents reloading NetworkManager</_message>
+    <description>Reload NetworkManager configuration</description>
+    <message>System policy prevents reloading NetworkManager</message>
     <defaults>
       <allow_any>auth_admin_keep</allow_any>
       <allow_inactive>auth_admin_keep</allow_inactive>
@@ -29,8 +29,8 @@
   </action>
 
   <action id="org.freedesktop.NetworkManager.sleep-wake">
-    <_description>Put NetworkManager to sleep or wake it up (should only be used by system power management)</_description>
-    <_message>System policy prevents putting NetworkManager to sleep or waking it up</_message>
+    <description>Put NetworkManager to sleep or wake it up (should only be used by system power management)</description>
+    <message>System policy prevents putting NetworkManager to sleep or waking it up</message>
     <defaults>
       <allow_inactive>no</allow_inactive>
       <allow_active>no</allow_active>
@@ -38,8 +38,8 @@
   </action>
 
   <action id="org.freedesktop.NetworkManager.enable-disable-wifi">
-    <_description>Enable or disable Wi-Fi devices</_description>
-    <_message>System policy prevents enabling or disabling Wi-Fi devices</_message>
+    <description>Enable or disable Wi-Fi devices</description>
+    <message>System policy prevents enabling or disabling Wi-Fi devices</message>
     <defaults>
       <allow_inactive>no</allow_inactive>
       <allow_active>yes</allow_active>
@@ -47,8 +47,8 @@
   </action>
 
   <action id="org.freedesktop.NetworkManager.enable-disable-wwan">
-    <_description>Enable or disable mobile broadband devices</_description>
-    <_message>System policy prevents enabling or disabling mobile broadband devices</_message>
+    <description>Enable or disable mobile broadband devices</description>
+    <message>System policy prevents enabling or disabling mobile broadband devices</message>
     <defaults>
       <allow_inactive>no</allow_inactive>
       <allow_active>yes</allow_active>
@@ -56,8 +56,8 @@
   </action>
 
   <action id="org.freedesktop.NetworkManager.enable-disable-wimax">
-    <_description>Enable or disable WiMAX mobile broadband devices</_description>
-    <_message>System policy prevents enabling or disabling WiMAX mobile broadband devices</_message>
+    <description>Enable or disable WiMAX mobile broadband devices</description>
+    <message>System policy prevents enabling or disabling WiMAX mobile broadband devices</message>
     <defaults>
       <allow_inactive>no</allow_inactive>
       <allow_active>yes</allow_active>
@@ -65,8 +65,8 @@
   </action>
 
   <action id="org.freedesktop.NetworkManager.network-control">
-    <_description>Allow control of network connections</_description>
-    <_message>System policy prevents control of network connections</_message>
+    <description>Allow control of network connections</description>
+    <message>System policy prevents control of network connections</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>yes</allow_inactive>
@@ -75,8 +75,8 @@
   </action>
 
   <action id="org.freedesktop.NetworkManager.wifi.scan">
-    <_description>Allow control of Wi-Fi scans</_description>
-    <_message>System policy prevents Wi-Fi scans</_message>
+    <description>Allow control of Wi-Fi scans</description>
+    <message>System policy prevents Wi-Fi scans</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>yes</allow_inactive>
@@ -85,8 +85,8 @@
   </action>
 
   <action id="org.freedesktop.NetworkManager.wifi.share.protected">
-    <_description>Connection sharing via a protected Wi-Fi network</_description>
-    <_message>System policy prevents sharing connections via a protected Wi-Fi network</_message>
+    <description>Connection sharing via a protected Wi-Fi network</description>
+    <message>System policy prevents sharing connections via a protected Wi-Fi network</message>
     <defaults>
       <allow_inactive>no</allow_inactive>
       <allow_active>yes</allow_active>
@@ -94,8 +94,8 @@
   </action>
 
   <action id="org.freedesktop.NetworkManager.wifi.share.open">
-    <_description>Connection sharing via an open Wi-Fi network</_description>
-    <_message>System policy prevents sharing connections via an open Wi-Fi network</_message>
+    <description>Connection sharing via an open Wi-Fi network</description>
+    <message>System policy prevents sharing connections via an open Wi-Fi network</message>
     <defaults>
       <allow_inactive>no</allow_inactive>
       <allow_active>yes</allow_active>
@@ -103,8 +103,8 @@
   </action>
 
   <action id="org.freedesktop.NetworkManager.settings.modify.own">
-    <_description>Modify personal network connections</_description>
-    <_message>System policy prevents modification of personal network settings</_message>
+    <description>Modify personal network connections</description>
+    <message>System policy prevents modification of personal network settings</message>
     <defaults>
       <allow_any>auth_self_keep</allow_any>
       <allow_inactive>yes</allow_inactive>
@@ -113,8 +113,8 @@
   </action>
 
   <action id="org.freedesktop.NetworkManager.settings.modify.system">
-    <_description>Modify network connections for all users</_description>
-    <_message>System policy prevents modification of network settings for all users</_message>
+    <description>Modify network connections for all users</description>
+    <message>System policy prevents modification of network settings for all users</message>
     <defaults>
       <allow_any>auth_admin_keep</allow_any>
       <allow_inactive>@NM_MODIFY_SYSTEM_POLICY@</allow_inactive>
@@ -123,8 +123,8 @@
   </action>
 
   <action id="org.freedesktop.NetworkManager.settings.modify.hostname">
-    <_description>Modify persistent system hostname</_description>
-    <_message>System policy prevents modification of the persistent system hostname</_message>
+    <description>Modify persistent system hostname</description>
+    <message>System policy prevents modification of the persistent system hostname</message>
     <defaults>
       <allow_any>auth_admin_keep</allow_any>
       <allow_inactive>auth_admin_keep</allow_inactive>
@@ -133,8 +133,8 @@
   </action>
 
   <action id="org.freedesktop.NetworkManager.settings.modify.global-dns">
-    <_description>Modify persistent global DNS configuration</_description>
-    <_message>System policy prevents modification of the persistent global DNS configuration</_message>
+    <description>Modify persistent global DNS configuration</description>
+    <message>System policy prevents modification of the persistent global DNS configuration</message>
     <defaults>
       <allow_any>auth_admin_keep</allow_any>
       <allow_inactive>auth_admin_keep</allow_inactive>
@@ -143,8 +143,8 @@
   </action>
 
   <action id="org.freedesktop.NetworkManager.checkpoint-rollback">
-    <_description>Perform a checkpoint or rollback of interfaces configuration</_description>
-    <_message>System policy prevents the creation of a checkpoint or its rollback</_message>
+    <description>Perform a checkpoint or rollback of interfaces configuration</description>
+    <message>System policy prevents the creation of a checkpoint or its rollback</message>
     <defaults>
       <allow_any>auth_admin_keep</allow_any>
       <allow_inactive>auth_admin_keep</allow_inactive>
@@ -153,8 +153,8 @@
   </action>
 
   <action id="org.freedesktop.NetworkManager.enable-disable-statistics">
-    <_description>Enable or disable device statistics</_description>
-    <_message>System policy prevents enabling or disabling device statistics</_message>
+    <description>Enable or disable device statistics</description>
+    <message>System policy prevents enabling or disabling device statistics</message>
     <defaults>
       <allow_inactive>no</allow_inactive>
       <allow_active>yes</allow_active>
@@ -162,8 +162,8 @@
   </action>
 
   <action id="org.freedesktop.NetworkManager.enable-disable-connectivity-check">
-    <_description>Enable or disable connectivity checking</_description>
-    <_message>System policy prevents enabling or disabling connectivity checking</_message>
+    <description>Enable or disable connectivity checking</description>
+    <message>System policy prevents enabling or disabling connectivity checking</message>
     <defaults>
       <allow_inactive>no</allow_inactive>
       <allow_active>yes</allow_active>

--- a/meson.build
+++ b/meson.build
@@ -820,10 +820,8 @@ pkg = import('pkgconfig')
 
 po_dir = join_paths(meson.source_root(), 'po')
 
-intltool_merge = find_program('intltool-merge')
-intltool_cache = join_paths(po_dir, '.intltool-merge-cache')
-intltool_desktop_cmd = [intltool_merge, '-d', '-u', '-c', intltool_cache, po_dir, '@INPUT@', '@OUTPUT@']
-intltool_xml_cmd = [intltool_merge, '-x', '-u', '-c', intltool_cache, po_dir, '@INPUT@', '@OUTPUT@']
+msgfmt = find_program('msgfmt')
+msgfmt_xml_cmd = [msgfmt, '--xml', '--template', '@INPUT@', '-d', po_dir, '-o', '@OUTPUT@']
 
 perl = find_program('perl')
 xsltproc = find_program('xsltproc')

--- a/po/Makevars
+++ b/po/Makevars
@@ -1,0 +1,9 @@
+DOMAIN = $(PACKAGE)
+
+subdir = po
+top_builddir = ..
+
+XGETTEXT_OPTIONS = --from-code=UTF-8 --keyword=_ --keyword=N_ --keyword=C_:1c,2 --keyword=NC_:1c,2 --keyword=g_dngettext:2,3 --add-comments
+COPYRIGHT_HOLDER = $(PACKAGE) authors
+MSGID_BUGS_ADDRESS = https://gitlab.freedesktop.org/NetworkManager/$(PACKAGE)/
+EXTRA_LOCALE_CATEGORIES =

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,4 +1,3 @@
-[encoding: UTF-8]
 # List of source files containing translatable strings.
 # Please keep this file sorted alphabetically.
 clients/cli/agent.c


### PR DESCRIPTION
Gettext, since version 0.18, provides infrastructure equivalent to
intltool (generating po/Makefile and translating the .xml policy).

Also, it seems to work better in that it actually honors MSGFMT_OPTS
that are determined by the configure script. That one typically ends up
set to "-c", meaning "check". Without it the bugs in the .po files are
easy to overlook.