### PR TITLE
logging: don't leave protected log domain unset

### DIFF
--- a/src/nm-logging.c
+++ b/src/nm-logging.c
@@ -157,9 +157,9 @@ NMLogDomain _nm_logging_enabled_state[_LOGL_N_REAL] = {
 	 *
 	 * Note: LOGD_VPN_PLUGIN is special and must be disabled for
 	 * DEBUG and TRACE levels. */
-	[LOGL_INFO] = LOGD_DEFAULT,
-	[LOGL_WARN] = LOGD_DEFAULT,
-	[LOGL_ERR]  = LOGD_DEFAULT,
+	[LOGL_INFO] = LOGD_ALL,
+	[LOGL_WARN] = LOGD_ALL,
+	[LOGL_ERR]  = LOGD_ALL,
 };
 
 /*****************************************************************************/


### PR DESCRIPTION
Otherwise the following in the config file results in VPN_PLUGIN (and
others) not logging at all.

  [logging]
  level=trace

It should go to the default level (INFO) instead.