### PR TITLE
[th/no-wifi-scan-rand-mac-address]

### DIFF
--- a/Makefile.examples
+++ b/Makefile.examples
@@ -147,8 +147,8 @@ EXTRA_DIST += \
 	examples/lua/lgi/change-vpn-username.lua \
 	examples/lua/lgi/deactivate-all.lua \
 	\
+	examples/nm-conf.d/10-no-wifi-scan-rand-mac-address.conf \
 	examples/nm-conf.d/30-anon.conf \
-	examples/nm-conf.d/31-mac-addr-change.conf \
 	\
 	examples/python/dbus/nm-state.py \
 	examples/python/dbus/add-connection.py \

--- a/contrib/fedora/rpm/NetworkManager.spec
+++ b/contrib/fedora/rpm/NetworkManager.spec
@@ -718,6 +718,12 @@ cp %{SOURCE4} %{buildroot}%{nmlibdir}/conf.d/
 cp %{SOURCE5} %{buildroot}%{nmlibdir}/conf.d/
 %endif
 
+%if %{with wifi}
+%if 0%{?fedora} < 28
+cp examples/nm-conf.d/10-no-wifi-scan-rand-mac-address.conf %{buildroot}%{nmlibdir}/conf.d/
+%endif
+%endif
+
 cp examples/dispatcher/10-ifcfg-rh-routes.sh %{buildroot}%{_sysconfdir}/%{name}/dispatcher.d/
 ln -s ../no-wait.d/10-ifcfg-rh-routes.sh %{buildroot}%{_sysconfdir}/%{name}/dispatcher.d/pre-up.d/
 ln -s ../10-ifcfg-rh-routes.sh %{buildroot}%{_sysconfdir}/%{name}/dispatcher.d/no-wait.d/
@@ -889,6 +895,9 @@ fi
 %if %{with wifi}
 %files wifi
 %{nmplugindir}/libnm-device-plugin-wifi.so
+%if 0%{?fedora}
+%{nmlibdir}/conf.d/10-no-wifi-scan-rand-mac-address.conf
+%endif
 %endif
 
 

--- a/examples/nm-conf.d/10-no-wifi-scan-rand-mac-address.conf
+++ b/examples/nm-conf.d/10-no-wifi-scan-rand-mac-address.conf
@@ -9,12 +9,11 @@ match-device=driver:rtl8723bs,driver:rtl8189es,driver:r8188eu,driver:8188eu,driv
 wifi.scan-rand-mac-address=no
 
 [connection-10-no-wifi-scan-rand-mac-address]
-# These are per-profile properties. Here we set the default value
-# for the profiles. Note that the default value already should be
-# "preserve", so this has no actual effect.
+# These are defaults for the connection profile. Here we set only the default
+# value. Note that the default value already should be "preserve", so this has
+# no actual effect.
 #
-# Also note that this is only the default. Per-profile settings
-# still take precedence.
+# Also note that this is only the default. Per-profile settings still take
+# precedence.
 match-device=driver:rtl8723bs,driver:rtl8189es,driver:r8188eu,driver:8188eu,driver:eagle_sdio,driver:wl
 wifi.cloned-mac-address=preserve
-ethernet.cloned-mac-address=preserve

--- a/examples/nm-conf.d/10-no-wifi-scan-rand-mac-address.conf
+++ b/examples/nm-conf.d/10-no-wifi-scan-rand-mac-address.conf
@@ -4,11 +4,11 @@
 # See man NetworkManager.conf
 #
 # https://bugzilla.gnome.org/show_bug.cgi?id=777523
-[device-31-mac-addr-change]
+[device-10-no-wifi-scan-rand-mac-address]
 match-device=driver:rtl8723bs,driver:rtl8189es,driver:r8188eu,driver:8188eu,driver:eagle_sdio,driver:wl
 wifi.scan-rand-mac-address=no
 
-[connection-31-mac-addr-change]
+[connection-10-no-wifi-scan-rand-mac-address]
 # These are per-profile properties. Here we set the default value
 # for the profiles. Note that the default value already should be
 # "preserve", so this has no actual effect.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1695696

---

Quote:


    contrib/rpm: install "/usr/lib/NetworkManager/conf.d/10-no-wifi-scan-rand-mac-address.conf"
    
    On Ubuntu 18.04 (bionic), package "wpasupplicant" installs a file
    "/usr/lib/NetworkManager/conf.d/no-mac-addr-change.conf" with similar
    content and purpose.
    
    These drivers are known to work badly with NetworkManager changing the
    MAC address. There is no point in causing pain for users for something
    that they cannot fix (short of buying different hardware).
    
    Install the snippet with "NetworkManager-wifi" package.
    
    [1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=833507
    
    https://bugzilla.redhat.com/show_bug.cgi?id=1695696
