### PR TITLE
NetworkManager periodically executes the periodic_update method to re…

### DIFF
--- a/src/core/devices/wifi/nm-device-wifi.c
+++ b/src/core/devices/wifi/nm-device-wifi.c
@@ -2007,7 +2007,7 @@ supplicant_iface_bss_changed_cb(NMSupplicantInterface *iface,
     }
 
     if (found_ap) {
-        if (!nm_wifi_ap_update_from_properties(found_ap, bss_info))
+        if (!nm_wifi_ap_update_from_properties(found_ap, bss_info, found_ap != priv->current_ap))
             return;
         _ap_dump(self, LOGL_DEBUG, found_ap, "updated", 0);
     } else {

--- a/src/core/devices/wifi/nm-wifi-ap.c
+++ b/src/core/devices/wifi/nm-wifi-ap.c
@@ -388,7 +388,7 @@ nm_wifi_ap_get_rsn_flags(const NMWifiAP *self)
 /*****************************************************************************/
 
 gboolean
-nm_wifi_ap_update_from_properties(NMWifiAP *ap, const NMSupplicantBssInfo *bss_info)
+nm_wifi_ap_update_from_properties(NMWifiAP *ap, const NMSupplicantBssInfo *bss_info, gboolean update_signal)
 {
     NMWifiAPPrivate *priv;
     gboolean         changed = FALSE;
@@ -410,7 +410,11 @@ nm_wifi_ap_update_from_properties(NMWifiAP *ap, const NMSupplicantBssInfo *bss_i
 
     changed |= nm_wifi_ap_set_flags(ap, bss_info->ap_flags);
     changed |= nm_wifi_ap_set_mode(ap, bss_info->mode);
-    changed |= nm_wifi_ap_set_strength(ap, bss_info->signal_percent);
+    if (update_signal) {
+        /* code */
+        changed |= nm_wifi_ap_set_strength(ap, bss_info->signal_percent);
+    }
+    
     changed |= nm_wifi_ap_set_freq(ap, bss_info->frequency);
     changed |= nm_wifi_ap_set_ssid(ap, bss_info->ssid);
 
@@ -760,7 +764,7 @@ nm_wifi_ap_new_from_properties(const NMSupplicantBssInfo *bss_info)
     NMWifiAP *ap;
 
     ap = g_object_new(NM_TYPE_WIFI_AP, NULL);
-    nm_wifi_ap_update_from_properties(ap, bss_info);
+    nm_wifi_ap_update_from_properties(ap, bss_info, TRUE);
     return ap;
 }
 

--- a/src/core/devices/wifi/nm-wifi-ap.h
+++ b/src/core/devices/wifi/nm-wifi-ap.h
@@ -49,7 +49,8 @@ NMWifiAP *nm_wifi_ap_new_from_properties(const struct _NMSupplicantBssInfo *bss_
 NMWifiAP *nm_wifi_ap_new_fake_from_connection(NMConnection *connection);
 
 gboolean nm_wifi_ap_update_from_properties(NMWifiAP                          *ap,
-                                           const struct _NMSupplicantBssInfo *bss_info);
+                                           const struct _NMSupplicantBssInfo *bss_info,
+                                           gboolean                          update_signal);
 
 gboolean nm_wifi_ap_check_compatible(NMWifiAP *self, NMConnection *connection);
 


### PR DESCRIPTION
…fresh signal measurements. When external active scanning occurs, it triggers wpa_supplicant to update BSS information. Upon receiving BSS update signals, NetworkManager proactively retrieves current WiFi properties from wpa_supplicant for updates. However, discrepancies exist between the signal strength values reported by wpa_supplicant and those obtained through NetworkManager's periodic_update method. Therefore, we should refrain from updating signal strength metrics when handling bss_update events to maintain measurement consistency