### PR TITLE
utils: obey modprobe blacklist

### DIFF
--- a/src/nm-core-utils.c
+++ b/src/nm-core-utils.c
@@ -443,6 +443,7 @@ nm_utils_modprobe (GError **error, gboolean suppress_error_logging, const char *
 	/* construct the argument list */
 	argv = g_ptr_array_sized_new (4);
 	g_ptr_array_add (argv, "/sbin/modprobe");
+	g_ptr_array_add (argv, "--use-blacklist");
 	g_ptr_array_add (argv, (char *) arg1);
 
 	va_start (ap, arg1);


### PR DESCRIPTION
If the user blacklisted a module we should not override their choice.