### PR TITLE
nm-initrd-generator: document support for rd.znet option

### DIFF
--- a/man/nm-initrd-generator.xml
+++ b/man/nm-initrd-generator.xml
@@ -148,6 +148,7 @@
             <member><option>rd.bootif</option></member>
             <member><option>rd.net.timeout.dhcp</option></member>
             <member><option>rd.net.timeout.carrier</option></member>
+            <member><option>rd.znet</option></member>
             <member><option>BOOTIF</option></member>
           </simplelist>
 


### PR DESCRIPTION
rd.znet support was added with commit 11d4412ee155 ("process s390
specific device info from rd.znet parameter in nm-initrd-generator").

Signed-off-by: Julian Wiedmann <jwi@linux.ibm.com>