### PR TITLE
wifi: add block scan list to a device section of key file.

### DIFF
--- a/man/NetworkManager.conf.xml
+++ b/man/NetworkManager.conf.xml
@@ -1399,6 +1399,16 @@ managed=1
             </para>
           </listitem>
         </varlistentry>
+        <varlistentry>
+          <term><varname>wifi.periodic-scan-block-list</varname></term>
+          <listitem>
+            <para>
+              Lists wireless interfaces separated by ',' for which periodic scan is unnecessary.
+              By default, NetworkManager runs periodic scans for all wireless interfaces. It may
+              not be necessary or even harmful for some systems.
+            </para>
+          </listitem>
+        </varlistentry>
         <varlistentry id="sriov-num-vfs">
          <term><varname>sriov-num-vfs</varname></term>
           <listitem>

--- a/src/libnm-base/nm-config-base.h
+++ b/src/libnm-base/nm-config-base.h
@@ -72,6 +72,7 @@
     "wifi.scan-generate-mac-address-mask"
 #define NM_CONFIG_KEYFILE_KEY_DEVICE_CARRIER_WAIT_TIMEOUT "carrier-wait-timeout"
 #define NM_CONFIG_KEYFILE_KEY_DEVICE_WIFI_IWD_AUTOCONNECT "wifi.iwd.autoconnect"
+#define NM_CONFIG_KEYFILE_KEY_DEVICE_WIFI_SCAN_BLOCK_LIST "wifi.periodic-scan-block-list"
 
 #define NM_CONFIG_KEYFILE_KEY_MATCH_DEVICE "match-device"
 #define NM_CONFIG_KEYFILE_KEY_STOP_MATCH   "stop-match"


### PR DESCRIPTION
On system startup (not all wireless devices are configured) NM starts periodic scans on all of interfaces. It creates a load on the dbus and NM, some services are failing with timeout because of it. Usually, it happens when a system has several virtual interfaces on one physical chip - wpa_supplicant sends scan results to all siblings. For example, if the system has 3 virtual interfaces, NM starts 3 scans and receives 3 scan results on each. So NM receives 9 scan results (mainly with the same APs since all scans are done on one chip).
This commit extends the configuration file, adds a possibility to specify device list for which a scan is unnecessary to avoid that situation.

<img width="693" alt="scan-issue-3-interfaces" src="https://github.com/user-attachments/assets/207bed86-7aee-48e1-ad2e-12d986482528">
