### PR TITLE
clients: only ask secrets for settings that require them

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4212,6 +4212,7 @@ clients_tui_nmtui_LDADD = \
 	libnm/libnm.la \
 	clients/tui/newt/libnmt-newt.a \
 	clients/common/libnmc-base.la \
+	clients/common/libnmc.la \
 	$(GLIB_LIBS) \
 	$(NEWT_LIBS) \
 	$(NULL)

--- a/clients/cli/connections.c
+++ b/clients/cli/connections.c
@@ -1276,12 +1276,18 @@ static void
 update_secrets_in_connection (NMRemoteConnection *remote, NMConnection *local)
 {
 	GetSecretsData data = { 0, };
+	GType setting_type;
 	int i;
 
 	data.local = local;
 	data.loop = g_main_loop_new (NULL, FALSE);
 
 	for (i = 0; i < _NM_META_SETTING_TYPE_NUM; i++) {
+		setting_type = nm_meta_setting_infos[i].get_setting_gtype();
+		if (!nm_connection_get_setting (NM_CONNECTION (remote), setting_type))
+			continue;
+		if (!nm_meta_setting_info_editor_has_secrets (nm_meta_setting_info_editor_find_by_gtype (setting_type)))
+			continue;
 		data.setting_name = nm_meta_setting_infos[i].setting_name;
 		nm_remote_connection_get_secrets_async (remote,
 		                                        nm_meta_setting_infos[i].setting_name,

--- a/clients/common/nm-meta-setting-access.c
+++ b/clients/common/nm-meta-setting-access.c
@@ -101,6 +101,22 @@ nm_meta_setting_info_editor_get_property_info (const NMMetaSettingInfoEditor *se
 	return NULL;
 }
 
+gboolean
+nm_meta_setting_info_editor_has_secrets (const NMMetaSettingInfoEditor *setting_info)
+{
+	guint i;
+
+	if (!setting_info)
+		return FALSE;
+
+	for (i = 0; i < setting_info->properties_num; i++) {
+		if (setting_info->properties[i]->is_secret)
+			return TRUE;
+	}
+
+	return FALSE;
+}
+
 const NMMetaPropertyInfo *
 nm_meta_property_info_find_by_name (const char *setting_name, const char *property_name)
 {

--- a/clients/common/nm-meta-setting-access.h
+++ b/clients/common/nm-meta-setting-access.h
@@ -39,6 +39,8 @@ const NMMetaPropertyInfo *nm_meta_property_info_find_by_name (const char *settin
 const NMMetaPropertyInfo *nm_meta_property_info_find_by_setting (NMSetting *setting,
                                                                  const char *property_name);
 
+gboolean nm_meta_setting_info_editor_has_secrets (const NMMetaSettingInfoEditor *setting_info);
+
 /*****************************************************************************/
 
 const NMMetaSettingInfoEditor *const*nm_meta_setting_infos_editor_p (void);

--- a/clients/tui/meson.build
+++ b/clients/tui/meson.build
@@ -56,6 +56,7 @@ sources = files(
 
 deps += [
   libnm_dep,
+  libnmc_dep,
   libnmc_base_dep,
   libnmt_newt_dep,
 ]

--- a/clients/tui/nmt-editor.c
+++ b/clients/tui/nmt-editor.c
@@ -53,6 +53,8 @@
 #include "nmt-page-vlan.h"
 #include "nmt-page-wifi.h"
 
+#include "nm-meta-setting-access.h"
+
 G_DEFINE_TYPE (NmtEditor, nmt_editor, NMT_TYPE_NEWT_FORM)
 
 #define NMT_EDITOR_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), NMT_TYPE_EDITOR, NmtEditorPrivate))
@@ -230,6 +232,8 @@ build_edit_connection (NMConnection *orig_connection)
 	settings = nm_connection_to_dbus (orig_connection, NM_CONNECTION_SERIALIZE_NO_SECRETS);
 	g_variant_iter_init (&iter, settings);
 	while (g_variant_iter_next (&iter, "{&s@a{sv}}", &setting_name, NULL)) {
+		if (!nm_meta_setting_info_editor_has_secrets (nm_meta_setting_info_editor_find_by_name (setting_name, FALSE)))
+			continue;
 		nmt_sync_op_init (&op);
 		nm_remote_connection_get_secrets_async (NM_REMOTE_CONNECTION (orig_connection),
 		                                        setting_name, NULL, got_secrets, &op);


### PR DESCRIPTION
When nmcli needs secrets for a connection it asks them for every known setting. nmtui is a bit smarter and asks them only for settings that actually exist in the connection. Make a step further and let clients ask secrets only for setting that exist *and* have any secret property. This decreases the number of D-Bus calls when editing or showing a connection with secrets.

https://bugzilla.redhat.com/show_bug.cgi?id=1506536