### PR TITLE
team: clean up state when connection to teamd fails

### DIFF
--- a/src/devices/team/nm-device-team.c
+++ b/src/devices/team/nm-device-team.c
@@ -408,8 +408,10 @@ teamd_dbus_appeared (GDBusConnection *connection,
 			success = teamd_read_config (device);
 		if (success)
 			nm_device_activate_schedule_stage2_device_config (device);
-		else if (!nm_device_sys_iface_state_is_external_or_assume (device))
+		else if (!nm_device_sys_iface_state_is_external_or_assume (device)) {
+			teamd_cleanup (device, TRUE);
 			nm_device_state_changed (device, NM_DEVICE_STATE_FAILED, NM_DEVICE_STATE_REASON_TEAMD_CONTROL_FAILED);
+		}
 	}
 }
 


### PR DESCRIPTION
If NM fails to connect to teamd, it currently just sets the device
state to FAILED and waits that deactivate() is called later. However,
the 5 seconds timeout on teamd process start can hit in the meantime,
which fails with an assertion "nm_device_is_activating (device)".

Clean up the device state when the connection to teamd fails.

https://bugzilla.redhat.com/show_bug.cgi?id=1697900