### PR TITLE
cli: fix a crash on "nmcli d wifi hotspot"

### DIFF
--- a/clients/cli/devices.c
+++ b/clients/cli/devices.c
@@ -3888,6 +3888,7 @@ do_device_wifi_hotspot (NmCli *nmc, int argc, char **argv)
 	info->nmc = nmc;
 	info->device = device;
 	info->hotspot = TRUE;
+	info->create = TRUE;
 
 	nm_client_add_and_activate_connection_async (nmc->client,
 	                                             connection,


### PR DESCRIPTION
Call the correct _finish() function for
nm_client_add_and_activate_connection_async(). add_and_activate_cb()
somewhat confusingly alternates between two different ones depending on
whether info->create is set.

Fixes: 35932375272a ('cli: reuse connections in nmcli dev wifi con')