### PR TITLE
[th/strsplit]

### DIFF
--- a/clients/cli/connections.c
+++ b/clients/cli/connections.c
@@ -1876,7 +1876,7 @@ parse_preferred_connection_order (const char *order, GError **error)
 	gboolean inverse, unique;
 	int i;
 
-	strv = nm_utils_strsplit_set (order, ":", FALSE);
+	strv = nm_utils_strsplit_set (order, ":");
 	if (!strv) {
 		g_set_error (error, NMCLI_ERROR, 0,
 		             _("incorrect string '%s' of '--order' option"), order);
@@ -2680,7 +2680,7 @@ parse_passwords (const char *passwd_file, GError **error)
 		return NULL;
 	}
 
-	strv = nm_utils_strsplit_set (contents, "\r\n", FALSE);
+	strv = nm_utils_strsplit_set (contents, "\r\n");
 	for (iter = strv; *iter; iter++) {
 		gs_free char *iter_s = g_strdup (*iter);
 

--- a/clients/cli/settings.c
+++ b/clients/cli/settings.c
@@ -338,7 +338,7 @@ _set_fcn_precheck_connection_secondaries (NMClient *client,
 	char **iter;
 	gboolean modified = FALSE;
 
-	strv0 = nm_utils_strsplit_set (value, " \t,", FALSE);
+	strv0 = nm_utils_strsplit_set (value, " \t,");
 	if (!strv0)
 		return TRUE;
 

--- a/clients/cli/utils.c
+++ b/clients/cli/utils.c
@@ -508,7 +508,8 @@ nmc_string_to_arg_array (const char *line, const char *delim, gboolean unquote,
 	gs_free const char **arr0 = NULL;
 	char **arr;
 
-	arr0 = nm_utils_strsplit_set (line ?: "", delim ?: " \t", FALSE);
+	arr0 = nm_utils_strsplit_set (line ?: "",
+	                              delim ?: " \t");
 	if (!arr0)
 		arr = g_new0 (char *, 1);
 	else

--- a/clients/common/nm-meta-setting-desc.c
+++ b/clients/common/nm-meta-setting-desc.c
@@ -197,19 +197,19 @@ _value_strsplit (const char *value,
 	/* note that all modes remove empty tokens (",", "a,,b", ",,"). */
 	switch (split_mode) {
 	case VALUE_STRSPLIT_MODE_STRIPPED:
-		strv = nm_utils_strsplit_set (value, NM_ASCII_SPACES",", FALSE);
+		strv = nm_utils_strsplit_set (value, NM_ASCII_SPACES",");
 		break;
 	case VALUE_STRSPLIT_MODE_OBJLIST:
-		strv = nm_utils_strsplit_set (value, ",", FALSE);
+		strv = nm_utils_strsplit_set (value, ",");
 		break;
 	case VALUE_STRSPLIT_MODE_OBJLIST_WITH_ESCAPE:
-		strv = nm_utils_strsplit_set (value, ",", TRUE);
+		strv = nm_utils_strsplit_set_full (value, ",", NM_UTILS_STRSPLIT_SET_FLAGS_ALLOW_ESCAPING);
 		break;
 	case VALUE_STRSPLIT_MODE_MULTILIST:
-		strv = nm_utils_strsplit_set (value, " \t,", FALSE);
+		strv = nm_utils_strsplit_set (value, " \t,");
 		break;
 	case VALUE_STRSPLIT_MODE_MULTILIST_WITH_ESCAPE:
-		strv = nm_utils_strsplit_set (value, MULTILIST_WITH_ESCAPE_CHARS, TRUE);
+		strv = nm_utils_strsplit_set_full (value, MULTILIST_WITH_ESCAPE_CHARS, NM_UTILS_STRSPLIT_SET_FLAGS_ALLOW_ESCAPING);
 		break;
 	default:
 		nm_assert_not_reached ();
@@ -306,7 +306,7 @@ _parse_ip_route (int family,
 	nm_assert (!error || !*error);
 
 	str_clean = nm_strstrip_avoid_copy_a (300, str, &str_clean_free);
-	routev = nm_utils_strsplit_set (str_clean, " \t", FALSE);
+	routev = nm_utils_strsplit_set (str_clean, " \t");
 	if (!routev) {
 		g_set_error (error, 1, 0,
 		             "'%s' is not valid. %s",
@@ -480,7 +480,7 @@ _parse_team_link_watcher (const char *str,
 	nm_assert (!error || !*error);
 
 	str_clean = nm_strstrip_avoid_copy_a (300, str, &str_clean_free);
-	watcherv = nm_utils_strsplit_set (str_clean, " \t", FALSE);
+	watcherv = nm_utils_strsplit_set (str_clean, " \t");
 	if (!watcherv) {
 		g_set_error (error, 1, 0, "'%s' is not valid", str);
 		return NULL;
@@ -489,7 +489,7 @@ _parse_team_link_watcher (const char *str,
 	for (i = 0; watcherv[i]; i++) {
 		gs_free const char **pair = NULL;
 
-		pair = nm_utils_strsplit_set (watcherv[i], "=", FALSE);
+		pair = nm_utils_strsplit_set (watcherv[i], "=");
 		if (!pair) {
 			g_set_error (error, 1, 0, "'%s' is not valid: %s", watcherv[i],
 			             "properties should be specified as 'key=value'");
@@ -1935,7 +1935,7 @@ _set_fcn_optionlist (ARGS_SET_FCN)
 		return _gobject_property_reset_default (setting, property_info->property_name);
 
 	nstrv = 0;
-	strv = nm_utils_strsplit_set (value, ",", FALSE);
+	strv = nm_utils_strsplit_set (value, ",");
 	if (strv) {
 		strv_val = g_new (const char *, NM_PTRARRAY_LEN (strv));
 		for (i = 0; strv[i]; i++) {
@@ -2187,7 +2187,7 @@ _set_fcn_gobject_bytes (ARGS_SET_FCN)
 	}
 
 	/* Otherwise, consider the following format: AA b 0xCc D */
-	strv = nm_utils_strsplit_set (value, " \t", FALSE);
+	strv = nm_utils_strsplit_set (value, " \t");
 	array = g_byte_array_sized_new (NM_PTRARRAY_LEN (strv));
 	for (iter = strv; iter && *iter; iter++) {
 		int v;
@@ -2797,7 +2797,7 @@ _set_fcn_dcb_flags (ARGS_SET_FCN)
 		const char *const*iter;
 
 		/* Check for individual flag numbers */
-		strv = nm_utils_strsplit_set (value, " \t,", FALSE);
+		strv = nm_utils_strsplit_set (value, " \t,");
 		for (iter = strv; iter && *iter; iter++) {
 			t = _nm_utils_ascii_str_to_int64 (*iter, 0, 0, DCB_ALL_FLAGS, -1);
 
@@ -3948,7 +3948,7 @@ _set_fcn_wired_s390_subchannels (ARGS_SET_FCN)
 	if (_SET_FCN_DO_RESET_DEFAULT (property_info, modifier, value))
 		return _gobject_property_reset_default (setting, property_info->property_name);
 
-	strv = nm_utils_strsplit_set (value, " ,\t", FALSE);
+	strv = nm_utils_strsplit_set (value, " ,\t");
 	len = NM_PTRARRAY_LEN (strv);
 	if (len != 2 && len != 3) {
 		g_set_error (error, 1, 0, _("'%s' is not valid; 2 or 3 strings should be provided"),

--- a/clients/common/nm-meta-setting-desc.c
+++ b/clients/common/nm-meta-setting-desc.c
@@ -2837,12 +2837,12 @@ dcb_parse_uint_array (const char *val,
                       guint out_array[static 8],
                       GError **error)
 {
-	gs_strfreev char **items = NULL;
-	char **iter;
+	gs_free const char **items = NULL;
+	const char *const*iter;
 	gsize i;
 
-	items = g_strsplit_set (val, ",", -1);
-	if (g_strv_length (items) != 8) {
+	items = nm_utils_strsplit_set_with_empty (val, ",");
+	if (NM_PTRARRAY_LEN (items) != 8) {
 		g_set_error_literal (error, 1, 0, _("must contain 8 comma-separated numbers"));
 		return FALSE;
 	}
@@ -2850,8 +2850,6 @@ dcb_parse_uint_array (const char *val,
 	i = 0;
 	for (iter = items; *iter; iter++) {
 		gint64 num;
-
-		*iter = g_strstrip (*iter);
 
 		num = _nm_utils_ascii_str_to_int64 (*iter, 10, 0, other ?: max, -1);
 

--- a/clients/common/nm-vpn-helpers.c
+++ b/clients/common/nm-vpn-helpers.c
@@ -203,7 +203,7 @@ nm_vpn_openconnect_authenticate_helper (const char *host,
                                         int *status,
                                         GError **error)
 {
-	char *output = NULL;
+	gs_free char *output = NULL;
 	gboolean ret;
 	char **strv = NULL, **iter;
 	char *argv[4];

--- a/libnm-core/nm-setting-bridge.c
+++ b/libnm-core/nm-setting-bridge.c
@@ -432,7 +432,7 @@ nm_bridge_vlan_from_str (const char *str, GError **error)
 	g_return_val_if_fail (str, NULL);
 	g_return_val_if_fail (!error || !*error, NULL);
 
-	tokens = nm_utils_strsplit_set (str, " ", FALSE);
+	tokens = nm_utils_strsplit_set (str, " ");
 	if (!tokens || !tokens[0]) {
 		g_set_error_literal (error,
 		                     NM_CONNECTION_ERROR,

--- a/libnm-core/nm-utils.c
+++ b/libnm-core/nm-utils.c
@@ -2849,7 +2849,7 @@ _nm_sriov_vf_parse_vlans (NMSriovVF *vf, const char *str, GError **error)
 	gs_free const char **vlans = NULL;
 	guint i;
 
-	vlans = nm_utils_strsplit_set (str, ";", FALSE);
+	vlans = nm_utils_strsplit_set (str, ";");
 	if (!vlans) {
 		g_set_error_literal (error,
 		                     NM_CONNECTION_ERROR,

--- a/libnm-core/tests/test-general.c
+++ b/libnm-core/tests/test-general.c
@@ -276,7 +276,15 @@ _do_test_nm_utils_strsplit_set (gboolean escape, const char *str, ...)
 
 	args = (const char *const*) args_array->pdata;
 
-	words = nm_utils_strsplit_set (str, " \t\n", escape);
+	if (!escape && nmtst_get_rand_bool ())
+		words = nm_utils_strsplit_set (str, " \t\n");
+	else {
+		words = nm_utils_strsplit_set_full (str,
+		                                    " \t\n",
+		                                      escape
+		                                    ? NM_UTILS_STRSPLIT_SET_FLAGS_ALLOW_ESCAPING
+		                                    : NM_UTILS_STRSPLIT_SET_FLAGS_NONE);
+	}
 
 	if (!args[0]) {
 		g_assert (!words);

--- a/shared/nm-utils/nm-shared-utils.c
+++ b/shared/nm-utils/nm-shared-utils.c
@@ -974,8 +974,7 @@ _char_lookup_table_init (guint8 lookup[static 256],
 /**
  * nm_utils_strsplit_set_full:
  * @str: the string to split.
- * @delimiters: the set of delimiters. If %NULL, defaults to " \t\n",
- *   like bash's $IFS.
+ * @delimiters: the set of delimiters.
  * @flags: additional flags for controlling the operation.
  *
  * This is a replacement for g_strsplit_set() which avoids copying
@@ -1017,8 +1016,10 @@ nm_utils_strsplit_set_full (const char *str,
 		return NULL;
 
 	/* initialize lookup table for delimiter */
-	if (!delimiters)
+	if (!delimiters) {
+		nm_assert_not_reached ();
 		delimiters = " \t\n";
+	}
 
 	_char_lookup_table_init (delimiters_table, delimiters);
 

--- a/shared/nm-utils/nm-shared-utils.h
+++ b/shared/nm-utils/nm-shared-utils.h
@@ -334,12 +334,24 @@ int nm_utils_dbus_path_cmp (const char *dbus_path_a, const char *dbus_path_b);
 
 typedef enum {
 	NM_UTILS_STRSPLIT_SET_FLAGS_NONE           = 0,
-	NM_UTILS_STRSPLIT_SET_FLAGS_ALLOW_ESCAPING = (1u << 0),
+	NM_UTILS_STRSPLIT_SET_FLAGS_PRESERVE_EMPTY = (1u << 0),
+	NM_UTILS_STRSPLIT_SET_FLAGS_ALLOW_ESCAPING = (1u << 1),
 } NMUtilsStrsplitSetFlags;
 
 const char **nm_utils_strsplit_set_full (const char *str,
                                          const char *delimiter,
                                          NMUtilsStrsplitSetFlags flags);
+
+static inline const char **
+nm_utils_strsplit_set_with_empty (const char *str,
+                                  const char *delimiters)
+{
+	/* this returns the same result as g_strsplit_set(str, delimiters, -1), except
+	 * it does not deep-clone the strv array.
+	 * Also, for @str == "", this returns %NULL while g_strsplit_set() would return
+	 * an empty strv array. */
+	return nm_utils_strsplit_set_full (str, delimiters, NM_UTILS_STRSPLIT_SET_FLAGS_PRESERVE_EMPTY);
+}
 
 static inline const char **
 nm_utils_strsplit_set (const char *str,

--- a/shared/nm-utils/nm-shared-utils.h
+++ b/shared/nm-utils/nm-shared-utils.h
@@ -332,7 +332,21 @@ int nm_utils_dbus_path_cmp (const char *dbus_path_a, const char *dbus_path_b);
 
 /*****************************************************************************/
 
-const char **nm_utils_strsplit_set (const char *str, const char *delimiters, gboolean allow_escaping);
+typedef enum {
+	NM_UTILS_STRSPLIT_SET_FLAGS_NONE           = 0,
+	NM_UTILS_STRSPLIT_SET_FLAGS_ALLOW_ESCAPING = (1u << 0),
+} NMUtilsStrsplitSetFlags;
+
+const char **nm_utils_strsplit_set_full (const char *str,
+                                         const char *delimiter,
+                                         NMUtilsStrsplitSetFlags flags);
+
+static inline const char **
+nm_utils_strsplit_set (const char *str,
+                       const char *delimiters)
+{
+	return nm_utils_strsplit_set_full (str, delimiters, NM_UTILS_STRSPLIT_SET_FLAGS_NONE);
+}
 
 char *nm_utils_str_simpletokens_extract_next (char **p_line_start);
 

--- a/src/devices/nm-device-bond.c
+++ b/src/devices/nm-device-bond.c
@@ -185,20 +185,18 @@ set_arp_targets (NMDevice *device,
                  const char *delim,
                  const char *prefix)
 {
-	char **items, **iter, *tmp;
+	gs_free const char **value_v = NULL;
+	gsize i;
 
-	if (!value || !*value)
+	value_v = nm_utils_strsplit_set (value, delim);
+	if (!value_v)
 		return;
+	for (i = 0; value_v[i]; i++) {
+		gs_free char *tmp = NULL;
 
-	items = g_strsplit_set (value, delim, 0);
-	for (iter = items; iter && *iter; iter++) {
-		if (*iter[0]) {
-			tmp = g_strdup_printf ("%s%s", prefix, *iter);
-			set_bond_attr (device, mode, NM_SETTING_BOND_OPTION_ARP_IP_TARGET, tmp);
-			g_free (tmp);
-		}
+		tmp = g_strdup_printf ("%s%s", prefix, value_v[i]);
+		set_bond_attr (device, mode, NM_SETTING_BOND_OPTION_ARP_IP_TARGET, tmp);
 	}
-	g_strfreev (items);
 }
 
 static void

--- a/src/nm-dcb.c
+++ b/src/nm-dcb.c
@@ -37,9 +37,11 @@ do_helper (const char *iface,
            const char *fmt,
            ...)
 {
-	char **argv = NULL, **split = NULL, *cmdline, *errmsg = NULL;
-	gboolean success = FALSE;
-	guint i, u;
+	gs_free const char **split = NULL;
+	gs_free char *cmdline = NULL;
+	gs_free const char **argv = NULL;
+	gsize i;
+	gsize u;
 	va_list args;
 
 	g_return_val_if_fail (fmt != NULL, FALSE);
@@ -48,35 +50,31 @@ do_helper (const char *iface,
 	cmdline = g_strdup_vprintf (fmt, args);
 	va_end (args);
 
-	split = g_strsplit_set (cmdline, " ", 0);
+	split = nm_utils_strsplit_set_with_empty (cmdline, " ");
 	if (!split) {
 		g_set_error (error, NM_MANAGER_ERROR, NM_MANAGER_ERROR_FAILED,
 		             "failure parsing %s command line", helper_names[which]);
-		goto out;
+		return FALSE;
 	}
 
 	/* Allocate space for path, custom arg, interface name, arguments, and NULL */
-	i = u = 0;
-	argv = g_new0 (char *, g_strv_length (split) + 4);
+	i = 0;
+	argv = g_new (const char *, NM_PTRARRAY_LEN (split) + 4);
 	argv[i++] = NULL;  /* Placeholder for dcbtool path */
 	if (which == DCBTOOL) {
 		argv[i++] = "sc";
 		argv[i++] = (char *) iface;
 	}
-	while (u < g_strv_length (split))
-		argv[i++] = split[u++];
+	for (u = 0; split[u]; u++)
+		argv[i++] = split[u];
 	argv[i++] = NULL;
-	success = run_func (argv, which, user_data, error);
-	if (!success && error)
-		g_assert (*error);
 
-out:
-	if (split)
-		g_strfreev (split);
-	g_free (argv);
-	g_free (cmdline);
-	g_free (errmsg);
-	return success;
+	if (!run_func ((char **) argv, which, user_data, error)) {
+		g_assert (!error || !*error);
+		return FALSE;
+	}
+
+	return TRUE;
 }
 
 gboolean

--- a/src/settings/plugins/ibft/nms-ibft-reader.h
+++ b/src/settings/plugins/ibft/nms-ibft-reader.h
@@ -23,6 +23,14 @@
 
 #include "nm-connection.h"
 
+static inline void
+_nm_auto_free_ibft_blocks (GSList **p_blocks)
+{
+	if (*p_blocks)
+		g_slist_free_full (*p_blocks, (GDestroyNotify) g_ptr_array_unref);
+}
+#define nm_auto_free_ibft_blocks nm_auto (_nm_auto_free_ibft_blocks)
+
 gboolean nms_ibft_reader_load_blocks (const char *iscsiadm_path,
                                       GSList **out_blocks,
                                       GError **error);

--- a/src/settings/plugins/ibft/tests/test-ibft.c
+++ b/src/settings/plugins/ibft/tests/test-ibft.c
@@ -40,16 +40,16 @@
 static GPtrArray *
 read_block (const char *iscsiadm_path, const char *expected_mac)
 {
-	GSList *blocks = NULL, *iter;
+	nm_auto_free_ibft_blocks GSList *blocks = NULL;
+	GSList *iter;
 	GPtrArray *block = NULL;
 	GError *error = NULL;
 	gboolean success;
 
 	success = nms_ibft_reader_load_blocks (iscsiadm_path, &blocks, &error);
-	g_assert_no_error (error);
-	g_assert (success);
-	g_assert (blocks);
+	nmtst_assert_success (success, error);
 
+	g_assert (blocks);
 	for (iter = blocks; iter; iter = iter->next) {
 		const char *s_hwaddr = NULL;
 
@@ -63,7 +63,6 @@ read_block (const char *iscsiadm_path, const char *expected_mac)
 	}
 	g_assert (block);
 
-	g_slist_free_full (blocks, (GDestroyNotify) g_ptr_array_unref);
 	return block;
 }
 
@@ -176,7 +175,7 @@ static void
 test_read_ibft_malformed (gconstpointer user_data)
 {
 	const char *iscsiadm_path = user_data;
-	GSList *blocks = NULL;
+	nm_auto_free_ibft_blocks GSList *blocks = NULL;
 	GError *error = NULL;
 	gboolean success;
 
@@ -185,9 +184,9 @@ test_read_ibft_malformed (gconstpointer user_data)
 	NMTST_EXPECT_NM_WARN ("*malformed iscsiadm record*");
 
 	success = nms_ibft_reader_load_blocks (iscsiadm_path, &blocks, &error);
-	g_assert_no_error (error);
-	g_assert (success);
-	g_assert (blocks == NULL);
+	nmtst_assert_success (success, error);
+
+	g_assert (!blocks);
 
 	g_test_assert_expected_messages ();
 }

--- a/src/settings/plugins/ifcfg-rh/nms-ifcfg-rh-reader.c
+++ b/src/settings/plugins/ifcfg-rh/nms-ifcfg-rh-reader.c
@@ -457,7 +457,7 @@ make_connection_setting (const char *file,
 	if (v) {
 		gs_free const char **items = NULL;
 
-		items = nm_utils_strsplit_set (v, " ", FALSE);
+		items = nm_utils_strsplit_set (v, " ");
 		for (iter = items; iter && *iter; iter++) {
 			if (!nm_setting_connection_add_permission (s_con, "user", *iter, NULL))
 				PARSE_WARNING ("invalid USERS item '%s'", *iter);
@@ -473,7 +473,7 @@ make_connection_setting (const char *file,
 	if (v) {
 		gs_free const char **items = NULL;
 
-		items = nm_utils_strsplit_set (v, " \t", FALSE);
+		items = nm_utils_strsplit_set (v, " \t");
 		for (iter = items; iter && *iter; iter++) {
 			if (!nm_setting_connection_add_secondary (s_con, *iter))
 				PARSE_WARNING ("secondary connection UUID '%s' already added", *iter);
@@ -889,7 +889,7 @@ parse_route_line (const char *line,
 	 * Maybe later we want to support some form of quotation here.
 	 * Which of course, would be incompatible with initscripts.
 	 */
-	words_free = nm_utils_strsplit_set (line, " \t\n", FALSE);
+	words_free = nm_utils_strsplit_set (line, " \t\n");
 
 	words = words_free ?: NM_PTRARRAY_EMPTY (const char *);
 
@@ -1327,7 +1327,7 @@ parse_dns_options (NMSettingIPConfig *ip_config, const char *value)
 	if (!nm_setting_ip_config_has_dns_options (ip_config))
 		nm_setting_ip_config_clear_dns_options (ip_config, TRUE);
 
-	options = nm_utils_strsplit_set (value, " ", FALSE);
+	options = nm_utils_strsplit_set (value, " ");
 	if (options) {
 		for (item = options; *item; item++) {
 			if (!nm_setting_ip_config_add_dns_option (ip_config, *item))
@@ -1443,7 +1443,7 @@ make_match_setting (shvarFile *ifcfg)
 	if (!v)
 		return NULL;
 
-	strv = nm_utils_strsplit_set (v, " \t", TRUE);
+	strv = nm_utils_strsplit_set_full (v, " \t", NM_UTILS_STRSPLIT_SET_FLAGS_ALLOW_ESCAPING);
 	if (strv) {
 		for (i = 0; strv[i]; i++) {
 			if (!s_match)
@@ -1722,7 +1722,7 @@ make_ip4_setting (shvarFile *ifcfg,
 		if (v) {
 			gs_free const char **searches = NULL;
 
-			searches = nm_utils_strsplit_set (v, " ", FALSE);
+			searches = nm_utils_strsplit_set (v, " ");
 			if (searches) {
 				for (item = searches; *item; item++) {
 					if (!nm_setting_ip_config_add_dns_search (s_ip4, *item))
@@ -1783,7 +1783,7 @@ make_ip4_setting (shvarFile *ifcfg,
 		if (v) {
 			gs_free const char **searches = NULL;
 
-			searches = nm_utils_strsplit_set (v, " ", FALSE);
+			searches = nm_utils_strsplit_set (v, " ");
 			if (searches) {
 				for (item = searches; *item; item++) {
 					if (!nm_setting_ip_config_add_dns_search (s_ip4, *item))
@@ -2099,7 +2099,7 @@ make_ip6_setting (shvarFile *ifcfg,
 	                   ipv6addr_secondaries ?: "",
 	                   NULL);
 
-	list = nm_utils_strsplit_set (value, " ", FALSE);
+	list = nm_utils_strsplit_set (value, " ");
 	for (iter = list, i = 0; iter && *iter; iter++, i++) {
 		NMIPAddress *addr = NULL;
 
@@ -2192,7 +2192,7 @@ make_ip6_setting (shvarFile *ifcfg,
 	if (v) {
 		gs_free const char **searches = NULL;
 
-		searches = nm_utils_strsplit_set (v, " ", FALSE);
+		searches = nm_utils_strsplit_set (v, " ");
 		if (searches) {
 			for (iter = searches; *iter; iter++) {
 				if (!nm_setting_ip_config_add_dns_search (s_ip6, *iter))
@@ -2551,7 +2551,7 @@ read_dcb_percent_array (shvarFile *ifcfg,
 		return TRUE;
 	}
 
-	split = nm_utils_strsplit_set (val, ",", FALSE);
+	split = nm_utils_strsplit_set (val, ",");
 	if (NM_PTRARRAY_LEN (split) != 8) {
 		PARSE_WARNING ("invalid %s percentage list value '%s'", prop, val);
 		g_set_error_literal (error, NM_SETTINGS_ERROR, NM_SETTINGS_ERROR_INVALID_CONNECTION,
@@ -2963,7 +2963,7 @@ fill_wpa_ciphers (shvarFile *ifcfg,
 	if (!p)
 		return TRUE;
 
-	list = nm_utils_strsplit_set (p, " ", FALSE);
+	list = nm_utils_strsplit_set (p, " ");
 	for (iter = list; iter && *iter; iter++, i++) {
 		/* Ad-Hoc configurations cannot have pairwise ciphers, and can only
 		 * have one group cipher.  Ignore any additional group ciphers and
@@ -3233,7 +3233,7 @@ eap_peap_reader (const char *eap_method,
 	}
 
 	/* Handle options for the inner auth method */
-	list = nm_utils_strsplit_set (v, " ", FALSE);
+	list = nm_utils_strsplit_set (v, " ");
 	iter = list;
 	if (iter) {
 		if (NM_IN_STRSET (*iter, "MSCHAPV2",
@@ -3311,7 +3311,7 @@ eap_ttls_reader (const char *eap_method,
 	inner_auth = g_ascii_strdown (v, -1);
 
 	/* Handle options for the inner auth method */
-	list = nm_utils_strsplit_set (inner_auth, " ", FALSE);
+	list = nm_utils_strsplit_set (inner_auth, " ");
 	iter = list;
 	if (iter) {
 		if (NM_IN_STRSET (*iter, "mschapv2",
@@ -3372,7 +3372,7 @@ eap_fast_reader (const char *eap_method,
 	if (fast_provisioning) {
 		gs_free const char **list1 = NULL;
 
-		list1 = nm_utils_strsplit_set (fast_provisioning, " \t", FALSE);
+		list1 = nm_utils_strsplit_set (fast_provisioning, " \t");
 		for (iter = list1; iter && *iter; iter++) {
 			if (strcmp (*iter, "allow-unauth") == 0)
 				allow_unauth = TRUE;
@@ -3406,7 +3406,7 @@ eap_fast_reader (const char *eap_method,
 	}
 
 	/* Handle options for the inner auth method */
-	list = nm_utils_strsplit_set (inner_auth, " ", FALSE);
+	list = nm_utils_strsplit_set (inner_auth, " ");
 	iter = list;
 	if (iter) {
 		if (   !strcmp (*iter, "MSCHAPV2")
@@ -3486,7 +3486,7 @@ read_8021x_list_value (shvarFile *ifcfg,
 	if (!v)
 		return;
 
-	strv = nm_utils_strsplit_set (v, " \t", FALSE);
+	strv = nm_utils_strsplit_set (v, " \t");
 	if (strv)
 		g_object_set (setting, prop_name, strv, NULL);
 }
@@ -3515,7 +3515,7 @@ fill_8021x (shvarFile *ifcfg,
 		return NULL;
 	}
 
-	list = nm_utils_strsplit_set (v, " ", FALSE);
+	list = nm_utils_strsplit_set (v, " ");
 
 	s_8021x = (NMSetting8021x *) nm_setting_802_1x_new ();
 
@@ -3829,7 +3829,7 @@ transform_hwaddr_blacklist (const char *blacklist)
 	const char **strv;
 	gsize i, j;
 
-	strv = nm_utils_strsplit_set (blacklist, " \t", FALSE);
+	strv = nm_utils_strsplit_set (blacklist, " \t");
 	if (!strv)
 		return NULL;
 	for (i = 0, j = 0; strv[j]; j++) {
@@ -4147,7 +4147,7 @@ parse_ethtool_option (const char *value,
 	gs_free const char **words = NULL;
 	guint i;
 
-	words = nm_utils_strsplit_set (value, NULL, FALSE);
+	words = nm_utils_strsplit_set (value, NULL);
 	if (!words)
 		return;
 
@@ -4418,7 +4418,7 @@ parse_ethtool_options (shvarFile *ifcfg, NMConnection *connection)
 			gs_free const char **opts = NULL;
 			const char *const *iter;
 
-			opts = nm_utils_strsplit_set (ethtool_opts, ";", FALSE);
+			opts = nm_utils_strsplit_set (ethtool_opts, ";");
 			for (iter = opts; iter && iter[0]; iter++) {
 				/* in case of repeated wol_passwords, parse_ethtool_option()
 				 * will do the right thing and clear wol_password before resetting. */
@@ -4514,7 +4514,7 @@ make_wired_setting (shvarFile *ifcfg,
 			gs_free const char **chans = NULL;
 			guint32 num_chans;
 
-			chans = nm_utils_strsplit_set (value, ",", FALSE);
+			chans = nm_utils_strsplit_set (value, ",");
 			num_chans = NM_PTRARRAY_LEN (chans);
 			if (num_chans < 2 || num_chans > 3) {
 				PARSE_WARNING ("invalid SUBCHANNELS '%s' (%u channels, 2 or 3 expected)",
@@ -4837,7 +4837,7 @@ make_bond_setting (shvarFile *ifcfg,
 		gs_free const char **items = NULL;
 		const char *const *iter;
 
-		items = nm_utils_strsplit_set (v, " ", FALSE);
+		items = nm_utils_strsplit_set (v, " ");
 		for (iter = items; iter && *iter; iter++) {
 			gs_strfreev char **keys = NULL;
 			const char *key, *val;
@@ -5117,7 +5117,7 @@ handle_bridging_opts (NMSetting *setting,
 	gs_free const char **items = NULL;
 	const char *const *iter;
 
-	items = nm_utils_strsplit_set (value, " ", FALSE);
+	items = nm_utils_strsplit_set (value, " ");
 	for (iter = items; iter && *iter; iter++) {
 		gs_strfreev char **keys = NULL;
 		const char *key, *val;
@@ -5151,7 +5151,7 @@ read_bridge_vlans (shvarFile *ifcfg,
 
 		array = g_ptr_array_new_with_free_func ((GDestroyNotify) nm_bridge_vlan_unref);
 
-		strv = nm_utils_strsplit_set (value, ",", FALSE);
+		strv = nm_utils_strsplit_set (value, ",");
 		if (strv) {
 			for (iter = strv; *iter; iter++) {
 				vlan = nm_bridge_vlan_from_str (*iter, &local);
@@ -5382,7 +5382,7 @@ parse_prio_map_list (NMSettingVlan *s_vlan,
 	v = svGetValueStr (ifcfg, key, &value);
 	if (!v)
 		return;
-	list = nm_utils_strsplit_set (v, ",", FALSE);
+	list = nm_utils_strsplit_set (v, ",");
 
 	for (iter = list; iter && *iter; iter++) {
 		if (!strchr (*iter, ':'))
@@ -5487,7 +5487,7 @@ make_vlan_setting (shvarFile *ifcfg,
 		gs_free const char **strv = NULL;
 		const char *const *ptr;
 
-		strv = nm_utils_strsplit_set (v, ", ", FALSE);
+		strv = nm_utils_strsplit_set (v, ", ");
 		for (ptr = strv; ptr && *ptr; ptr++) {
 			if (nm_streq (*ptr, "GVRP") && gvrp == -1)
 				vlan_flags |= NM_VLAN_FLAG_GVRP;
@@ -5629,7 +5629,7 @@ check_dns_search_domains (shvarFile *ifcfg, NMSetting *s_ip4, NMSetting *s_ip6)
 			gs_free const char **searches = NULL;
 			const char *const *item;
 
-			searches = nm_utils_strsplit_set (v, " ", FALSE);
+			searches = nm_utils_strsplit_set (v, " ");
 			if (searches) {
 				for (item = searches; *item; item++) {
 					if (!nm_setting_ip_config_add_dns_search (NM_SETTING_IP_CONFIG (s_ip6), *item))

--- a/src/settings/plugins/ifcfg-rh/nms-ifcfg-rh-reader.c
+++ b/src/settings/plugins/ifcfg-rh/nms-ifcfg-rh-reader.c
@@ -4548,22 +4548,23 @@ make_wired_setting (shvarFile *ifcfg,
 
 	value = svGetValueStr_cp (ifcfg, "OPTIONS");
 	if (value) {
-		char **options, **iter;
+		gs_free const char **options = NULL;
+		gsize i;
 
-		iter = options = g_strsplit_set (value, " ", 0);
-		while (iter && *iter) {
-			char *equals = strchr (*iter, '=');
+		options = nm_utils_strsplit_set_with_empty (value, " ");
+		for (i = 0; options && options[i]; i++) {
+			const char *line = options[i];
+			const char *equals;
 			gboolean valid = FALSE;
 
+			equals = strchr (line, '=');
 			if (equals) {
-				*equals = '\0';
-				valid = nm_setting_wired_add_s390_option (s_wired, *iter, equals + 1);
+				((char *) equals)[0] = '\0';
+				valid = nm_setting_wired_add_s390_option (s_wired, line, equals + 1);
 			}
 			if (!valid)
-				PARSE_WARNING ("invalid s390 OPTION '%s'", *iter);
-			iter++;
+				PARSE_WARNING ("invalid s390 OPTION '%s'", line);
 		}
-		g_strfreev (options);
 		nm_clear_g_free (&value);
 	}
 

--- a/src/settings/plugins/ifcfg-rh/nms-ifcfg-rh-reader.c
+++ b/src/settings/plugins/ifcfg-rh/nms-ifcfg-rh-reader.c
@@ -4147,7 +4147,7 @@ parse_ethtool_option (const char *value,
 	gs_free const char **words = NULL;
 	guint i;
 
-	words = nm_utils_strsplit_set (value, NULL);
+	words = nm_utils_strsplit_set (value, " \t\n");
 	if (!words)
 		return;
 


### PR DESCRIPTION
Recently, when refactoring nmcli (f224d6a8537dd58fafc8b7ba977ec7fffe8c31e9), handling of list-typed properties improved.

Still, the splitting such values should be improved. For example, currently there is no way to escape the ',' separator. The code (and behavior) for this should be unified and powerful to support arbitrary strings (that contain the delimiter characters).

In a first step, improve our `nm_utils_strsplit_set*()` implementation which will be used for that.

`nm_utils_strsplit_set*()` is a replacement for `g_strsplit_set()`, but differs in some aspects:
- it may (configurably) skip empty tokens right away (repeated delimiters)
- it only clones the string once, instead of returning a full strv array.
- it may (optionally) honor backslash as escape characters. We will need this to make splitting options in nmcli escapeable.

Add `NM_UTILS_STRSPLIT_SET_FLAGS_PRESERVE_EMPTY` flag, so that empty tokens are preserved. As such, `nm_utils_strsplit_set_with_empty()` is now very similar to `g_strsplit_set()`.

Also, replace uses of `g_strsplit_set()` with our variant. That avoids the overhead of cloning all items of the strv array and we can leverage our variant -- that we already have and need for `NM_UTILS_STRSPLIT_SET_FLAGS_PRESERVE_EMPTY`.