### PR TITLE
Handle routes even when there are no rules

### DIFF
--- a/examples/dispatcher/10-ifcfg-rh-routes.sh
+++ b/examples/dispatcher/10-ifcfg-rh-routes.sh
@@ -22,10 +22,6 @@ file_regex='^/etc/sysconfig/network-scripts/ifcfg-([^/]+)$'
 
 profile="${BASH_REMATCH[1]}"
 
-if [ ! -f "/etc/sysconfig/network-scripts/rule-$profile" ] && [ ! -f "/etc/sysconfig/network-scripts/rule6-$profile" ]; then
-    exit 0
-fi
-
 MATCH='^[[:space:]]*(\#.*)?$'
 
 handle_file () {


### PR DESCRIPTION
Hi,

The script exits when rule configuration files don't exist. This prevents it from handling routes when there are no rules. The check for the rule configuration file is also done later and checks for additional rule files. Therefore, it seems that we can safely remove this early check.