### PR TITLE
contrib: Provide list of units to %systemd_postun

### DIFF
--- a/contrib/fedora/rpm/NetworkManager.spec
+++ b/contrib/fedora/rpm/NetworkManager.spec
@@ -41,6 +41,7 @@
 
 %global real_version_major %(printf '%s' '%{real_version}' | sed -n 's/^\\([1-9][0-9]*\\.[1-9][0-9]*\\)\\.[1-9][0-9]*$/\\1/p')
 
+%global system_units NetworkManager.service NetworkManager-wait-online.service NetworkManager-dispatcher.service
 ###############################################################################
 
 %bcond_with meson
@@ -777,7 +778,7 @@ fi
 /usr/bin/udevadm control --reload-rules || :
 /usr/bin/udevadm trigger --subsystem-match=net || :
 
-%systemd_post NetworkManager.service NetworkManager-wait-online.service NetworkManager-dispatcher.service
+%systemd_post %systemd_units
 
 %triggerin -- initscripts
 if [ -f %{_sbindir}/ifup -a ! -L %{_sbindir}/ifup ]; then
@@ -806,7 +807,7 @@ fi
 /usr/bin/udevadm control --reload-rules || :
 /usr/bin/udevadm trigger --subsystem-match=net || :
 
-%systemd_postun
+%systemd_postun %systemd_units
 
 
 %if (0%{?fedora} && 0%{?fedora} < 28) || 0%{?rhel}


### PR DESCRIPTION
%systemd_postun is meant to be run with arguments and Fedora Rawhide
seems to enforce this now. Therefore provide the units there, too.

This might also need to be fixed in  Fedora itself. Actual build error without this patch:
https://copr-be.cloud.fedoraproject.org/results/till/NetworkManager/fedora-rawhide-x86_64/00884799-NetworkManager/builder-live.log

```
error: This macro requires some arguments
error: line 809: %systemd_postun
```