### PR TITLE
settings: keep the added connection alive for a bit longer

### DIFF
--- a/src/settings/nm-settings.c
+++ b/src/settings/nm-settings.c
@@ -1138,7 +1138,7 @@ pk_add_cb (NMAuthChain *chain,
 	NMAuthCallResult result;
 	GError *error = NULL;
 	NMConnection *connection = NULL;
-	NMSettingsConnection *added = NULL;
+	gs_unref_object NMSettingsConnection *added = NULL;
 	NMSettingsAddCallback callback;
 	gpointer callback_data;
 	NMAuthSubject *subject;
@@ -1169,6 +1169,12 @@ pk_add_cb (NMAuthChain *chain,
 
 		save_to_disk = GPOINTER_TO_UINT (nm_auth_chain_get_data (chain, "save-to-disk"));
 		added = nm_settings_add_connection (self, connection, save_to_disk, &error);
+
+		/* The callback may remove the connection from the settings manager (e.g.
+		 * because it's found to be incompatible with the device on AddAndActivate).
+		 * But we need to keep it alive for a bit longer, precisely to check wehther
+		 * it's still known to the setting manager. */
+		g_object_ref (added);
 	}
 
 	callback = nm_auth_chain_get_data (chain, "callback");


### PR DESCRIPTION
Fixes a crash on failed AddAndActivate:

  $ ip link set eth0 down
  $ nmcli d conn eth0
  Error: Failed to add/activate new connection: Connection 'eth0' is not available on device eth0 because device has no carrier
  <NetworkManager crashes>

  #3  0x000055555558b6c5 in _nm_g_return_if_fail_warning
  #4  0x00005555557008c7 in nm_settings_has_connection
  #5  0x0000555555700e5f in pk_add_cb
  #6  0x0000555555726e30 in pk_call_cb
  #7  0x0000555555726e30 in pk_call_cb
  #8  0x0000555555726e30 in pk_call_cb
  #9  0x00005555555aaea8 in _call_id_invoke_callback
  #10 0x00005555555ab2e8 in _call_on_idle