### PR TITLE
Fix copy/paste comment error from another script

### DIFF
--- a/examples/python/dbus/wifi-active-ap.py
+++ b/examples/python/dbus/wifi-active-ap.py
@@ -5,7 +5,7 @@
 #
 
 #
-# This example starts or stops a wifi hotspot
+# This example prints the current wifi access point
 #
 # Configuration settings are described at
 # https://developer.gnome.org/NetworkManager/1.0/ref-settings.html


### PR DESCRIPTION
The git commit history shows `wifi-active-ap.py` after `wifi-hotspot.py`. I'm guessing it was based on it and the old comment got left in by mistake. It's somewhat confusing to see it, as at first I took it at its word and assumed there were two scripts to create a hotspot for some reason.