### PR TITLE
Change ipv6 failure log from warn to info.

### DIFF
--- a/src/core/nm-l3-ipv6ll.c
+++ b/src/core/nm-l3-ipv6ll.c
@@ -574,7 +574,7 @@ _check(NML3IPv6LL *self)
         self->wait_for_addr_source =
             nm_g_timeout_add_source(10000, _wait_for_addr_timeout_cb, self);
         if (_set_cur_lladdr_bin(self, NM_L3_IPV6LL_STATE_DAD_FAILED, NULL)) {
-            _LOGW("changed: no IPv6 link local address to retry after Duplicate Address Detection "
+            _LOGI("changed: no IPv6 link local address to retry after Duplicate Address Detection "
                   "failures (back off)");
             _lladdr_handle_changed(self, FALSE);
         }


### PR DESCRIPTION
When ipv6 is disabled via kernel switch, NWM continually logs warnings like this, when IPv6 is never ever ever going to be possible:

```
Mar 02 13:51:19 master NetworkManager[945]: <warn>  [1740887479.2680] platform-linux: do-add-ip6-address[2: fe80::a945:4203:a653:76c]: failure 95 (Operation not supported)
Mar 02 13:51:21 master NetworkManager[945]: <warn>  [1740887481.2707] platform-linux: do-add-ip6-address[2: fe80::913f:95a7:efd3:293a]: failure 95 (Operation not supported)
Mar 02 13:51:23 master NetworkManager[945]: <warn>  [1740887483.2724] platform-linux: do-add-ip6-address[2: fe80::8ccc:64d7:d2b6:1651]: failure 95 (Operation not supported)
Mar 02 13:51:25 master NetworkManager[945]: <warn>  [1740887485.2752] platform-linux: do-add-ip6-address[2: fe80::bb93:ebaf:a26e:edea]: failure 95 (Operation not supported)
Mar 02 13:51:27 master NetworkManager[945]: <warn>  [1740887487.2781] platform-linux: do-add-ip6-address[2: fe80::3b17:25c7:ae41:8534]: failure 95 (Operation not supported)
Mar 02 13:51:29 master NetworkManager[945]: <warn>  [1740887489.2803] platform-linux: do-add-ip6-address[2: fe80::78e:4be3:1eea:51b2]: failure 95 (Operation not supported)
Mar 02 13:51:31 master NetworkManager[945]: <warn>  [1740887491.2826] ipv6ll[ad8d17db7e5088b5,ifindex=2]: changed: no IPv6 link local address to retry after Duplicate Address Detection failures (back off)
```

Really what's needed is for NWM is detect that IPv6 is disabled in such a way that it's never going to be somehow re-enabled like ~ `grep ipv6.disable=1 /proc/cmdline`

Related [so question](https://unix.stackexchange.com/questions/791844/disabling-ipv6-in-networkmanager-globally). 
