### PR TITLE
Change nmcli to use XDG_DATA_HOME instead of HOME

### DIFF
--- a/clients/cli/connections.c
+++ b/clients/cli/connections.c
@@ -6344,7 +6344,7 @@ nmcli_editor_tab_completion (const char *text, int start, int end)
 	return match_array;
 }
 
-#define NMCLI_EDITOR_HISTORY ".nmcli-history"
+#define NMCLI_EDITOR_HISTORY "nmcli-history"
 
 static void
 load_history_cmds (const char *uuid)
@@ -6356,7 +6356,7 @@ load_history_cmds (const char *uuid)
 	size_t i;
 	GError *err = NULL;
 
-	filename = g_build_filename (g_get_home_dir (), NMCLI_EDITOR_HISTORY, NULL);
+	filename = g_build_filename (g_get_user_data_dir (), NMCLI_EDITOR_HISTORY, NULL);
 	kf = g_key_file_new ();
 	if (!g_key_file_load_from_file (kf, filename, G_KEY_FILE_KEEP_COMMENTS, &err)) {
 		if (g_error_matches (err, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE))
@@ -6391,7 +6391,7 @@ save_history_cmds (const char *uuid)
 
 	hist = history_list ();
 	if (hist) {
-		filename = g_build_filename (g_get_home_dir (), NMCLI_EDITOR_HISTORY, NULL);
+		filename = g_build_filename (g_get_user_data_dir (), NMCLI_EDITOR_HISTORY, NULL);
 		kf = g_key_file_new ();
 		if (!g_key_file_load_from_file (kf, filename, G_KEY_FILE_KEEP_COMMENTS, &err)) {
 			if (   !g_error_matches (err, G_FILE_ERROR, G_FILE_ERROR_NOENT)


### PR DESCRIPTION
Right now nmcli saves its history into ~/.nmcli-history. This would change it so that it stores it in XDG_DATA_HOME (i.e. ~/.local/share/nmcli-history for most users).