### PR TITLE
Ih/nmcli ovs port type

### DIFF
--- a/src/nmcli/connections.c
+++ b/src/nmcli/connections.c
@@ -4615,8 +4615,11 @@ set_connection_type(NmCli            *nmc,
                     gboolean          allow_reset,
                     GError          **error)
 {
-    GError     *local     = NULL;
-    const char *port_type = NULL;
+    NMSettingConnection *s_con     = nm_connection_get_setting_connection(con);
+    GError              *local     = NULL;
+    const char          *port_type = NULL;
+
+    nm_assert(s_con);
 
     value = check_valid_name_toplevel(value, &port_type, &local);
     if (!value) {
@@ -4631,7 +4634,7 @@ set_connection_type(NmCli            *nmc,
         return FALSE;
     }
 
-    if (port_type) {
+    if (!nm_setting_connection_get_port_type(s_con) && port_type) {
         if (!set_property(nmc->client,
                           con,
                           NM_SETTING_CONNECTION_SETTING_NAME,

--- a/src/nmcli/connections.c
+++ b/src/nmcli/connections.c
@@ -3860,6 +3860,11 @@ check_valid_name_toplevel(const char *val, const char **port_type, GError **erro
         return NM_SETTING_WIRED_SETTING_NAME;
     }
 
+    if (nm_streq(str, "ovs-port"))
+        NM_SET_OUT(port_type, NM_SETTING_OVS_BRIDGE_SETTING_NAME);
+    else if (NM_IN_STRSET(str, "ovs-interface", "ovs-patch"))
+        NM_SET_OUT(port_type, NM_SETTING_OVS_PORT_SETTING_NAME);
+
     setting_info = nm_meta_setting_info_editor_find_by_name(str, TRUE);
     if (setting_info)
         return setting_info->general->setting_name;

--- a/src/nmcli/connections.c
+++ b/src/nmcli/connections.c
@@ -5262,10 +5262,11 @@ nmc_process_connection_properties(NmCli              *nmc,
         for (src = *argv; src < *argv + *argc - 1; src += 2) {
             option = (**src == '+' || **src == '-') ? *src + 1 : *src;
             if (NM_IN_STRSET(option,
-                             "connection.port-type",
-                             "port-type",
-                             "connection.slave-type",
-                             "slave-type")) {
+                             NM_SETTING_CONNECTION_SETTING_NAME "." NM_SETTING_CONNECTION_PORT_TYPE,
+                             "port-type", /* alias */
+                             NM_SETTING_CONNECTION_SETTING_NAME
+                             "." NM_SETTING_CONNECTION_SLAVE_TYPE,
+                             "slave-type" /* alias */)) {
                 dst[0] = src[0];
                 dst[1] = src[1];
                 dst += 2;
@@ -5273,7 +5274,9 @@ nmc_process_connection_properties(NmCli              *nmc,
         }
         for (src = *argv; src < *argv + *argc - 1; src += 2) {
             option = (**src == '+' || **src == '-') ? *src + 1 : *src;
-            if (NM_IN_STRSET(option, "connection.type", "type")) {
+            if (NM_IN_STRSET(option,
+                             NM_SETTING_CONNECTION_SETTING_NAME "." NM_SETTING_CONNECTION_TYPE,
+                             "type" /* alias */)) {
                 dst[0] = src[0];
                 dst[1] = src[1];
                 dst += 2;
@@ -5281,13 +5284,14 @@ nmc_process_connection_properties(NmCli              *nmc,
         }
         for (src = *argv; src < *argv + *argc - 1; src += 2) {
             option = (**src == '+' || **src == '-') ? *src + 1 : *src;
-            if (!NM_IN_STRSET(option,
-                              "connection.port-type",
-                              "port-type",
-                              "connection.slave-type",
-                              "slave-type",
-                              "connection.type",
-                              "type")) {
+            if (!NM_IN_STRSET(
+                    option,
+                    NM_SETTING_CONNECTION_SETTING_NAME "." NM_SETTING_CONNECTION_PORT_TYPE,
+                    "port-type",
+                    NM_SETTING_CONNECTION_SETTING_NAME "." NM_SETTING_CONNECTION_SLAVE_TYPE,
+                    "slave-type",
+                    NM_SETTING_CONNECTION_SETTING_NAME "." NM_SETTING_CONNECTION_TYPE,
+                    "type")) {
                 dst[0] = src[0];
                 dst[1] = src[1];
                 dst += 2;


### PR DESCRIPTION
If the connection is a port we need to set the connection.port-type
property. Usually this property is guessed by nmcli depending on the
connection type or the chosen controller, so it doesn't need to be
specified by the user. However, if it is explicitly set by the user
we should not guess, but just use it.

When we process arguments like "controller" or "type" we call custom
functions like set_connection_controller that will guess the port-type
if needed. By processing port-type first, it will be set in the
connection by the time that these other properties are processed, so they
won't try to guess.

After port-type, process connection.type, as we are usually capable of
deducing the port-type from it.

Also, add some other minor fixes and improvements to nmcli's handling of
port-type.

Resolves: https://issues.redhat.com/browse/RHEL-80273