### PR TITLE
wwan/device-modem: don't enter available state until registered

### DIFF
--- a/src/devices/wwan/nm-device-modem.c
+++ b/src/devices/wwan/nm-device-modem.c
@@ -473,11 +473,6 @@ check_connection_available (NMDevice *device,
 	}
 
 	state = nm_modem_get_state (priv->modem);
-	if (state <= NM_MODEM_STATE_INITIALIZING) {
-		nm_utils_error_set_literal (error, NM_UTILS_ERROR_CONNECTION_AVAILABLE_TEMPORARY,
-		                            "modem not initialized");
-		return FALSE;
-	}
 
 	if (state == NM_MODEM_STATE_LOCKED) {
 		if (!nm_connection_get_setting_gsm (connection)) {
@@ -485,6 +480,12 @@ check_connection_available (NMDevice *device,
 			                            "modem is locked without pin available");
 			return FALSE;
 		}
+	}
+
+	if (state < NM_MODEM_STATE_REGISTERED) {
+		nm_utils_error_set_literal (error, NM_UTILS_ERROR_CONNECTION_AVAILABLE_TEMPORARY,
+		                            "modem not registered");
+		return FALSE;
 	}
 
 	return TRUE;
@@ -658,7 +659,7 @@ is_available (NMDevice *device, NMDeviceCheckDevAvailableFlags flags)
 
 	g_assert (priv->modem);
 	modem_state = nm_modem_get_state (priv->modem);
-	if (modem_state <= NM_MODEM_STATE_INITIALIZING)
+	if (modem_state < NM_MODEM_STATE_REGISTERED)
 		return FALSE;
 
 	return TRUE;


### PR DESCRIPTION
Based on Ubuntu's "Modify NMDeviceModem's available logic" patch by
Tony Espy <espy@canonical.com>. The original commit message:

This patch modifies NMDeviceModem's available logic such that the device
is only considered available if the modem_state is
>= NM_MODEM_STATE_REGISTERED.  NMDevice defines 'available' as meaning the
device is in such a state that it can be activated.  This change prevents
NM from trying to activate a modem which is not yet ready to be activated.

Bug-Ubuntu: https://bugs.launchpad.net/bugs/1445080