### PR TITLE
fix: to fix 'Wstringop-truncation' related compile warning

### DIFF
--- a/src/libnm-glib-aux/nm-macros-internal.h
+++ b/src/libnm-glib-aux/nm-macros-internal.h
@@ -1376,13 +1376,17 @@ nm_memdup_nul(gconstpointer data, gsize size)
 static inline char *
 _nm_strndup_a_step(char *s, const char *str, gsize len)
 {
+#if defined(__GNUC__) && (__GNUC__ > 8 || (__GNUC__ == 8 && __GNUC_MINOR__ >= 1))
     NM_PRAGMA_WARNING_DISABLE("-Wstringop-truncation");
+#endif
     NM_PRAGMA_WARNING_DISABLE("-Wstringop-overflow");
     if (len > 0)
         strncpy(s, str, len);
     s[len] = '\0';
     return s;
+#if defined(__GNUC__) && (__GNUC__ > 8 || (__GNUC__ == 8 && __GNUC_MINOR__ >= 1))
     NM_PRAGMA_WARNING_REENABLE;
+#endif
     NM_PRAGMA_WARNING_REENABLE;
 }
 


### PR DESCRIPTION
There are some compile warning while building with gcc 7
```
./src/libnm-glib-aux/nm-macros-internal.h:1379:54: warning：‘#pragma GCC diagnostic’ unknown option  [-Wpragmas]
     NM_PRAGMA_WARNING_DISABLE("-Wstringop-truncation");
                                                      ^
  CC       src/libnm-lldp/libnm_lldp_la-nm-lldp-network.lo
```

Refer to https://gcc.gnu.org/gcc-8/changes.html, Wstringop-truncation is introduced with GCC 8.1

So,  this PR is created to fix the compile warning

Could U help to review it? thanks
