### PR TITLE
ovs: don't traverse interface through disconnected when the ovsdb entry is removed

### DIFF
--- a/src/devices/ovs/nm-ovs-factory.c
+++ b/src/devices/ovs/nm-ovs-factory.c
@@ -120,22 +120,13 @@ ovsdb_device_removed (NMOvsdb *ovsdb, const char *name, NMDeviceType device_type
                       NMDeviceFactory *self)
 {
 	NMDevice *device;
-	NMDeviceState device_state;
 
 	device = nm_manager_get_device (nm_manager_get (), name, device_type);
 	if (!device)
 		return;
 
-	device_state = nm_device_get_state (device);
-	if (   device_type == NM_DEVICE_TYPE_OVS_INTERFACE
-	    && device_state > NM_DEVICE_STATE_DISCONNECTED
-	    && device_state < NM_DEVICE_STATE_DEACTIVATING) {
-		nm_device_state_changed (device,
-		                         NM_DEVICE_STATE_DEACTIVATING,
-		                         NM_DEVICE_STATE_REASON_REMOVED);
-	} else if (device_state == NM_DEVICE_STATE_UNMANAGED) {
+	if (device_type == NM_DEVICE_TYPE_OVS_INTERFACE)
 		nm_device_unrealize (device, TRUE, NULL);
-	}
 }
 
 static void


### PR DESCRIPTION
Go straight to unmanaged. That's what all the other devices do when
their backing resources vanish. If the device reached disconnected
state, an autoconnect check would try to connect it back, in vain.