### PR TITLE
device: fix the slave state change reason on master connection removal

### DIFF
--- a/src/devices/nm-device.c
+++ b/src/devices/nm-device.c
@@ -5081,6 +5081,11 @@ nm_device_slave_notify_release (NMDevice *self, NMDeviceStateReason reason)
 			reason = NM_DEVICE_STATE_REASON_DEPENDENCY_FAILED;
 			master_status = "deactivated by user request";
 			break;
+		case NM_DEVICE_STATE_REASON_CONNECTION_REMOVED:
+			new_state = NM_DEVICE_STATE_DEACTIVATING;
+			reason = NM_DEVICE_STATE_REASON_DEPENDENCY_FAILED;
+			master_status = "deactivated because master was removed";
+			break;
 		default:
 			new_state = NM_DEVICE_STATE_DISCONNECTED;
 			master_status = "deactivated";


### PR DESCRIPTION
If we surprise-remove the master, slaves would immediately attempt to bring
things up by autoconnecting. Not cool. Policy, however, blocks
autoconnect if the slaves disconnect due to "dependency-failed", and it
indeed seems to be an appropriate reason here:

  $ nmcli c add type bridge
  $ nmcli c add type dummy ifname dummy0 master bridge autoconnect yes
  $ nmcli c del bridge
  $

Before:

  (nm-bridge): state change: ip-config -> deactivating (reason 'connection-removed')
  (nm-bridge): state change: deactivating -> disconnected (reason 'connection-removed')
  (nm-bridge): detached bridge port dummy0
  (dummy0): state change: activated -> disconnected (reason 'connection-removed')
  (nm-bridge): state change: disconnected -> unmanaged (reason 'user-requested')
  (dummy0): state change: disconnected -> unmanaged (reason 'user-requested')
  policy: auto-activating connection 'bridge-slave-dummy0'

After:

  (nm-bridge): state change: ip-config -> deactivating (reason 'connection-removed')
  (nm-bridge): state change: deactivating -> disconnected (reason 'connection-removed')
  (nm-bridge): detached bridge port dummy0
  (dummy0): state change: activated -> deactivating (reason 'dependency-failed')
  (nm-bridge): state change: disconnected -> unmanaged (reason 'user-requested')
  (dummy0): state change: deactivating -> disconnected (reason 'dependency-failed')
  (dummy0): state change: disconnected -> unmanaged (reason 'user-requested')