### PR TITLE
don't realize unmanaged software devices

### DIFF
--- a/src/devices/nm-device.c
+++ b/src/devices/nm-device.c
@@ -5315,7 +5315,8 @@ nm_device_autoconnect_allowed (NMDevice *self)
 		if (priv->state < NM_DEVICE_STATE_DISCONNECTED)
 			return FALSE;
 	} else {
-		/* Unrealized devices can always autoconnect. */
+		if (!nm_device_check_unrealized_device_managed (self))
+			return FALSE;
 	}
 
 	/* The 'autoconnect-allowed' signal is emitted on a device to allow
@@ -13515,6 +13516,32 @@ nm_device_set_unmanaged_by_flags_queue (NMDevice *self,
                                         NMDeviceStateReason reason)
 {
 	_set_unmanaged_flags (self, flags, set_op, TRUE, FALSE, reason);
+}
+
+/**
+ * nm_device_check_unrealized_device_managed:
+ *
+ * Checks if a unrealized device is managed from user settings
+ * or user configuration.
+ */
+gboolean
+nm_device_check_unrealized_device_managed (NMDevice *self)
+{
+	NMDevicePrivate *priv = NM_DEVICE_GET_PRIVATE (self);
+
+	nm_assert (!nm_device_is_real (self));
+
+	if (!nm_config_data_get_device_config_boolean (NM_CONFIG_GET_DATA,
+	                                               NM_CONFIG_KEYFILE_KEY_DEVICE_MANAGED,
+	                                               self,
+	                                               TRUE,
+	                                               TRUE))
+		return FALSE;
+
+	if (nm_device_spec_match_list (self, nm_settings_get_unmanaged_specs (priv->settings)))
+		return FALSE;
+
+	return TRUE;
 }
 
 void

--- a/src/devices/nm-device.c
+++ b/src/devices/nm-device.c
@@ -15977,17 +15977,22 @@ nm_device_spec_match_list_full (NMDevice *self, const GSList *specs, int no_matc
 {
 	NMDeviceClass *klass;
 	NMMatchSpecMatchType m;
+	const char *hw_address = NULL;
+	gboolean is_fake;
 
 	g_return_val_if_fail (NM_IS_DEVICE (self), FALSE);
 
 	klass = NM_DEVICE_GET_CLASS (self);
+	hw_address = nm_device_get_permanent_hw_address_full (self,
+	                                                      !nm_device_get_unmanaged_flags (self, NM_UNMANAGED_PLATFORM_INIT),
+	                                                      &is_fake);
 
 	m = nm_match_spec_device (specs,
 	                          nm_device_get_iface (self),
 	                          nm_device_get_type_description (self),
 	                          nm_device_get_driver (self),
 	                          nm_device_get_driver_version (self),
-	                          nm_device_get_permanent_hw_address (self),
+	                          is_fake ? NULL : hw_address,
 	                          klass->get_s390_subchannels ? klass->get_s390_subchannels (self) : NULL,
 	                          nm_dhcp_manager_get_config (nm_dhcp_manager_get ()));
 

--- a/src/devices/nm-device.h
+++ b/src/devices/nm-device.h
@@ -691,6 +691,8 @@ void nm_device_set_unmanaged_by_user_udev (NMDevice *self);
 void nm_device_set_unmanaged_by_user_conf (NMDevice *self);
 void nm_device_set_unmanaged_by_quitting (NMDevice *device);
 
+gboolean nm_device_check_unrealized_device_managed (NMDevice *self);
+
 gboolean nm_device_is_nm_owned (NMDevice *device);
 
 gboolean nm_device_has_capability (NMDevice *self, NMDeviceCapabilities caps);

--- a/src/nm-manager.c
+++ b/src/nm-manager.c
@@ -1995,6 +1995,13 @@ system_create_virtual_device (NMManager *self, NMConnection *connection)
 		g_object_unref (device);
 	}
 
+	if (!nm_device_check_unrealized_device_managed (device)) {
+		_LOG3D (LOGD_DEVICE, connection,
+		        "skip activation because virtual device '%s' is unmanaged",
+		        nm_device_get_iface (device));
+		return device;
+	}
+
 	/* Create backing resources if the device has any autoconnect connections */
 	connections = nm_settings_get_connections_clone (priv->settings, NULL,
 	                                                 NULL, NULL,


### PR DESCRIPTION
Currently, if user configuration or settings specify that a software device is unmanaged, for example:

     [device-bond-unmanaged]
     match-device=interface-name:bond*
     managed=0
or

     [keyfile]
     unmanaged-devices=interface-name:bond*

and there is a connection for the device with autoconnect=yes, NM creates the platform link and a realized device in unmanaged state at startup. Fix this.

https://bugzilla.redhat.com/show_bug.cgi?id=1679230
