### PR TITLE
wwan/ofono: pass the right argument to manager proxy callback

### DIFF
--- a/src/devices/wwan/nm-modem-ofono.c
+++ b/src/devices/wwan/nm-modem-ofono.c
@@ -651,7 +651,7 @@ handle_connman_iface (NMModemOfono *self, gboolean found)
 		                          OFONO_DBUS_INTERFACE_CONNECTION_MANAGER,
 		                          priv->connman_proxy_cancellable,
 		                          _connman_proxy_new_cb,
-		                          NULL);
+		                          self);
 	}
 }
 


### PR DESCRIPTION
Otherwise it will be dereferencing NULL when invoked.

Fixes: 58712c95464a ('ofono: take D-Bus proxy for ConnectionManager asynchronously')