### PR TITLE
ovs-interface: dissociate the link on disconnection

### DIFF
--- a/src/devices/ovs/nm-device-ovs-interface.c
+++ b/src/devices/ovs/nm-device-ovs-interface.c
@@ -118,6 +118,16 @@ link_changed (NMDevice *device,
 	}
 }
 
+static void
+state_changed (NMDevice *device,
+               NMDeviceState new_state,
+               NMDeviceState old_state,
+               NMDeviceStateReason reason)
+{
+	if (new_state <= NM_DEVICE_STATE_DISCONNECTED)
+		nm_device_update_from_platform_link (device, NULL);
+}
+
 static gboolean
 _is_internal_interface (NMDevice *device)
 {
@@ -190,6 +200,7 @@ nm_device_ovs_interface_class_init (NMDeviceOvsInterfaceClass *klass)
 	device_class->is_available = is_available;
 	device_class->check_connection_compatible = check_connection_compatible;
 	device_class->link_changed = link_changed;
+	device_class->state_changed = state_changed;
 	device_class->act_stage3_ip_config_start = act_stage3_ip_config_start;
 	device_class->can_unmanaged_external_down = can_unmanaged_external_down;
 }

--- a/src/devices/ovs/nm-ovs-factory.c
+++ b/src/devices/ovs/nm-ovs-factory.c
@@ -120,20 +120,13 @@ ovsdb_device_removed (NMOvsdb *ovsdb, const char *name, NMDeviceType device_type
                       NMDeviceFactory *self)
 {
 	NMDevice *device;
-	NMDeviceState device_state;
 
 	device = nm_manager_get_device (nm_manager_get (), name, device_type);
 	if (!device)
 		return;
 
-	device_state = nm_device_get_state (device);
 	if (   device_type == NM_DEVICE_TYPE_OVS_INTERFACE
-	    && device_state > NM_DEVICE_STATE_DISCONNECTED
-	    && device_state < NM_DEVICE_STATE_DEACTIVATING) {
-		nm_device_state_changed (device,
-		                         NM_DEVICE_STATE_DEACTIVATING,
-		                         NM_DEVICE_STATE_REASON_REMOVED);
-	} else if (device_state == NM_DEVICE_STATE_UNMANAGED) {
+	    || nm_device_get_state (device) == NM_DEVICE_STATE_UNMANAGED) {
 		nm_device_unrealize (device, TRUE, NULL);
 	}
 }


### PR DESCRIPTION
Open vSwitch is the special kid on the block -- it likes to be in charge of
the link lifetime and so we shouldn't be. This means that we shouldn't be
attempting to remove the link: we'd just (gracefully) fail anyways.

More importantly, this also means that we shouldn't care if we see the link
go away. Once the device reaches DISCONNECTED state, its configuration is
cleaned up and we may already be activating another connection. We shouldn't
alter the device state when OpenVSwitch decides to drop the old link.

https://bugzilla.redhat.com/show_bug.cgi?id=1543557