### PR TITLE
update_resolv_conf_no_stub: Don't create temporary file while updating

### DIFF
--- a/src/core/dns/nm-dns-manager.c
+++ b/src/core/dns/nm-dns-manager.c
@@ -1019,7 +1019,7 @@ update_resolv_conf_no_stub(NMDnsManager      *self,
 
     content = create_resolv_conf(searches, nameservers, options);
 
-    if (!g_file_set_contents(NO_STUB_RESOLV_CONF, content, -1, &local)) {
+    if (!g_file_set_contents_full(NO_STUB_RESOLV_CONF, content, -1, G_FILE_SET_CONTENTS_DURABLE, 0666, &local)) {
         _LOGD("update-resolv-no-stub: failure to write file: %s", local->message);
         g_error_free(local);
         return;


### PR DESCRIPTION
The previous call to g_file_set_contents causes issues with SELinux, because the labeling rules can't deal with a temp file being created with a random suffix. Switch to g_file_set_contents_full to prevent this.
Context: https://bugzilla.suse.com/show_bug.cgi?id=1248136

I tried to do this on https://gitlab.freedesktop.org as requested, but I can't fork the repo there:
> Limit reached You cannot create projects in your personal namespace. Contact your GitLab administrator.
If someone can change that for my account (jsegitz) I'll transfer it there
