### PR TITLE
[th/libnm-team-fixes]

### DIFF
--- a/libnm-core/nm-core-internal.h
+++ b/libnm-core/nm-core-internal.h
@@ -537,6 +537,8 @@ gboolean _nm_utils_inet6_is_token (const struct in6_addr *in6addr);
 
 /*****************************************************************************/
 
+gboolean _nm_team_link_watchers_equal (GPtrArray *a, GPtrArray *b, gboolean ignore_order);
+
 gboolean _nm_utils_team_config_equal (const char *conf1, const char *conf2, gboolean port);
 GValue *_nm_utils_team_config_get (const char *conf,
                                    const char *key,

--- a/libnm-core/nm-core-internal.h
+++ b/libnm-core/nm-core-internal.h
@@ -284,7 +284,6 @@ char **     _nm_utils_slist_to_strv (GSList *slist, gboolean deep_copy);
 
 GPtrArray * _nm_utils_strv_to_ptrarray (char **strv);
 char **     _nm_utils_ptrarray_to_strv (GPtrArray *ptrarray);
-gboolean    _nm_utils_strv_equal (char **strv1, char **strv2);
 
 gboolean _nm_utils_check_file (const char *filename,
                                gint64 check_owner,

--- a/libnm-core/nm-setting-team-port.c
+++ b/libnm-core/nm-setting-team-port.c
@@ -396,31 +396,18 @@ compare_property (const NMSettInfoSetting *sett_info,
 {
 	NMSettingTeamPortPrivate *a_priv;
 	NMSettingTeamPortPrivate *b_priv;
-	guint i, j;
 
 	if (nm_streq (sett_info->property_infos[property_idx].name, NM_SETTING_TEAM_PORT_LINK_WATCHERS)) {
 
 		if (NM_FLAGS_HAS (flags, NM_SETTING_COMPARE_FLAG_INFERRABLE))
 			return NM_TERNARY_DEFAULT;
-
-		if (other) {
-			a_priv = NM_SETTING_TEAM_PORT_GET_PRIVATE (setting);
-			b_priv = NM_SETTING_TEAM_PORT_GET_PRIVATE (other);
-
-			if (a_priv->link_watchers->len != b_priv->link_watchers->len)
-				return FALSE;
-			for (i = 0; i < a_priv->link_watchers->len; i++) {
-				for (j = 0; j < b_priv->link_watchers->len; j++) {
-					if (nm_team_link_watcher_equal (a_priv->link_watchers->pdata[i],
-					                                b_priv->link_watchers->pdata[j])) {
-						break;
-					}
-				}
-				if (j == b_priv->link_watchers->len)
-					return FALSE;
-			}
-		}
-		return TRUE;
+		if (!other)
+			return TRUE;
+		a_priv = NM_SETTING_TEAM_PORT_GET_PRIVATE (setting);
+		b_priv = NM_SETTING_TEAM_PORT_GET_PRIVATE (other);
+		return _nm_team_link_watchers_equal (a_priv->link_watchers,
+		                                     b_priv->link_watchers,
+		                                     TRUE);
 	}
 
 	if (nm_streq (sett_info->property_infos[property_idx].name, NM_SETTING_TEAM_PORT_CONFIG)) {

--- a/libnm-core/nm-setting-team.c
+++ b/libnm-core/nm-setting-team.c
@@ -1240,9 +1240,9 @@ verify (NMSetting *setting, NMConnection *connection, GError **error)
 
 		if (!name) {
 			g_set_error (error, NM_CONNECTION_ERROR, NM_CONNECTION_ERROR_MISSING_SETTING,
-				     _("missing link watcher name"));
+			             _("missing link watcher name"));
 			g_prefix_error (error, "%s.%s: ", nm_setting_get_name (setting),
-					NM_SETTING_TEAM_LINK_WATCHERS);
+			                NM_SETTING_TEAM_LINK_WATCHERS);
 			return FALSE;
 		}
 		if (!NM_IN_STRSET (name,
@@ -1250,9 +1250,9 @@ verify (NMSetting *setting, NMConnection *connection, GError **error)
 		                   NM_TEAM_LINK_WATCHER_ARP_PING,
 		                   NM_TEAM_LINK_WATCHER_NSNA_PING)) {
 			g_set_error (error, NM_CONNECTION_ERROR, NM_CONNECTION_ERROR_INVALID_SETTING,
-				     _("unknown link watcher \"%s\""), name);
+			             _("unknown link watcher \"%s\""), name);
 			g_prefix_error (error, "%s.%s: ", nm_setting_get_name (setting),
-					NM_SETTING_TEAM_LINK_WATCHERS);
+			                NM_SETTING_TEAM_LINK_WATCHERS);
 			return FALSE;
 		}
 
@@ -1261,17 +1261,17 @@ verify (NMSetting *setting, NMConnection *connection, GError **error)
 		                  NM_TEAM_LINK_WATCHER_NSNA_PING)
 		    && !nm_team_link_watcher_get_target_host (link_watcher)) {
 			g_set_error (error, NM_CONNECTION_ERROR, NM_CONNECTION_ERROR_MISSING_SETTING,
-				     _("missing target host"));
+			             _("missing target host"));
 			g_prefix_error (error, "%s.%s: ", nm_setting_get_name (setting),
-					NM_SETTING_TEAM_LINK_WATCHERS);
+			                NM_SETTING_TEAM_LINK_WATCHERS);
 			return FALSE;
 		}
 		if (nm_streq (name, NM_TEAM_LINK_WATCHER_ARP_PING)
 		    && !nm_team_link_watcher_get_source_host (link_watcher)) {
 			g_set_error (error, NM_CONNECTION_ERROR, NM_CONNECTION_ERROR_MISSING_SETTING,
-				     _("missing source address"));
+			             _("missing source address"));
 			g_prefix_error (error, "%s.%s: ", nm_setting_get_name (setting),
-					NM_SETTING_TEAM_LINK_WATCHERS);
+			                NM_SETTING_TEAM_LINK_WATCHERS);
 			return FALSE;
 		}
 	}
@@ -1373,10 +1373,8 @@ _align_team_properties (NMSettingTeam *setting)
 	priv->runner_tx_balancer =       JSON_TO_VAL (string, PROP_RUNNER_TX_BALANCER);
 	priv->runner_agg_select_policy = JSON_TO_VAL (string, PROP_RUNNER_AGG_SELECT_POLICY);
 
-	if (priv->runner_tx_hash) {
-		g_ptr_array_unref (priv->runner_tx_hash);
-		priv->runner_tx_hash = NULL;
-	}
+	nm_clear_pointer (&priv->runner_tx_hash, g_ptr_array_unref);
+
 	strv = JSON_TO_VAL (strv, PROP_RUNNER_TX_HASH);
 	if (strv) {
 		for (i = 0; strv[i]; i++)
@@ -1420,8 +1418,10 @@ get_property (GObject *object, guint prop_id,
 		g_value_set_string (value, nm_setting_team_get_runner_hwaddr_policy (setting));
 		break;
 	case PROP_RUNNER_TX_HASH:
-		g_value_take_boxed (value, priv->runner_tx_hash ?
-		                    _nm_utils_ptrarray_to_strv (priv->runner_tx_hash): NULL);
+		g_value_take_boxed (value,
+		                      priv->runner_tx_hash
+		                    ? _nm_utils_ptrarray_to_strv (priv->runner_tx_hash)
+		                    : NULL);
 		break;
 	case PROP_RUNNER_TX_BALANCER:
 		g_value_set_string (value, nm_setting_team_get_runner_tx_balancer (setting));
@@ -1773,9 +1773,9 @@ nm_setting_team_class_init (NMSettingTeamClass *klass)
 	obj_properties[PROP_RUNNER_TX_HASH] =
 	    g_param_spec_boxed (NM_SETTING_TEAM_RUNNER_TX_HASH, "", "",
 	                        G_TYPE_STRV,
-	                             G_PARAM_READWRITE |
+	                        G_PARAM_READWRITE |
 	                        NM_SETTING_PARAM_INFERRABLE |
-	                             G_PARAM_STATIC_STRINGS);
+	                        G_PARAM_STATIC_STRINGS);
 
 	/**
 	 * NMSettingTeam:runner-tx-balancer:

--- a/libnm-core/nm-setting-team.c
+++ b/libnm-core/nm-setting-team.c
@@ -1397,7 +1397,7 @@ _align_team_properties (NMSettingTeam *setting)
 	                          NM_CAST_STRV_CC (strv),
 	                          -1) != 0) {
 		nm_clear_pointer (&priv->runner_tx_hash, g_ptr_array_unref);
-		if (strv && strv[0]) {
+		if (strv) {
 			priv->runner_tx_hash = g_ptr_array_new_full (NM_PTRARRAY_LEN (strv), g_free);
 			for (i = 0; strv[i]; i++)
 				g_ptr_array_add (priv->runner_tx_hash, strv[i]);

--- a/libnm-core/nm-setting-team.c
+++ b/libnm-core/nm-setting-team.c
@@ -929,13 +929,14 @@ nm_setting_team_remove_runner_tx_hash_by_value (NMSettingTeam *setting,
 
 	g_return_val_if_fail (NM_IS_SETTING_TEAM (setting), FALSE);
 	g_return_val_if_fail (txhash != NULL, FALSE);
-	g_return_val_if_fail (txhash[0] != '\0', FALSE);
 
-	for (i = 0; i < priv->runner_tx_hash->len; i++) {
-		if (nm_streq (txhash, priv->runner_tx_hash->pdata[i])) {
-			g_ptr_array_remove_index (priv->runner_tx_hash, i);
-			_notify (setting, PROP_RUNNER_TX_HASH);
-			return TRUE;
+	if (priv->runner_tx_hash) {
+		for (i = 0; i < priv->runner_tx_hash->len; i++) {
+			if (nm_streq (txhash, priv->runner_tx_hash->pdata[i])) {
+				g_ptr_array_remove_index (priv->runner_tx_hash, i);
+				_notify (setting, PROP_RUNNER_TX_HASH);
+				return TRUE;
+			}
 		}
 	}
 	return FALSE;

--- a/libnm-core/nm-utils-private.h
+++ b/libnm-core/nm-utils-private.h
@@ -179,7 +179,8 @@ _nm_utils_json_extract_strv (char *conf,
 	if (   !t_value
 	    || !G_TYPE_CHECK_VALUE_TYPE (t_value, G_TYPE_STRV))
 		return NULL;
-	return g_strdupv (g_value_get_boxed (t_value));
+	return    g_strdupv (g_value_get_boxed (t_value))
+	       ?: g_new0 (char *, 1);
 }
 
 static inline GPtrArray *

--- a/libnm-core/nm-utils-private.h
+++ b/libnm-core/nm-utils-private.h
@@ -134,7 +134,8 @@ _nm_utils_json_extract_int (char *conf,
 	nm_auto_unset_and_free_gvalue GValue *t_value = NULL;
 
 	t_value = _nm_utils_team_config_get (conf, key.key1, key.key2, key.key3, is_port);
-	if (!t_value)
+	if (   !t_value
+	    || !G_VALUE_HOLDS_INT (t_value))
 		return key.default_int;
 	return g_value_get_int (t_value);
 }
@@ -147,7 +148,8 @@ _nm_utils_json_extract_boolean (char *conf,
 	nm_auto_unset_and_free_gvalue GValue *t_value = NULL;
 
 	t_value = _nm_utils_team_config_get (conf, key.key1, key.key2, key.key3, is_port);
-	if (!t_value)
+	if (   !t_value
+	    || !G_VALUE_HOLDS_BOOLEAN (t_value))
 		return key.default_bool;
 	return g_value_get_boolean (t_value);
 }
@@ -160,7 +162,8 @@ _nm_utils_json_extract_string (char *conf,
 	nm_auto_unset_and_free_gvalue GValue *t_value = NULL;
 
 	t_value = _nm_utils_team_config_get (conf, key.key1, key.key2, key.key3, is_port);
-	if (!t_value)
+	if (   !t_value
+	    || !G_VALUE_HOLDS_STRING (t_value))
 		return g_strdup (key.default_str);
 	return g_value_dup_string (t_value);
 }
@@ -173,7 +176,8 @@ _nm_utils_json_extract_strv (char *conf,
 	nm_auto_unset_and_free_gvalue GValue *t_value = NULL;
 
 	t_value = _nm_utils_team_config_get (conf, key.key1, key.key2, key.key3, is_port);
-	if (!t_value)
+	if (   !t_value
+	    || !G_TYPE_CHECK_VALUE_TYPE (t_value, G_TYPE_STRV))
 		return NULL;
 	return g_strdupv (g_value_get_boxed (t_value));
 }
@@ -190,7 +194,8 @@ _nm_utils_json_extract_ptr_array (char *conf,
 	ret = g_ptr_array_new_with_free_func ((GDestroyNotify) nm_team_link_watcher_unref);
 
 	t_value = _nm_utils_team_config_get (conf, key.key1, key.key2, key.key3, is_port);
-	if (!t_value)
+	if (   !t_value
+	    || !G_TYPE_CHECK_VALUE_TYPE (t_value, G_TYPE_PTR_ARRAY))
 		return ret;
 
 	data = g_value_get_boxed (t_value);

--- a/libnm-core/nm-utils-private.h
+++ b/libnm-core/nm-utils-private.h
@@ -105,6 +105,16 @@ gboolean    _nm_sriov_vf_parse_vlans (NMSriovVF *vf, const char *str, GError **e
 
 /* JSON to GValue conversion macros */
 
+static inline void
+_nm_auto_unset_and_free_gvalue (GValue **ptr)
+{
+	if (*ptr) {
+		g_value_unset (*ptr);
+		g_free (*ptr);
+	}
+}
+#define nm_auto_unset_and_free_gvalue nm_auto(_nm_auto_unset_and_free_gvalue)
+
 typedef struct {
 	const char *key1;
 	const char *key2;
@@ -121,16 +131,12 @@ _nm_utils_json_extract_int (char *conf,
                             _NMUtilsTeamPropertyKeys key,
                             gboolean is_port)
 {
-	gs_free GValue *t_value = NULL;
-	int ret;
+	nm_auto_unset_and_free_gvalue GValue *t_value = NULL;
 
 	t_value = _nm_utils_team_config_get (conf, key.key1, key.key2, key.key3, is_port);
 	if (!t_value)
 		return key.default_int;
-
-	ret = g_value_get_int (t_value);
-	g_value_unset (t_value);
-	return ret;
+	return g_value_get_int (t_value);
 }
 
 static inline gboolean
@@ -138,16 +144,12 @@ _nm_utils_json_extract_boolean (char *conf,
                                 _NMUtilsTeamPropertyKeys key,
                                 gboolean is_port)
 {
-	gs_free GValue *t_value = NULL;
-	gboolean ret;
+	nm_auto_unset_and_free_gvalue GValue *t_value = NULL;
 
 	t_value = _nm_utils_team_config_get (conf, key.key1, key.key2, key.key3, is_port);
 	if (!t_value)
 		return key.default_bool;
-
-	ret = g_value_get_boolean (t_value);
-	g_value_unset (t_value);
-	return ret;
+	return g_value_get_boolean (t_value);
 }
 
 static inline char *
@@ -155,16 +157,12 @@ _nm_utils_json_extract_string (char *conf,
                                _NMUtilsTeamPropertyKeys key,
                                gboolean is_port)
 {
-	gs_free GValue *t_value = NULL;
-	char *ret;
+	nm_auto_unset_and_free_gvalue GValue *t_value = NULL;
 
 	t_value = _nm_utils_team_config_get (conf, key.key1, key.key2, key.key3, is_port);
 	if (!t_value)
 		return g_strdup (key.default_str);
-
-	ret = g_value_dup_string (t_value);
-	g_value_unset (t_value);
-	return ret;
+	return g_value_dup_string (t_value);
 }
 
 static inline char **
@@ -172,28 +170,25 @@ _nm_utils_json_extract_strv (char *conf,
                              _NMUtilsTeamPropertyKeys key,
                              gboolean is_port)
 {
-	gs_free GValue *t_value = NULL;
-	char **ret;
+	nm_auto_unset_and_free_gvalue GValue *t_value = NULL;
 
 	t_value = _nm_utils_team_config_get (conf, key.key1, key.key2, key.key3, is_port);
 	if (!t_value)
 		return NULL;
-
-	ret = g_strdupv (g_value_get_boxed (t_value));
-	g_value_unset (t_value);
-	return ret;
+	return g_strdupv (g_value_get_boxed (t_value));
 }
 
 static inline GPtrArray *
 _nm_utils_json_extract_ptr_array (char *conf,
-                             _NMUtilsTeamPropertyKeys key,
-                             gboolean is_port)
+                                  _NMUtilsTeamPropertyKeys key,
+                                  gboolean is_port)
 {
-	gs_free GValue *t_value = NULL;
+	nm_auto_unset_and_free_gvalue GValue *t_value = NULL;
 	GPtrArray *data, *ret;
 	guint i;
 
 	ret = g_ptr_array_new_with_free_func ((GDestroyNotify) nm_team_link_watcher_unref);
+
 	t_value = _nm_utils_team_config_get (conf, key.key1, key.key2, key.key3, is_port);
 	if (!t_value)
 		return ret;
@@ -201,10 +196,8 @@ _nm_utils_json_extract_ptr_array (char *conf,
 	data = g_value_get_boxed (t_value);
 	if (!data)
 		return ret;
-
 	for (i = 0; i < data->len; i++)
 		g_ptr_array_add (ret, nm_team_link_watcher_dup (data->pdata[i]));
-	g_value_unset (t_value);
 	return ret;
 }
 

--- a/libnm-core/nm-utils.c
+++ b/libnm-core/nm-utils.c
@@ -5898,11 +5898,9 @@ _nm_utils_team_config_get (const char *conf,
 				if (json_is_string (str_element))
 					g_ptr_array_add (data, g_strdup (json_string_value (str_element)));
 			}
-			if (data->len) {
-				g_value_init (value, G_TYPE_STRV);
-				g_value_take_boxed (value, _nm_utils_ptrarray_to_strv (data));
-			}
-			g_ptr_array_free (data, TRUE);
+			g_ptr_array_add (data, NULL);
+			g_value_init (value, G_TYPE_STRV);
+			g_value_take_boxed (value, g_ptr_array_free (data, FALSE));
 		} else {
 			g_assert_not_reached ();
 			g_free (value);

--- a/libnm-core/nm-utils.c
+++ b/libnm-core/nm-utils.c
@@ -6032,6 +6032,8 @@ done:
 	conf_new = json_dumps (json, JSON_PRESERVE_ORDER);
 	if (nm_streq0 (conf_new, "{}"))
 		nm_clear_g_free (&conf_new);
+	if (nm_streq0 (conf_new, *conf))
+		return FALSE;
 	g_free (*conf);
 	*conf = g_steal_pointer (&conf_new);
 	return TRUE;

--- a/libnm-core/nm-utils.c
+++ b/libnm-core/nm-utils.c
@@ -5406,11 +5406,11 @@ _json_team_add_defaults (json_t *json,
 
 	if (nm_streq (runner, NM_SETTING_TEAM_RUNNER_ACTIVEBACKUP)) {
 		_json_add_object (json, "notify_peers", "count", NULL,
-				  json_integer (NM_SETTING_TEAM_NOTIFY_PEERS_COUNT_ACTIVEBACKUP_DEFAULT));
+		                  json_integer (NM_SETTING_TEAM_NOTIFY_PEERS_COUNT_ACTIVEBACKUP_DEFAULT));
 		_json_add_object (json, "mcast_rejoin", "count", NULL,
-				  json_integer (NM_SETTING_TEAM_NOTIFY_MCAST_COUNT_ACTIVEBACKUP_DEFAULT));
+		                  json_integer (NM_SETTING_TEAM_NOTIFY_MCAST_COUNT_ACTIVEBACKUP_DEFAULT));
 	} else if (   nm_streq (runner, NM_SETTING_TEAM_RUNNER_LOADBALANCE)
-		   || nm_streq (runner, NM_SETTING_TEAM_RUNNER_LACP)) {
+	           || nm_streq (runner, NM_SETTING_TEAM_RUNNER_LACP)) {
 		json_element = json_array ();
 		json_array_append_new (json_element, json_string ("eth"));
 		json_array_append_new (json_element, json_string ("ipv4"));

--- a/libnm-core/nm-utils.c
+++ b/libnm-core/nm-utils.c
@@ -1034,30 +1034,6 @@ _nm_utils_ptrarray_to_strv (GPtrArray *ptrarray)
 	return strv;
 }
 
-/**
- * _nm_utils_strv_equal:
- * @strv1: a string array
- * @strv2: a string array
- *
- * Compare NULL-terminated string arrays for equality.
- *
- * Returns: %TRUE if the arrays are equal, %FALSE otherwise.
- **/
-gboolean
-_nm_utils_strv_equal (char **strv1, char **strv2)
-{
-	if (strv1 == strv2)
-		return TRUE;
-
-	if (!strv1 || !strv2)
-		return FALSE;
-
-	for ( ; *strv1 && *strv2 && !strcmp (*strv1, *strv2); strv1++, strv2++)
-		;
-
-	return !*strv1 && !*strv2;
-}
-
 static gboolean
 device_supports_ap_ciphers (guint32 dev_caps,
                             guint32 ap_flags,

--- a/shared/nm-utils/nm-shared-utils.c
+++ b/shared/nm-utils/nm-shared-utils.c
@@ -2318,6 +2318,57 @@ _nm_utils_strv_sort (const char **strv, gssize len)
 	                   NULL);
 }
 
+/**
+ * _nm_utils_strv_cmp_n:
+ * @strv1: a string array
+ * @len1: the length of @strv1, or -1 for NULL terminated array.
+ * @strv2: a string array
+ * @len2: the length of @strv2, or -1 for NULL terminated array.
+ *
+ * Note that
+ *   - len == -1 && strv == NULL
+ * is treated like a %NULL argument and compares differently from
+ * other arrays.
+ *
+ * Note that an empty array can be represented as
+ *   - len == -1 &&  strv && !strv[0]
+ *   - len ==  0 && !strv
+ *   - len ==  0 &&  strv
+ * These 3 forms all compare equal.
+ * It also means, if length is 0, then it is permissible for strv to be %NULL.
+ *
+ * The strv arrays may contain %NULL strings (if len is positive).
+ *
+ * Returns: 0 if the arrays are equal (using strcmp).
+ **/
+int
+_nm_utils_strv_cmp_n (const char *const*strv1,
+                      gssize len1,
+                      const char *const*strv2,
+                      gssize len2)
+{
+	gsize n, n2;
+
+	if (len1 < 0) {
+		if (!strv1)
+			return (len2 < 0 && !strv2) ? 0 : -1;
+		n = NM_PTRARRAY_LEN (strv1);
+	} else
+		n = len1;
+
+	if (len2 < 0) {
+		if (!strv2)
+			return 1;
+		n2 = NM_PTRARRAY_LEN (strv2);
+	} else
+		n2 = len2;
+
+	NM_CMP_DIRECT (n, n2);
+	for (; n > 0; n--, strv1++, strv2++)
+		NM_CMP_DIRECT_STRCMP0 (*strv1, *strv2);
+	return 0;
+}
+
 /*****************************************************************************/
 
 gpointer

--- a/shared/nm-utils/nm-shared-utils.h
+++ b/shared/nm-utils/nm-shared-utils.h
@@ -941,6 +941,18 @@ gboolean nm_utils_hash_table_equal (const GHashTable *a,
 void _nm_utils_strv_sort (const char **strv, gssize len);
 #define nm_utils_strv_sort(strv, len) _nm_utils_strv_sort (NM_CAST_STRV_MC (strv), len)
 
+int _nm_utils_strv_cmp_n (const char *const*strv1,
+                          gssize len1,
+                          const char *const*strv2,
+                          gssize len2);
+
+static inline gboolean
+_nm_utils_strv_equal (char **strv1, char **strv2)
+{
+	return _nm_utils_strv_cmp_n ((const char *const*) strv1, -1,
+	                             (const char *const*) strv2, -1) == 0;
+}
+
 /*****************************************************************************/
 
 #define NM_UTILS_NS_PER_SECOND   ((gint64) 1000000000)

--- a/shared/nm-utils/nm-test-utils.h
+++ b/shared/nm-utils/nm-test-utils.h
@@ -1136,12 +1136,13 @@ nmtst_uuid_generate (void)
 
 #endif
 
-#define NMTST_SWAP(x,y) \
+#define NMTST_SWAP(x, y) \
 	G_STMT_START { \
-		char __nmtst_swap_temp[sizeof(x) == sizeof(y) ? (signed) sizeof(x) : -1]; \
-		memcpy(__nmtst_swap_temp, &y, sizeof(x)); \
-		memcpy(&y,                &x, sizeof(x)); \
-		memcpy(&x, __nmtst_swap_temp, sizeof(x)); \
+		char __nmtst_swap_temp[sizeof((x)) == sizeof((y)) ? (signed) sizeof((x)) : -1]; \
+		\
+		memcpy(__nmtst_swap_temp, &(y),              sizeof (__nmtst_swap_temp)); \
+		memcpy(&(y),              &(x),              sizeof (__nmtst_swap_temp)); \
+		memcpy(&(x),              __nmtst_swap_temp, sizeof (__nmtst_swap_temp)); \
 	} G_STMT_END
 
 #define nmtst_assert_str_has_substr(str, substr) \


### PR DESCRIPTION
CI tests for #317 fail now test `team_abs_set_runner_tx_hash`.

It reveals that `g_object_set (s_team, "runner-tx-hash", NULL, NULL)` does not actually clear the settings. That was hid by `set_fcn()` in nmcli wrongly calling `nm_setting_team_remove_runner_tx_hash()` [[1]](https://cgit.freedesktop.org/NetworkManager/NetworkManager/tree/clients/common/nm-meta-setting-desc.c?id=cfcd746260b0dc1af80dd769d67dfa2649569b36#n4082).

This branch attempts to address these issues for `NMSettingTeam`.

As of now,  `NMSettingTeamPort` is still not changed. Please first ACK this approach, before I am going to spend time doing the wrong thing. Thanks.