### PR TITLE
ovs-port: dissociate the link from the interface device on delete

### DIFF
--- a/src/devices/nm-device.c
+++ b/src/devices/nm-device.c
@@ -14219,6 +14219,7 @@ static void
 _cleanup_generic_post (NMDevice *self, CleanupType cleanup_type)
 {
 	NMDevicePrivate *priv = NM_DEVICE_GET_PRIVATE (self);
+	int ifindex;
 
 	priv->v4_commit_first_time = TRUE;
 	priv->v6_commit_first_time = TRUE;
@@ -14283,7 +14284,9 @@ _cleanup_generic_post (NMDevice *self, CleanupType cleanup_type)
 		/* Check if the device was deactivated, and if so, delete_link.
 		 * Don't call delete_link synchronously because we are currently
 		 * handling a state change -- which is not reentrant. */
-		delete_on_deactivate_check_and_schedule (self, nm_device_get_ip_ifindex (self));
+		ifindex = nm_device_get_ip_ifindex (self);
+		if (ifindex > 0)
+			delete_on_deactivate_check_and_schedule (self, ifindex);
 	}
 
 	/* ip_iface should be cleared after flushing all routes and addresses, since

--- a/src/devices/ovs/nm-device-ovs-port.c
+++ b/src/devices/ovs/nm-device-ovs-port.c
@@ -139,6 +139,13 @@ del_iface_cb (GError *error, gpointer user_data)
 static void
 release_slave (NMDevice *device, NMDevice *slave, gboolean configure)
 {
+	/* Dissociate the platform link from the device -- openvswitch is going
+	 * to remove the link, not us. We shouldn't care about whatever happen to it.
+	 * In particular, we don't want to alter the NMDevice state if we see the
+	 * link go away, because the device may already have another activation
+	 * enqueued. */
+	nm_device_update_from_platform_link (slave, NULL);
+
 	nm_ovsdb_del_interface (nm_ovsdb_get (), nm_device_get_iface (slave),
 	                        del_iface_cb, g_object_ref (slave));
 }


### PR DESCRIPTION
Open vSwitch is the special kid on the block -- it likes to be in charge of
the link lifetime and so we shouldn't be. This means that we shouldn't be
attempting to remove the link: we'd just (gracefully) fail anyways.

More importantly, this also means that we shouldn't care if we see the link
go away. We may already be activating another connection and shouldn't alter
the device state when OpenVSwitch decides to drop the old link.

https://bugzilla.redhat.com/show_bug.cgi?id=1543557